### PR TITLE
fix(scout): 큐레이션 배치 분할 + GeekNews Atom 파서 교체

### DIFF
--- a/cmd/scout/main.go
+++ b/cmd/scout/main.go
@@ -396,7 +396,7 @@ func fetchGitHubTrending(ctx context.Context, hc *http.Client, max int) ([]Candi
 }
 
 // ---------------------------------------------------------------------------
-// Source: GeekNews (hada.io feedburner RSS)
+// Source: GeekNews (hada.io feedburner — serves Atom, with RSS fallback)
 // ---------------------------------------------------------------------------
 
 func fetchGeekNews(ctx context.Context, hc *http.Client, max int) ([]Candidate, error) {
@@ -406,7 +406,54 @@ func fetchGeekNews(ctx context.Context, hc *http.Client, max int) ([]Candidate, 
 		return nil, err
 	}
 
-	var feed struct {
+	// Primary: Atom (<feed><entry>…) — what feedburner actually serves for GeekNews.
+	var atom struct {
+		Entries []struct {
+			Title string `xml:"title"`
+			Links []struct {
+				Rel  string `xml:"rel,attr"`
+				Href string `xml:"href,attr"`
+			} `xml:"link"`
+			Content   string `xml:"content"`
+			Summary   string `xml:"summary"`
+			Published string `xml:"published"`
+			Updated   string `xml:"updated"`
+		} `xml:"entry"`
+	}
+	if err := xml.Unmarshal(body, &atom); err == nil && len(atom.Entries) > 0 {
+		out := make([]Candidate, 0, len(atom.Entries))
+		for i, e := range atom.Entries {
+			if i >= max {
+				break
+			}
+			link := ""
+			for _, l := range e.Links {
+				if l.Rel == "alternate" || link == "" {
+					link = l.Href
+				}
+			}
+			when := e.Published
+			if when == "" {
+				when = e.Updated
+			}
+			pub, _ := time.Parse(time.RFC3339, when)
+			desc := e.Content
+			if desc == "" {
+				desc = e.Summary
+			}
+			out = append(out, Candidate{
+				Source:    sourceGeekNews,
+				Title:     clean(e.Title),
+				URL:       strings.TrimSpace(link),
+				Snippet:   truncate(clean(stripTags(desc)), 800),
+				Published: pub,
+			})
+		}
+		return out, nil
+	}
+
+	// Fallback: RSS 2.0 (<channel><item>…), in case the feed format changes back.
+	var rss struct {
 		Items []struct {
 			Title       string `xml:"title"`
 			Link        string `xml:"link"`
@@ -414,12 +461,12 @@ func fetchGeekNews(ctx context.Context, hc *http.Client, max int) ([]Candidate, 
 			PubDate     string `xml:"pubDate"`
 		} `xml:"channel>item"`
 	}
-	if err := xml.Unmarshal(body, &feed); err != nil {
-		return nil, fmt.Errorf("parse rss: %w", err)
+	if err := xml.Unmarshal(body, &rss); err != nil {
+		return nil, fmt.Errorf("parse feed: %w", err)
 	}
 
-	out := make([]Candidate, 0, len(feed.Items))
-	for i, it := range feed.Items {
+	out := make([]Candidate, 0, len(rss.Items))
+	for i, it := range rss.Items {
 		if i >= max {
 			break
 		}
@@ -428,7 +475,7 @@ func fetchGeekNews(ctx context.Context, hc *http.Client, max int) ([]Candidate, 
 			Source:    sourceGeekNews,
 			Title:     clean(it.Title),
 			URL:       strings.TrimSpace(it.Link),
-			Snippet:   truncate(clean(it.Description), 800),
+			Snippet:   truncate(clean(stripTags(it.Description)), 800),
 			Published: pub,
 		})
 	}
@@ -469,7 +516,39 @@ summary_ko에는 항목 자체의 핵심을 2~3문장 한국어로 요약하라.
 [{"id": <int>, "score": <int>, "axis": "<rag-search|go-backend|agent-tooling|ai-trend>", "reason_ko": "<...>", "summary_ko": "<...>"}]
 모든 후보를 빠짐없이 포함하라.`
 
+// curateBatchSize bounds how many candidates go into a single Claude request.
+// One giant request (90+ items) risks both the HTTP client timeout and
+// max_tokens truncation of the JSON reply; small sequential batches are slower
+// but reliably complete.
+const curateBatchSize = 25
+
 func curate(ctx context.Context, hc *http.Client, cfg config, cands []Candidate) ([]Scored, error) {
+	out := make([]Scored, 0, len(cands))
+	var firstErr error
+	for start := 0; start < len(cands); start += curateBatchSize {
+		end := start + curateBatchSize
+		if end > len(cands) {
+			end = len(cands)
+		}
+		batch, err := curateBatch(ctx, hc, cfg, cands[start:end])
+		if err != nil {
+			// One failed batch should not discard the others' verdicts.
+			slog.Warn("curation batch failed", "from", start, "to", end, "err", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		out = append(out, batch...)
+		slog.Info("curation batch done", "from", start, "to", end, "scored", len(batch))
+	}
+	if len(out) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+func curateBatch(ctx context.Context, hc *http.Client, cfg config, cands []Candidate) ([]Scored, error) {
 	payload, err := json.Marshal(cands)
 	if err != nil {
 		return nil, err
@@ -728,6 +807,26 @@ func stripFences(s string) string {
 
 func clean(s string) string {
 	return strings.Join(strings.Fields(s), " ")
+}
+
+// stripTags removes HTML tags (best-effort) so feed HTML bodies become plain
+// text snippets. Not a sanitizer — output is only fed to the curation prompt.
+func stripTags(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	inTag := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			inTag = true
+		case r == '>':
+			inTag = false
+			b.WriteByte(' ')
+		case !inTag:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func truncate(s string, n int) string {


### PR DESCRIPTION
## 배경
첫 dry-run(run #1) 결과 두 가지 문제 발견:

1. **큐레이션 타임아웃** — 90개 후보를 단일 Claude 요청으로 보내 4분 HTTP 클라이언트 타임아웃 초과 (`context deadline exceeded`). max_tokens 잘림 위험도 있었음
2. **GeekNews 0건** — feedburner가 RSS가 아니라 **Atom**(`<feed><entry>`)을 서빙하는데 RSS 파서(`channel>item`)로 파싱해 0건

## 수정
- `curate()` → 25개 단위 배치로 분할(`curateBatchSize`), 배치별 실패는 warn 후 계속(부분 성공 허용), 전체 실패시만 에러
- `fetchGeekNews()` → Atom 우선 파싱(alternate link, published, content), RSS는 fallback 유지
- `stripTags()` 추가 — 피드 HTML 본문을 텍스트 snippet으로 정리

## 검증
- `gofmt` clean / `go vet` 통과 / `go build` 성공 (Go 1.26.4)
- 머지 후 dry_run=true 재실행으로 확인 예정