### PR TITLE
fix: scout axis 라벨 + auto-dev 일괄 클로즈 방지

### DIFF
--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -1,6 +1,6 @@
 name: auto-dev
 description: "Automated development pipeline for second-brain — scoped release unit from triage to deploy"
-version: "1.2.0-second-brain"
+version: "1.2.1-second-brain"
 
 # Target: baekenough/second-brain (Go backend + Next.js frontend + Postgres/pgvector + k8s)
 # Release artifacts: git tag + GitHub Release + Docker image (no npm publish)
@@ -19,6 +19,20 @@ steps:
         - phase/0..4 — roadmap features
         - chore + blocker — infra/CI/integrations
         - decision-needed — blocked on human decision (EXCLUDE)
+        - scout — knowledge scout items (see scout handling below)
+
+      Scout issue handling (label `scout`) — NEVER blanket-close as out-of-scope:
+        - These are knowledge-internalization candidates from cmd/scout, NOT release
+          work items. EXCLUDE them from release scope selection, but branch on axis:
+        - axis:go-backend, axis:rag-search → PRODUCT-relevant reference. Keep open.
+          Optionally add P2/P3 and link to a roadmap item (EXPANSION.md) if it maps
+          to planned work.
+        - axis:agent-tooling, axis:ai-trend → harness/reference knowledge. May close,
+          but ONLY after leaving a 1-2 line comment stating what was internalized
+          (or why nothing was) — generic boilerplate closures are forbidden.
+        - Issues with `scout` but no axis label: read 분류 in the issue body header
+          and apply the same branching. When in doubt, leave open and tag
+          decision-needed instead of closing.
 
       For each issue compute:
         - dependencies: parse "see #N", "depends on #N", "#N 참조" from body

--- a/cmd/scout/main.go
+++ b/cmd/scout/main.go
@@ -681,6 +681,13 @@ func ensureLabels(ctx context.Context, hc *http.Client, cfg config) error {
 		{"scout:hn", "d93f0b", "출처: Hacker News"},
 		{"scout:github", "333333", "출처: GitHub"},
 		{"scout:geeknews", "fbca04", "출처: GeekNews"},
+		// Axis labels let downstream triage (auto-dev pre-triage) tell product
+		// items (go-backend, rag-search) apart from harness knowledge
+		// (agent-tooling, ai-trend) instead of blanket-closing everything.
+		{"axis:rag-search", "0052cc", "평가축: RAG·임베딩·하이브리드 검색 (제품)"},
+		{"axis:go-backend", "006b75", "평가축: Go 백엔드/인프라/Postgres (제품)"},
+		{"axis:agent-tooling", "bfd4f2", "평가축: 에이전트/스킬/LLM 오케스트레이션 (하네스)"},
+		{"axis:ai-trend", "c5def5", "평가축: 넓은 AI 동향 (참고)"},
 	}
 	var firstErr error
 	for _, l := range labels {
@@ -702,12 +709,24 @@ var sourceLabel = map[string]string{
 	sourceGeekNews: "scout:geeknews",
 }
 
+// validAxes guards against the model inventing axis values; only known axes
+// become labels so the label namespace stays bounded.
+var validAxes = map[string]bool{
+	"rag-search":    true,
+	"go-backend":    true,
+	"agent-tooling": true,
+	"ai-trend":      true,
+}
+
 func createIssue(ctx context.Context, hc *http.Client, cfg config, s Scored) error {
 	title := fmt.Sprintf("[%s] %s", s.cand.Source, truncate(s.cand.Title, 140))
 	body := renderIssueBody(s)
 	labels := []string{"scout", "scout:internalize"}
 	if l, ok := sourceLabel[s.cand.Source]; ok {
 		labels = append(labels, l)
+	}
+	if validAxes[s.Axis] {
+		labels = append(labels, "axis:"+s.Axis)
 	}
 	b, _ := json.Marshal(map[string]any{"title": title, "body": body, "labels": labels})
 	_, status, err := httpDo(ctx, hc, http.MethodPost,


### PR DESCRIPTION
## 배경
auto-dev 파이프라인이 scout 이슈 8건(#75~#82)을 전부 "하네스 내재화 건, 제품 범위 외"라는 동일 코멘트로 일괄 클로즈했다. 실제로는 pg_durable(#82), mnemo(#77), Agent Memory 논문(#75) 등 제품(검색·수집기·Postgres) 직결 항목이 섮여 있었다. 원인은 두 가지: (1) scout가 axis를 본문 텍스트로만 남기고 라벨로는 안 달아 트리아지가 구분 불가, (2) auto-dev pre-triage가 scout 이슈 처리 규칙 부재.

## 변경
- `cmd/scout/main.go`: 통과 항목에 `axis:{rag-search|go-backend|agent-tooling|ai-trend}` 라벨 부착 (validAxes 검증, ensureLabels에 4종 추가)
- `.claude/skills/pipeline/workflows/auto-dev.yaml` (1.2.1): pre-triage에 scout 분기 규칙 추가 — axis:go-backend/rag-search는 오픈 유지(제품 참고), axis:agent-tooling/ai-trend는 내재화 메모 남기고 클로즈 허용, 보일러플레이트 일괄 클로즈 금지

## 검증
- gofmt clean / go vet 통과 / go build 성공 (Go 1.26.4)
- auto-dev.yaml YAML 파싱 유효성 확인

## 참고
- #75, #77, #82는 수동 재오픈 완료(각 이슈에 제품 관점 보강 코멘트 첨부)
- 기존 이슈의 axis 라벨은 소급 부착 불필요 — 본문 헤더의 분류 필드로 커버됨