### PR TITLE
feat(collector): 전사 백엔드를 OpenAI gpt-4o-transcribe-diarize로 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,31 +74,49 @@ FILESYSTEM_EXCLUDE_EXTS=
 # How often collectors run. Examples: 1h, 30m, 6h
 COLLECT_INTERVAL=1h
 
-# --- Whisper (OpenAI-compatible ASR — audio transcription) ---
+# --- Whisper / transcription (OpenAI gpt-4o-transcribe-diarize — default, only operational path) ---
 #
-# Two deployment modes (see deploy/whisper-lb/README.md for full details):
+# Call/recording audio is sent to OpenAI for transcription + speaker diarization
+# in a single API call (deliberate decision, explicit exception to issue #100's
+# local-only stance). Transcription is DISABLED entirely if WHISPER_API_KEY is empty.
 #
-#   Mode A — Non-distributed / local (default):
-#     Whisper runs as the 'whisper' service in docker-compose.local.yml.
-#     WHISPER_API_URL=http://whisper:8000/v1
-#     WHISPER_CONCURRENCY=1
-#
-#   Mode B — Distributed 2-node LB (home servers via Tailscale):
-#     Caddy LB on the collector host (<lb-host>:8770) fronts faster-whisper backends.
-#     WHISPER_API_URL=http://<lb-host>:8770/v1
-#     WHISPER_CONCURRENCY=2
-#
-# Base URL of the whisper API (must end with /v1).
-WHISPER_API_URL=http://whisper:8000/v1
-# Number of concurrent transcription requests the collector sends.
-# 1 for single-instance; increase to match the number of LB backends.
-WHISPER_CONCURRENCY=1
+# Base URL of the transcription API (must end with /v1).
+WHISPER_API_URL=https://api.openai.com/v1
+# OpenAI API key. REQUIRED — empty disables transcription.
+WHISPER_API_KEY=
+# Model name. gpt-4o-transcribe-diarize combines ASR + speaker diarization.
+WHISPER_MODEL=gpt-4o-transcribe-diarize
 # BCP-47 language code for transcription. Use "ko" for Korean.
 WHISPER_LANGUAGE=ko
-# HuggingFace model repo ID used by the whisper server.
-WHISPER_MODEL=Systran/faster-whisper-medium
+# REQUIRED for speaker diarization: verified against the live API that without
+# this set to "auto", the response carries no speaker segments at all.
+WHISPER_CHUNKING_STRATEGY=auto
+# Acknowledges that call audio intentionally leaves the machine for OpenAI
+# (#100 exception). Never blocks anything — only changes a log level.
+WHISPER_CLOUD_ALLOWED=true
+# OpenAI hard limit: 25 MB per audio file.
+# Number of concurrent transcription requests the collector sends.
+# Tune against OpenAI rate limits when using the cloud path.
+WHISPER_CONCURRENCY=1
 # Host path to the directory containing audio files for transcription.
 WHISPER_AUDIO_DIR=/data/call
+#
+# --- Local-only fallback (docker-compose.local.yml, --profile local-inference, opt-in) ---
+# For environments that cannot send audio to a cloud API. Not enabled by
+# default; start with `docker compose --profile local-inference up -d` and
+# override the values above:
+#   WHISPER_API_URL=http://whisper:8000/v1
+#   WHISPER_MODEL=Systran/faster-whisper-medium
+# See deploy/whisper-lb/README.md for the distributed 2-node LB variant
+# (Caddy LB on the collector host fronting faster-whisper backends,
+# WHISPER_API_URL=http://<lb-host>:8770/v1, WHISPER_CONCURRENCY=2).
+#
+# --- Legacy local pyannote diarization (local-inference profile ONLY) ---
+# The native cloud model above always returns speaker labels and IGNORES
+# these two variables — they are NOT a cloud-diarization switch. They only
+# select the legacy local pyannote.audio service (see deploy/diarization/README.md).
+# DIARIZATION_API_URL=http://diarization:8001
+# DIARIZATION_ENABLED=false
 
 # --- Discord collector (issue #27) ---
 DISCORD_BOT_TOKEN=your_discord_bot_token_here

--- a/.env.local.example
+++ b/.env.local.example
@@ -18,6 +18,14 @@ EMBEDDING_API_KEY=
 # Production deployments (exposed via external tunnel) MUST set this to a strong random token.
 API_KEY=
 
+# --- 로컬 전용 폴백 (local-inference profile) ---
+# 아래 HF_TOKEN 은 레거시 로컬 pyannote 화자분리 서비스 전용입니다.
+# 기본 전사 경로(OpenAI gpt-4o-transcribe-diarize, 아래 WHISPER_* 참고)는
+# 화자 분리를 자체 내장하며 이 값을 사용하지 않습니다.
+# `docker compose --profile local-inference up -d` 로 whisper/diarization
+# 컨테이너를 opt-in 기동할 때만 필요합니다 (오디오를 클라우드로 보낼 수
+# 없는 환경을 위한 대안).
+#
 # HuggingFace 토큰 (diarization 서비스의 gated 모델 다운로드에 필수)
 # pyannote/speaker-diarization-3.1 을 처음 사용하기 전에:
 #   1. https://huggingface.co/pyannote/speaker-diarization-3.1 — 약관 동의
@@ -46,28 +54,45 @@ PORT=8080
 COLLECTOR_INSTANCE=laptop
 COLLECT_INTERVAL=1m
 
-# --- Whisper (OpenAI-compatible ASR) ---
+# --- Whisper / 전사 (OpenAI gpt-4o-transcribe-diarize — 기본, 유일한 운영 경로) ---
 #
-# Mode A — Non-distributed / local (default):
-#   Whisper runs as the 'whisper' service inside docker-compose.local.yml.
-#   WHISPER_API_URL=http://whisper:8000/v1
-#   WHISPER_CONCURRENCY=1
-#
-# Mode B — Distributed 2-node LB (home servers via Tailscale):
-#   Caddy round-robin LB on ubuntu1 fronts two faster-whisper backends.
-#   See deploy/whisper-lb/README.md for full setup and rollback instructions.
-#   WHISPER_API_URL=http://<lb-host>:8770/v1
-#   WHISPER_CONCURRENCY=2
-#
-# Default (Mode A):
-WHISPER_API_URL=http://whisper:8000/v1
-# Number of concurrent transcription requests the collector sends to the
-# whisper endpoint. Set to 1 for local single-instance; 2 for 2-node LB.
+# 통화/녹음 오디오는 전사 + 화자 분리를 위해 OpenAI 로 전송됩니다
+# (의도적 결정, issue #100 의 로컬 전용 원칙에 대한 명시적 예외).
+# WHISPER_API_KEY 가 비어있으면 전사 자체가 비활성화됩니다 (필수 값).
+WHISPER_API_URL=https://api.openai.com/v1
+# OpenAI API 키. 반드시 설정해야 합니다 — 비어있으면 전사가 비활성화됩니다.
+WHISPER_API_KEY=
+WHISPER_MODEL=gpt-4o-transcribe-diarize
+WHISPER_LANGUAGE=ko
+# 화자 분리(speaker segments)를 받으려면 반드시 auto 로 설정해야 합니다.
+# 실제 API 호출로 확인됨: 이 값이 없으면 응답에 화자 세그먼트가 전혀 포함되지 않습니다.
+WHISPER_CHUNKING_STRATEGY=auto
+# 통화 오디오가 의도적으로 기기를 벗어나 OpenAI 로 전송된다는 것을 인지했음을
+# 나타내는 플래그입니다 (#100 예외). 동작을 차단하지 않으며 로그 레벨만 바꿉니다.
+WHISPER_CLOUD_ALLOWED=true
+# OpenAI 오디오 업로드 제한: 파일당 25 MB.
+# 동시 전사 요청 수. 클라우드 경로에서는 OpenAI 레이트리밋에 맞춰 조정하세요.
 WHISPER_CONCURRENCY=1
-# In distributed mode, when this Mac is also a whisper backend, bind the whisper
-# port to this host's Tailscale interface:
+#
+# --- 로컬 전용 폴백 (local-inference profile, opt-in) ---
+# 클라우드로 오디오를 보낼 수 없는 환경을 위한 대안입니다.
+# `docker compose --profile local-inference up -d` 로 whisper 컨테이너를
+# 함께 기동한 뒤 아래 값으로 덮어쓰세요 (화자 분리는 별도 diarization
+# 서비스 + DIARIZATION_ENABLED=true 필요):
+#   WHISPER_API_URL=http://whisper:8000/v1
+#   WHISPER_MODEL=Systran/faster-whisper-medium
+# 분산 모드(ubuntu1 Caddy LB)는 deploy/whisper-lb/README.md 참고.
+# 이 Mac 이 whisper 백엔드로도 동작할 때 Tailscale IP 로 바인딩:
 #   WHISPER_HOST_BIND=<this-host-tailscale-ip>
-# Default (local-only mode) is 127.0.0.1.
+# 기본값(로컬 전용 모드)은 127.0.0.1.
+#
+# DIARIZATION_ENABLED/DIARIZATION_API_URL: 레거시 로컬 pyannote 화자분리
+# 서비스 전용 셀렉터입니다. 기본 클라우드 전사 경로(gpt-4o-transcribe-diarize)는
+# 화자 분리를 자체 내장하며 이 두 값을 절대 참조하지 않습니다 —
+# "클라우드 화자분리 스위치"가 아닙니다. local-inference profile 로
+# whisper+diarization 을 함께 띄운 경우에만 아래를 true 로 설정하세요.
+#   DIARIZATION_ENABLED=false
+#   DIARIZATION_API_URL=http://diarization:8001
 
 # SQLite 소스 경로 (컨테이너 내부 경로. compose 가 호스트 파일을 ro 마운트)
 SECRETARY_DB_PATH=/data/secretary.db

--- a/ARCHITECTURE.en.md
+++ b/ARCHITECTURE.en.md
@@ -86,14 +86,15 @@ flowchart TD
         end
         subgraph AI["AI Services"]
             OLLAMA["ollama\ngemma3:12b-it-qat\nollama_models volume"]
-            WHISPER["whisper\nfaster-whisper-medium\nint8 CPU :8000"]
-            DIARIZATION["diarization\npyannote.audio\n:8001"]
+            WHISPER["whisper (opt-in)\nlocal-inference profile\nfaster-whisper-medium\nint8 CPU :8000"]
+            DIARIZATION["diarization (opt-in)\nlocal-inference profile\npyannote.audio\n:8001"]
         end
         WEB["web\nNext.js standalone\n:3000"]
     end
 
     subgraph EXTERNAL["External APIs"]
         OPENAI["OpenAI API\ntext-embedding-3-small"]
+        OPENAIWHISPER["OpenAI API\ngpt-4o-transcribe-diarize\n(transcribe + diarize, default)"]
         SLACK["Slack Web API"]
         GITHUB["GitHub REST API"]
         WEBHOOK["Alert Webhook\n(Slack)"]
@@ -118,8 +119,9 @@ flowchart TD
     COLLECTOR --> OPENAI
     COLLECTOR --> SLACK
     COLLECTOR --> GITHUB
-    COLLECTOR --> WHISPER
-    COLLECTOR --> DIARIZATION
+    COLLECTOR --> OPENAIWHISPER
+    COLLECTOR -.->|opt-in local fallback| WHISPER
+    COLLECTOR -.->|opt-in local fallback| DIARIZATION
     COLLECTOR --> OLLAMA
     COLLECTOR -.-> SECRETARYDB
     COLLECTOR -.-> LLMMEMORY
@@ -129,13 +131,15 @@ flowchart TD
 
     class SERVER,COLLECTOR focal;
     class PG data;
-    class OPENAI,SLACK,GITHUB,WEBHOOK ext;
+    class OPENAI,OPENAIWHISPER,SLACK,GITHUB,WEBHOOK ext;
     class OLLAMA,WHISPER,DIARIZATION,WEB,MCP,EVALRUNNER,ANDROID muted;
 ```
 
 > **eraser render** ([edit](https://app.eraser.io/workspace/PyHgjPmM97MYtJNoVD5H)):
 >
 > ![System Runtime Topology](docs/diagrams/01-system-runtime-topology.png)
+>
+> This PNG renders an older topology where whisper/diarization were always-on services. The mermaid source above is authoritative (whisper/diarization are now opt-in under the `local-inference` profile; the default transcription path is the OpenAI cloud API).
 
 ### docker-compose.local.yml Services
 
@@ -147,8 +151,8 @@ flowchart TD
 | mcp | `second-brain-mcp:local` | 8090 | MCP streamable HTTP server |
 | eval-runner | `second-brain-eval:local` | — | Nightly eval scheduler (03:00 KST) |
 | ollama | `ollama/ollama:latest` | 11434 (internal) | Local LLM (gemma3:12b-it-qat) |
-| whisper | `fedirz/faster-whisper-server:latest-cpu` | 8000 (internal) | Whisper ASR (int8 CPU) |
-| diarization | `second-brain-diarization:local` | 8001 (internal) | pyannote.audio speaker diarization |
+| whisper (`local-inference` profile, opt-in) | `fedirz/faster-whisper-server:latest-cpu` | 8000 (internal) | Legacy local ASR fallback (int8 CPU). Default transcription path is OpenAI gpt-4o-transcribe-diarize |
+| diarization (`local-inference` profile, opt-in) | `second-brain-diarization:local` | 8001 (internal) | Legacy local pyannote.audio speaker diarization fallback |
 | web | `second-brain-web:local` | 3000 | Next.js frontend |
 
 ---
@@ -502,7 +506,7 @@ type Scheduler struct {
 
 SMS and calls: The Android second-brain-push app sends data via `POST /api/v1/ingest/messages`. Source ID format: `sms:{dateMs}:{sha256(addr)[:16]}:{direction}`. Migration 019 re-keyed existing bodyHash-based source IDs.
 
-Recordings: Received as `.m4a` multipart via `POST /api/v1/ingest/recording` → Whisper ASR → text conversion and storage. Corrupted audio is isolated (#152).
+Recordings: Received as `.m4a` multipart via `POST /api/v1/ingest/recording` → OpenAI gpt-4o-transcribe-diarize (cloud) → text conversion + speaker diarization and storage. Corrupted audio is isolated (#152).
 
 #### secretary / gmail / calendar / llm-memory
 
@@ -879,8 +883,13 @@ Server-side proxy pattern: backend address and API key are never exposed to the 
 | `ENTITY_EXTRACTION_ENABLED` | `false` | Enable entity extraction + search lane |
 | `FILESYSTEM_PATH` | — | Filesystem collection root |
 | `FILESYSTEM_ENABLED` | `false` | Activate filesystem collector |
-| `DIARIZATION_API_URL` | — | Speaker diarization server URL |
-| `DIARIZATION_ENABLED` | `false` | Enable speaker diarization |
+| `WHISPER_API_URL` | `https://api.openai.com/v1` | Transcription API endpoint (default: OpenAI cloud) |
+| `WHISPER_API_KEY` | — | OpenAI API key. Required — empty disables transcription entirely |
+| `WHISPER_MODEL` | `gpt-4o-transcribe-diarize` | Combined transcription + speaker diarization model |
+| `WHISPER_CHUNKING_STRATEGY` | `auto` | Required to receive speaker diarization segments |
+| `WHISPER_CLOUD_ALLOWED` | `false` | Acknowledges audio is sent to OpenAI. Never blocks — only changes a log level |
+| `DIARIZATION_API_URL` | — | (legacy local-only) Speaker diarization server URL — unused by the default cloud transcription path |
+| `DIARIZATION_ENABLED` | `false` | (legacy local-only) Selects the local pyannote diarization service — the cloud transcription model always includes diarization regardless of this flag |
 
 ### cliproxy Integration
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,14 +86,15 @@ flowchart TD
         end
         subgraph AI["AI Services"]
             OLLAMA["ollama\ngemma3:12b-it-qat\nollama_models volume"]
-            WHISPER["whisper\nfaster-whisper-medium\nint8 CPU :8000"]
-            DIARIZATION["diarization\npyannote.audio\n:8001"]
+            WHISPER["whisper (opt-in)\nlocal-inference profile\nfaster-whisper-medium\nint8 CPU :8000"]
+            DIARIZATION["diarization (opt-in)\nlocal-inference profile\npyannote.audio\n:8001"]
         end
         WEB["web\nNext.js standalone\n:3000"]
     end
 
     subgraph EXTERNAL["External APIs"]
         OPENAI["OpenAI API\ntext-embedding-3-small"]
+        OPENAIWHISPER["OpenAI API\ngpt-4o-transcribe-diarize\n(전사 + 화자분리, 기본)"]
         SLACK["Slack Web API"]
         GITHUB["GitHub REST API"]
         WEBHOOK["Alert Webhook\n(Slack)"]
@@ -118,8 +119,9 @@ flowchart TD
     COLLECTOR --> OPENAI
     COLLECTOR --> SLACK
     COLLECTOR --> GITHUB
-    COLLECTOR --> WHISPER
-    COLLECTOR --> DIARIZATION
+    COLLECTOR --> OPENAIWHISPER
+    COLLECTOR -.->|opt-in 로컬 폴백| WHISPER
+    COLLECTOR -.->|opt-in 로컬 폴백| DIARIZATION
     COLLECTOR --> OLLAMA
     COLLECTOR -.-> SECRETARYDB
     COLLECTOR -.-> LLMMEMORY
@@ -129,13 +131,15 @@ flowchart TD
 
     class SERVER,COLLECTOR focal;
     class PG data;
-    class OPENAI,SLACK,GITHUB,WEBHOOK ext;
+    class OPENAI,OPENAIWHISPER,SLACK,GITHUB,WEBHOOK ext;
     class OLLAMA,WHISPER,DIARIZATION,WEB,MCP,EVALRUNNER,ANDROID muted;
 ```
 
 > **eraser 렌더** ([편집](https://app.eraser.io/workspace/PyHgjPmM97MYtJNoVD5H)):
 >
 > ![시스템 런타임 토폴로지](docs/diagrams/01-system-runtime-topology.png)
+>
+> 위 PNG는 whisper/diarization을 항상 기동되는 서비스로 그린 구 토폴로지 렌더링입니다. 최신 상태는 위 mermaid 소스를 기준으로 합니다 (whisper/diarization은 `local-inference` profile opt-in, 기본 전사 경로는 OpenAI 클라우드 API).
 
 ### docker-compose.local.yml 서비스 목록
 
@@ -147,8 +151,8 @@ flowchart TD
 | mcp | `second-brain-mcp:local` | 8090 | MCP streamable HTTP 서버 |
 | eval-runner | `second-brain-eval:local` | — | nightly eval 스케줄러 (03:00 KST) |
 | ollama | `ollama/ollama:latest` | 11434 (내부) | 로컬 LLM (gemma3:12b-it-qat) |
-| whisper | `fedirz/faster-whisper-server:latest-cpu` | 8000 (내부) | Whisper ASR (int8 CPU) |
-| diarization | `second-brain-diarization:local` | 8001 (내부) | pyannote.audio 화자 분리 |
+| whisper (`local-inference` profile, opt-in) | `fedirz/faster-whisper-server:latest-cpu` | 8000 (내부) | 레거시 로컬 ASR 폴백 (int8 CPU). 기본 전사 경로는 OpenAI gpt-4o-transcribe-diarize |
+| diarization (`local-inference` profile, opt-in) | `second-brain-diarization:local` | 8001 (내부) | 레거시 로컬 pyannote.audio 화자 분리 폴백 |
 | web | `second-brain-web:local` | 3000 | Next.js 프론트엔드 |
 
 ---
@@ -502,7 +506,7 @@ type Scheduler struct {
 
 SMS·통화: Android second-brain-push 앱이 `POST /api/v1/ingest/messages`로 전송. `source_id = sms:{dateMs}:{sha256(addr)[:16]}:{direction}`. migration 019로 이전 bodyHash 기반 source_id를 재키잉.
 
-녹음: `POST /api/v1/ingest/recording`으로 `.m4a` multipart 수신 → Whisper ASR → 텍스트 변환 후 저장. 손상 오디오는 격리 처리 (#152).
+녹음: `POST /api/v1/ingest/recording`으로 `.m4a` multipart 수신 → OpenAI gpt-4o-transcribe-diarize (클라우드) → 텍스트 변환 + 화자 분리 후 저장. 손상 오디오는 격리 처리 (#152).
 
 #### secretary / gmail / calendar / llm-memory
 
@@ -897,8 +901,13 @@ const API_KEY = process.env.API_KEY ?? "";  // 서버사이드만 사용 (클라
 | `ENTITY_EXTRACTION_ENABLED` | `false` | 엔티티 추출 + 검색 레인 활성화 |
 | `FILESYSTEM_PATH` | — | 파일시스템 수집 루트 |
 | `FILESYSTEM_ENABLED` | `false` | 파일시스템 수집기 활성화 |
-| `DIARIZATION_API_URL` | — | 화자 분리 서버 URL |
-| `DIARIZATION_ENABLED` | `false` | 화자 분리 활성화 |
+| `WHISPER_API_URL` | `https://api.openai.com/v1` | 전사 API 엔드포인트 (기본: OpenAI 클라우드) |
+| `WHISPER_API_KEY` | — | OpenAI API 키. 필수 — 비어있으면 전사 자체가 비활성화 |
+| `WHISPER_MODEL` | `gpt-4o-transcribe-diarize` | 전사 + 화자 분리 통합 모델 |
+| `WHISPER_CHUNKING_STRATEGY` | `auto` | 화자 분리 세그먼트를 받기 위해 필수 |
+| `WHISPER_CLOUD_ALLOWED` | `false` | 오디오가 OpenAI로 전송됨을 인지했다는 플래그. 동작을 막지 않고 로그 레벨만 변경 |
+| `DIARIZATION_API_URL` | — | (레거시 로컬 전용) pyannote 화자 분리 서버 URL — 기본 클라우드 전사 경로(gpt-4o-transcribe-diarize)는 이 값을 사용하지 않음 |
+| `DIARIZATION_ENABLED` | `false` | (레거시 로컬 전용) 로컬 pyannote 화자 분리 셀렉터 — 클라우드 화자 분리는 항상 내장되어 있어 이 값과 무관 |
 
 ### cliproxy 통합
 

--- a/README.en.md
+++ b/README.en.md
@@ -75,8 +75,9 @@ flowchart LR
     PG["PostgreSQL 16\n+ pgvector\n+ pg_bigm"]
     LLM["LLM / Ollama\n(curation + HyDE\n+ entity extract)"]
     OpenAI["OpenAI Embeddings\ntext-embedding-3-small\n1536 dim"]
-    Whisper["Whisper\nASR :8000"]
-    Diarization["diarization\nspeaker sep :8001"]
+    OpenAIWhisper["OpenAI\ngpt-4o-transcribe-diarize\ntranscribe + diarize (default)"]
+    Whisper["whisper (opt-in)\nlocal-inference profile\nASR :8000"]
+    Diarization["diarization (opt-in)\nlocal-inference profile\nspeaker sep :8001"]
     Sources["Collection Sources\nFilesystem / Slack / GitHub\nSMS / Calls / Recordings\nGmail / Calendar / llm-memory"]
 
     Agent -->|REST /api/v1| Server
@@ -87,18 +88,21 @@ flowchart LR
     Collector -->|SQL + pgvector| PG
     Collector -->|POST /embeddings| OpenAI
     Collector -->|collect| Sources
-    Collector -->|audio files| Whisper
-    Collector -->|diarize| Diarization
+    Collector -->|audio transcription| OpenAIWhisper
+    Collector -.->|opt-in local fallback| Whisper
+    Collector -.->|opt-in local fallback| Diarization
     EvalRunner -->|eval query| PG
     EvalRunner -->|regression webhook| LLM
 
     class Server,Collector focal;
     class PG data;
-    class LLM,OpenAI,Whisper,Diarization,Sources ext;
+    class LLM,OpenAI,OpenAIWhisper,Sources ext;
+    class Whisper,Diarization muted;
     class Agent,MCP,EvalRunner muted;
 ```
 
 ![System Runtime Topology](docs/diagrams/01-system-runtime-topology.png)
+> The PNG above renders an older topology where whisper/diarization were always-on services. The mermaid source above the PNG is authoritative (whisper/diarization are now opt-in under the `local-inference` profile; the default transcription path is the OpenAI cloud API).
 
 The server (API) and collector are separate binaries. Each collector runs on a configurable per-source `COLLECT_INTERVAL`. Collected text is split by a rune-based chunker, then embedded and stored in a `pgvector` column. Production runs on **Mac mini docker-compose** (`docker-compose.local.yml`); `deploy/k8s/` is the future Kubernetes target.
 
@@ -112,8 +116,8 @@ The server (API) and collector are separate binaries. Each collector runs on a c
 | second-brain eval (nightly eval) | `second-brain-eval:local` | golang:alpine → alpine | — |
 | postgres | `second-brain-postgres:local` | pgvector/pgvector:pg16 + pg_bigm | — |
 | ollama | `ollama/ollama:latest` | — | — |
-| whisper | `fedirz/faster-whisper-server:latest-cpu` | faster-whisper (int8 CPU) | — |
-| diarization | `second-brain-diarization:local` | pyannote.audio | — |
+| whisper (`local-inference` profile, opt-in) | `fedirz/faster-whisper-server:latest-cpu` | faster-whisper (int8 CPU) | — |
+| diarization (`local-inference` profile, opt-in) | `second-brain-diarization:local` | pyannote.audio | — |
 | web | `second-brain-web:local` | node:alpine (Next.js standalone) | 10001 |
 
 ---
@@ -371,8 +375,12 @@ Key environment variables based on `internal/config/config.go`.
 | `GITHUB_TOKEN` | — | GitHub Personal Access Token |
 | `GITHUB_ORG` | — | GitHub organization name |
 | `GDRIVE_CREDENTIALS_JSON` | — | Google ADC JSON path |
-| `DIARIZATION_API_URL` | — | pyannote.audio speaker diarization server URL |
-| `DIARIZATION_ENABLED` | `false` | Enable speaker diarization |
+| `DIARIZATION_API_URL` | — | (legacy local-only) pyannote.audio speaker diarization server URL — unused by the default cloud transcription path |
+| `DIARIZATION_ENABLED` | `false` | (legacy local-only) selects the local pyannote diarization service — the cloud transcription model always includes diarization regardless of this flag |
+| `WHISPER_API_URL` | `https://api.openai.com/v1` | Transcription API endpoint (default: OpenAI cloud) |
+| `WHISPER_API_KEY` | — | OpenAI API key. Required — empty disables transcription |
+| `WHISPER_MODEL` | `gpt-4o-transcribe-diarize` | Combined transcription + speaker diarization model |
+| `WHISPER_CHUNKING_STRATEGY` | `auto` | Required to receive speaker diarization segments |
 | `ENTITY_EXTRACTION_ENABLED` | `false` | Enable entity extraction |
 
 > When both `EMBEDDING_API_KEY` and `CLIPROXY_AUTH_FILE` are set, `CLIPROXY_AUTH_FILE` takes precedence.
@@ -387,7 +395,7 @@ Key environment variables based on `internal/config/config.go`.
 | slack | `SLACK_BOT_TOKEN` set | Complete | Public channels only; DMs automatically excluded |
 | github | `GITHUB_TOKEN` + `GITHUB_ORG` set | Complete | Issues + PRs |
 | sms / call | Android app + server URL/token configured | Fully operational | Galaxy Z Flip6 live-tested. App: [`mobile/second-brain-push/`](mobile/second-brain-push/README.md) |
-| recording | Same as above + Whisper server | Fully operational | Whisper ASR → text transcription |
+| recording | Same as above + `WHISPER_API_KEY` | Fully operational | OpenAI gpt-4o-transcribe-diarize (cloud) → text transcription + speaker diarization |
 | secretary | `SECRETARY_DB_HOST_PATH` mounted | Fully operational | secretary SQLite read-only mount |
 | gmail | `/data/gmail` mounted | Fully operational | Gmail export via secretary |
 | calendar | `/data/calendar` mounted | Fully operational | Calendar export via secretary |

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ flowchart LR
     PG["PostgreSQL 16\n+ pgvector\n+ pg_bigm"]
     LLM["LLM / Ollama\n(curation + HyDE\n+ entity extract)"]
     OpenAI["OpenAI Embeddings\ntext-embedding-3-small\n1536 dim"]
-    Whisper["Whisper\n음성인식 :8000"]
-    Diarization["diarization\n화자분리 :8001"]
+    OpenAIWhisper["OpenAI\ngpt-4o-transcribe-diarize\n전사 + 화자분리 (기본)"]
+    Whisper["whisper (opt-in)\nlocal-inference profile\n음성인식 :8000"]
+    Diarization["diarization (opt-in)\nlocal-inference profile\n화자분리 :8001"]
     Sources["수집 소스\nFilesystem / Slack / GitHub\nSMS·통화·녹음 / Gmail\nCalendar / llm-memory"]
 
     Agent -->|REST /api/v1| Server
@@ -87,18 +88,21 @@ flowchart LR
     Collector -->|SQL + pgvector| PG
     Collector -->|POST /embeddings| OpenAI
     Collector -->|수집| Sources
-    Collector -->|음성 파일| Whisper
-    Collector -->|화자 분리| Diarization
+    Collector -->|음성 파일 전사| OpenAIWhisper
+    Collector -.->|opt-in 로컬 폴백| Whisper
+    Collector -.->|opt-in 로컬 폴백| Diarization
     EvalRunner -->|eval query| PG
     EvalRunner -->|회귀 웹훅| LLM
 
     class Server,Collector focal;
     class PG data;
-    class LLM,OpenAI,Whisper,Diarization,Sources ext;
+    class LLM,OpenAI,OpenAIWhisper,Sources ext;
+    class Whisper,Diarization muted;
     class Agent,MCP,EvalRunner muted;
 ```
 
 ![System Runtime Topology](docs/diagrams/01-system-runtime-topology.png)
+> 위 PNG는 whisper/diarization을 항상 기동되는 서비스로 그린 구 토폴로지 렌더링입니다. 최신 상태는 PNG 위의 mermaid 소스를 기준으로 합니다 (whisper/diarization은 `local-inference` profile opt-in, 기본 전사 경로는 OpenAI 클라우드).
 
 서버(API)와 수집기(Collector)는 독립된 바이너리로 분리되어 있습니다. 수집기는 소스별 `COLLECT_INTERVAL`로 실행되며, 수집된 텍스트는 rune 기반 chunker로 분할 후 임베딩되어 `pgvector` 컬럼에 저장됩니다. 프로덕션은 **Mac mini docker-compose** (`docker-compose.local.yml`) 기반이며 `deploy/k8s/`는 향후 Kubernetes 전환용입니다.
 
@@ -112,8 +116,8 @@ flowchart LR
 | second-brain eval (nightly eval) | `second-brain-eval:local` | golang:alpine → alpine | — |
 | postgres | `second-brain-postgres:local` | pgvector/pgvector:pg16 + pg_bigm | — |
 | ollama | `ollama/ollama:latest` | — | — |
-| whisper | `fedirz/faster-whisper-server:latest-cpu` | faster-whisper (int8 CPU) | — |
-| diarization | `second-brain-diarization:local` | pyannote.audio | — |
+| whisper (`local-inference` profile, opt-in) | `fedirz/faster-whisper-server:latest-cpu` | faster-whisper (int8 CPU) | — |
+| diarization (`local-inference` profile, opt-in) | `second-brain-diarization:local` | pyannote.audio | — |
 | web | `second-brain-web:local` | node:alpine (Next.js standalone) | 10001 |
 
 ---
@@ -373,8 +377,12 @@ Android second-brain-push 앱이 SMS·통화 기록을 JSON 배치로 전송합�
 | `GITHUB_TOKEN` | — | GitHub Personal Access Token |
 | `GITHUB_ORG` | — | GitHub 조직명 |
 | `GDRIVE_CREDENTIALS_JSON` | — | Google ADC JSON 경로 |
-| `DIARIZATION_API_URL` | — | pyannote.audio 화자 분리 서버 URL |
-| `DIARIZATION_ENABLED` | `false` | 화자 분리 활성화 |
+| `DIARIZATION_API_URL` | — | (레거시 로컬 전용) pyannote.audio 화자 분리 서버 URL — 기본 클라우드 전사 경로는 사용하지 않음 |
+| `DIARIZATION_ENABLED` | `false` | (레거시 로컬 전용) 로컬 pyannote 화자 분리 셀렉터 — 클라우드 화자 분리는 항상 내장되어 무관 |
+| `WHISPER_API_URL` | `https://api.openai.com/v1` | 전사 API 엔드포인트 (기본: OpenAI 클라우드) |
+| `WHISPER_API_KEY` | — | OpenAI API 키. 필수 — 비어있으면 전사 비활성화 |
+| `WHISPER_MODEL` | `gpt-4o-transcribe-diarize` | 전사 + 화자 분리 통합 모델 |
+| `WHISPER_CHUNKING_STRATEGY` | `auto` | 화자 분리 세그먼트를 받기 위해 필수 |
 | `ENTITY_EXTRACTION_ENABLED` | `false` | 엔티티 추출 활성화 |
 
 > `EMBEDDING_API_KEY`와 `CLIPROXY_AUTH_FILE`이 모두 설정된 경우 `CLIPROXY_AUTH_FILE`이 우선합니다.
@@ -389,7 +397,7 @@ Android second-brain-push 앱이 SMS·통화 기록을 JSON 배치로 전송합�
 | slack | `SLACK_BOT_TOKEN` 설정 | 구현 완료 | public_channel만, DM 자동 제외 |
 | github | `GITHUB_TOKEN` + `GITHUB_ORG` 설정 | 구현 완료 | Issues + PR 수집 |
 | sms / call | Android 앱 설치 + 서버 URL/토큰 설정 | 완전 동작 | Galaxy Z Flip6 실기 검증. 앱: [`mobile/second-brain-push/`](mobile/second-brain-push/README.md) |
-| recording (통화 녹음) | 위와 동일 + Whisper 서버 | 완전 동작 | Whisper ASR → 텍스트 변환 후 저장 |
+| recording (통화 녹음) | 위와 동일 + `WHISPER_API_KEY` | 완전 동작 | OpenAI gpt-4o-transcribe-diarize (클라우드) → 텍스트 변환 + 화자 분리 후 저장 |
 | secretary | `SECRETARY_DB_HOST_PATH` 마운트 | 완전 동작 | secretary SQLite ro 마운트 |
 | gmail | `/data/gmail` 마운트 | 완전 동작 | secretary 연동 Gmail 익스포트 |
 | calendar | `/data/calendar` 마운트 | 완전 동작 | secretary 연동 Calendar 익스포트 |

--- a/deploy/diarization/README.md
+++ b/deploy/diarization/README.md
@@ -1,5 +1,13 @@
 # Speaker Diarization Service
 
+> **Status: legacy local-only fallback, opt-in.** The default transcription
+> path is now OpenAI `gpt-4o-transcribe-diarize`, which returns speaker
+> diarization natively in the same API call (see `WHISPER_MODEL` /
+> `WHISPER_CHUNKING_STRATEGY` in `.env.local.example`). This service is only
+> needed for environments that cannot send call audio to a cloud API; it is
+> started with `docker compose --profile local-inference up -d` and is no
+> longer part of the default `docker compose up -d` stack.
+
 Wraps [pyannote.audio 3.1](https://github.com/pyannote/pyannote-audio) to
 provide speaker-segment output for mono call/voice recordings. The Go
 transcription pipeline calls this service to get *who-spoke-when* timestamps,

--- a/deploy/whisper-lb/README.md
+++ b/deploy/whisper-lb/README.md
@@ -1,5 +1,15 @@
 # Whisper Deployment Guide
 
+> **Status: decommissioned / historical.** The default transcription path is
+> now OpenAI `gpt-4o-transcribe-diarize` (cloud, deliberate exception to the
+> local-only stance below — see `.env.local.example`). The local whisper
+> containers referenced throughout this guide have been removed from all
+> servers; "Mode B" is no longer running anywhere. This document is kept for
+> historical reference and as a fallback recipe (`docker-compose.local.yml`
+> `whisper` service, now behind the opt-in `local-inference` compose profile)
+> for anyone who needs to run transcription without sending audio to a cloud
+> API.
+
 Two deployment modes are available. The collector switches between them via
 `WHISPER_API_URL` and `WHISPER_CONCURRENCY` in `.env.local`.
 
@@ -31,10 +41,12 @@ WHISPER_CONCURRENCY=1
 ### Start
 
 ```bash
-docker compose -f docker-compose.local.yml up -d
+docker compose -f docker-compose.local.yml --profile local-inference up -d
 ```
 
-The `whisper` service starts automatically via `depends_on`.
+The `whisper` service is opt-in behind the `local-inference` compose profile
+(it is no longer started by a plain `docker compose up -d`, nor via
+`depends_on` on `collector`).
 
 ---
 
@@ -173,9 +185,9 @@ If the distributed setup is unavailable:
    WHISPER_API_URL=http://whisper:8000/v1
    WHISPER_CONCURRENCY=1
    ```
-2. Start the local whisper service and recreate the collector:
+2. Start the local whisper service (opt-in profile) and recreate the collector:
    ```bash
-   docker compose -f docker-compose.local.yml up -d whisper
+   docker compose -f docker-compose.local.yml --profile local-inference up -d whisper
    docker compose -f docker-compose.local.yml up -d --no-deps collector
    ```
 3. The Mac whisper container picks up any backlog; no data loss occurs because

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -10,6 +10,12 @@
 # 중지/정리:
 #   docker compose -f docker-compose.local.yml down
 #   docker compose -f docker-compose.local.yml down -v   # 볼륨 포함 삭제
+# -----------------------------------------------------------------------------
+# 전사(transcription) 경로 — OpenAI gpt-4o-transcribe-diarize (기본, 유일한
+# 운영 경로). 통화/녹음 오디오가 OpenAI로 전송됩니다 (의도적 결정, #100 예외).
+# WHISPER_API_KEY 가 비어있으면 전사 자체가 비활성화됩니다.
+# 아래 whisper/diarization 서비스는 로컬 전용 폴백으로만 남아있으며 기본
+# `docker compose up -d` 로는 기동되지 않습니다 (opt-in, --profile local-inference).
 # =============================================================================
 
 name: second-brain-local
@@ -72,16 +78,16 @@ services:
     env_file:
       - .env.local
     environment:
+      # 레거시 로컬 pyannote 전용 셀렉터. 기본 전사 경로(OpenAI
+      # gpt-4o-transcribe-diarize)는 화자 분리를 자체 내장하며 이 값을
+      # 무시한다. `--profile local-inference` 로 diarization 서비스를
+      # 함께 띄운 경우에만 의미가 있다.
       DIARIZATION_API_URL: "http://diarization:8001"
       DIARIZATION_ENABLED: "${DIARIZATION_ENABLED:-false}"
     depends_on:
       postgres:
         condition: service_healthy
       ollama:
-        condition: service_started
-      whisper:
-        condition: service_started
-      diarization:
         condition: service_started
     volumes:
       - ${LLM_MEMORY_DB_HOST_PATH:-/Users/user/workspace/llm-memory/data/memory.sqlite}:/data/llm-memory.sqlite:ro
@@ -110,11 +116,15 @@ services:
       - default
 
   # ---------------------------------------------------------------------------
-  # diarization — pyannote.audio 기반 화자 분리 서버 (#111, 내부 포트 8001).
+  # diarization — pyannote.audio 기반 로컬 화자 분리 서버 (#111, 내부 포트 8001).
+  #   레거시 로컬 전용 폴백. 기본 전사 경로(OpenAI gpt-4o-transcribe-diarize)는
+  #   화자 분리를 자체 내장하므로 이 서비스는 더 이상 기본 기동되지 않는다
+  #   (opt-in: `docker compose --profile local-inference up -d`).
+  #   클라우드로 오디오를 보낼 수 없는 환경을 위한 대안으로만 유지한다.
   #   엔드포인트: POST /diarize, GET /health
   #   HF_TOKEN: HuggingFace 토큰 (gated 모델 다운로드에 필수 — .env 또는 셸에 설정).
   #   DIARIZATION_DEVICE: cpu (macOS arm64 CPU 전용; 느림).
-  #   collector 가 DIARIZATION_ENABLED=true 일 때 http://diarization:8001 로 호출.
+  #   collector 가 DIARIZATION_ENABLED=true 일 때만 http://diarization:8001 로 호출.
   #   주의: pyannote/speaker-diarization-3.x 모델 사용 전 HuggingFace 모델 페이지에서
   #         약관 동의(gated-model acceptance) 필요.
   # ---------------------------------------------------------------------------
@@ -123,6 +133,7 @@ services:
       context: ./deploy/diarization
       dockerfile: Dockerfile
     image: second-brain-diarization:local
+    profiles: ["local-inference"]
     environment:
       # HF_TOKEN: required for first-time gated-model download; safe blank default
       # suppresses the "variable is not set" compose warning when token is absent.
@@ -134,13 +145,20 @@ services:
       - default
 
   # ---------------------------------------------------------------------------
-  # whisper — OpenAI-호환 음성인식 서버 (내부 포트 8000).
+  # whisper — 레거시 로컬 ASR 서버 (내부 포트 8000, faster-whisper).
+  #   레거시 로컬 전용 폴백. 기본 전사 경로는 OpenAI gpt-4o-transcribe-diarize
+  #   (WHISPER_API_URL=https://api.openai.com/v1, .env.local 에서 설정)이며
+  #   이 서비스는 더 이상 기본 기동되지 않는다
+  #   (opt-in: `docker compose --profile local-inference up -d`).
+  #   클라우드로 오디오를 보낼 수 없는 환경을 위한 대안으로만 유지한다.
   #   fedirz/faster-whisper-server:latest-cpu 사용.
   #   엔드포인트: POST /v1/audio/transcriptions (multipart: file/model/language)
-  #   WHISPER__MODEL 로 모델 지정 (HuggingFace repo ID).
+  #   WHISPER__MODEL 로 모델 지정 (HuggingFace repo ID). 화자 분리는 미지원 —
+  #   이 경로를 쓰려면 위 diarization 서비스를 함께 활성화해야 한다.
   # ---------------------------------------------------------------------------
   whisper:
     image: fedirz/faster-whisper-server:latest-cpu
+    profiles: ["local-inference"]
     environment:
       WHISPER__MODEL: Systran/faster-whisper-medium
       WHISPER__INFERENCE_DEVICE: cpu

--- a/internal/collector/whisper.go
+++ b/internal/collector/whisper.go
@@ -32,6 +32,15 @@ import (
 // over this constant; this constant exists only as a defence-in-depth fallback.
 const whisperDefaultHTTPTimeout = 2 * time.Hour
 
+// whisperCloudMaxFileBytes is the hard per-file upload limit enforced by
+// OpenAI's /v1/audio/transcriptions endpoint (verified against the live API).
+// This is NOT configurable — it reflects a fixed server-side constraint, not
+// a local operational preference (contrast with cfg.WhisperMaxFileBytes,
+// which IS configurable and exists to bound local disk/network usage). It
+// applies only when the resolved endpoint is non-local (isLocalWhisperEndpoint
+// == false); self-hosted whisper.cpp servers do not enforce this limit.
+const whisperCloudMaxFileBytes = 25 << 20 // 25 MiB
+
 // whisperAudioExts is the set of audio file extensions that the collector will
 // submit for transcription. Extensions are lowercase and include the leading dot.
 var whisperAudioExts = map[string]bool{
@@ -85,30 +94,122 @@ type diarizeResponse struct {
 	Segments []diarSegment `json:"segments"`
 }
 
-// labelTranscript aligns whisper transcript segments with speaker diarization
-// segments and returns speaker-labelled content and the number of distinct
-// speakers.
+// modelSupportsNativeDiarization reports whether model performs speaker
+// diarization as part of the transcription response itself (OpenAI's
+// gpt-4o-transcribe-diarize family), as opposed to a plain transcription
+// model whose output must be aligned against a separate diarization pass
+// (see diarizeAudio / diarSegment above).
 //
-// Alignment strategy:
-//   - For each whisper segment, find the diarization speaker whose time
-//     interval has the maximum overlap (overlap = max(0, min(ends)-max(starts))).
-//   - When no diarization segment overlaps a whisper segment at all, the
-//     nearest diarization speaker by midpoint distance is assigned.
-//   - Diarization speaker IDs (e.g. "SPEAKER_00") are mapped to 화자1, 화자2, …
-//     in order of first appearance across the whisper segments.
+// Detection is a case-insensitive substring match on "diarize" rather than an
+// exact allow-list, so future model variants that follow the same naming
+// convention are recognised without a code change.
+func modelSupportsNativeDiarization(model string) bool {
+	return strings.Contains(strings.ToLower(model), "diarize")
+}
+
+// diarizedSegment is a single speaker-labelled segment from the OpenAI
+// gpt-4o-transcribe-diarize response (response_format=diarized_json).
 //
-// Consecutive whisper segments assigned to the same speaker are grouped into a
-// single block; blocks are rendered as "[화자N] text" and separated by newlines.
+// Verified response shape (ground truth — checked against the live OpenAI
+// API):
 //
-// If whisperSegs or diarSegs is empty the function returns ("", 0) so callers
-// can fall back to the plain transcript text.
-func labelTranscript(whisperSegs []whisperSegment, diarSegs []diarSegment) (content string, speakerCount int) {
-	if len(whisperSegs) == 0 || len(diarSegs) == 0 {
+//	{"type":"transcript.text.segment","text":" ...","speaker":"A",
+//	 "start":0.0,"end":5.55,"id":"seg_0"}
+//
+// Speaker values are single uppercase letters ("A", "B", …) — NOT the
+// "SPEAKER_00" style produced by the pyannote microservice (diarSegment
+// above). The two speaker-ID vocabularies are never mixed: each audio file
+// is processed by exactly one diarization path (see
+// modelSupportsNativeDiarization).
+type diarizedSegment struct {
+	Type    string  `json:"type"`
+	Text    string  `json:"text"`
+	Speaker string  `json:"speaker"`
+	Start   float64 `json:"start"`
+	End     float64 `json:"end"`
+	ID      string  `json:"id"`
+}
+
+// diarizedResponse is the JSON body returned by /v1/audio/transcriptions
+// when response_format=diarized_json is requested. Segments may be absent or
+// empty even on a 200 response — observed when chunking_strategy is
+// omitted/misconfigured (see transcribeFile) or for very short clips the
+// model chooses not to segment. Callers must fall back to the flat Text
+// field in that case; see transcribeFile and buildDocument.
+type diarizedResponse struct {
+	Text     string            `json:"text"`
+	Task     string            `json:"task"`
+	Duration float64           `json:"duration"`
+	Segments []diarizedSegment `json:"segments"`
+}
+
+// rawLabelledSeg pairs a raw (pre-화자N) speaker identifier with a segment's
+// text. It is the common input shape consumed by renderSpeakerBlocks: the two
+// diarization paths (pyannote alignment in labelTranscript, and native
+// diarization in nativeDiarizedSegsToRawLabelled) differ only in HOW they
+// arrive at a (speaker, text) pair per segment — one aligns by time-interval
+// overlap, the other reads an already-authoritative field — but both converge
+// on this same shape so a single renderer guarantees identical stored output
+// format ("[화자N] text" grouped blocks) regardless of path.
+type rawLabelledSeg struct {
+	speaker string // raw ID, e.g. "SPEAKER_00" (pyannote) or "A" (native diarize) — not yet a 화자N label
+	text    string
+}
+
+// nativeDiarizedSegsToRawLabelled converts diarized_json segments into the
+// rawLabelledSeg sequence consumed by renderSpeakerBlocks.
+//
+// This function deliberately does NOT reuse labelTranscript's overlap-based
+// alignment. labelTranscript exists to solve a different problem: aligning
+// two INDEPENDENTLY timestamped sequences (whisper transcript segments vs. a
+// separate diarization service's segments) that were never guaranteed to
+// share boundaries. Native diarize segments have no such problem — each
+// diarizedSegment carries its OWN authoritative speaker for its OWN text,
+// assigned by the model as part of producing that exact segment. There is
+// nothing to align.
+//
+// Routing native segments through labelTranscript's overlap-based
+// assignSpeaker instead would be actively wrong: assignSpeaker scores ALL
+// diarSegs against a given whisper segment and picks the STRICTLY GREATEST
+// overlap (ties go to whichever candidate it evaluates first), so if the API
+// ever returns a segment whose interval fully contains another's — plausible
+// at chunking_strategy=auto chunk boundaries — the contained segment's own
+// interval loses the overlap contest to the containing segment, silently
+// misattributing its text to the wrong speaker. That failure mode is
+// invisible (no error, wrong output) and depends entirely on a third-party
+// API's segmentation behaviour, which this code does not control. Native
+// diarization output must therefore be trusted per-segment, never re-aligned.
+func nativeDiarizedSegsToRawLabelled(segs []diarizedSegment) []rawLabelledSeg {
+	out := make([]rawLabelledSeg, len(segs))
+	for i, s := range segs {
+		out[i] = rawLabelledSeg{speaker: s.Speaker, text: s.Text}
+	}
+	return out
+}
+
+// renderSpeakerBlocks converts a per-segment sequence of (raw speaker, text)
+// pairs — in original segment order — into content formatted as consecutive
+// "[화자N] text" blocks, plus the number of distinct speakers.
+//
+// Raw speaker IDs are mapped to 화자1, 화자2, … in order of FIRST APPEARANCE in
+// segs (not alphabetical/numeric order of the raw ID), so the mapping is
+// stable and readable regardless of whether the raw vocabulary is pyannote's
+// "SPEAKER_00" style or the native diarize API's "A"/"B" style.
+//
+// Consecutive segments assigned to the same 화자N label are merged into a
+// single block (space-joined); blocks themselves are newline-separated.
+// Segments with empty (post-trim) text contribute no text but do not break an
+// in-progress block.
+//
+// If segs is empty the function returns ("", 0) so callers can fall back to
+// the plain transcript text.
+func renderSpeakerBlocks(segs []rawLabelledSeg) (content string, speakerCount int) {
+	if len(segs) == 0 {
 		return "", 0
 	}
 
-	// speakerMap maps raw diarization speaker IDs → 화자N labels in order of
-	// first appearance. A slice is used to keep insertion-order traversal O(n).
+	// speakerMap maps raw speaker IDs → 화자N labels in order of first
+	// appearance. A slice is used to keep insertion-order traversal O(n).
 	speakerMap := map[string]string{}
 	var speakerOrder []string // raw IDs in order of first appearance
 
@@ -120,6 +221,82 @@ func labelTranscript(whisperSegs []whisperSegment, diarSegs []diarSegment) (cont
 		speakerMap[rawID] = label
 		speakerOrder = append(speakerOrder, rawID)
 		return label
+	}
+
+	type labelledSeg struct {
+		speaker string
+		text    string
+	}
+	labelled := make([]labelledSeg, len(segs))
+	for i, s := range segs {
+		labelled[i] = labelledSeg{
+			speaker: speakerLabel(s.speaker),
+			text:    strings.TrimSpace(s.text),
+		}
+	}
+
+	// Group consecutive segments with the same speaker into blocks.
+	var sb strings.Builder
+	blockSpeaker := labelled[0].speaker
+	var blockTexts []string
+
+	flushBlock := func() {
+		if len(blockTexts) == 0 {
+			return
+		}
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString("[")
+		sb.WriteString(blockSpeaker)
+		sb.WriteString("] ")
+		sb.WriteString(strings.Join(blockTexts, " "))
+	}
+
+	for _, seg := range labelled {
+		if seg.speaker != blockSpeaker {
+			flushBlock()
+			blockSpeaker = seg.speaker
+			blockTexts = blockTexts[:0]
+		}
+		if seg.text != "" {
+			blockTexts = append(blockTexts, seg.text)
+		}
+	}
+	flushBlock()
+
+	return sb.String(), len(speakerOrder)
+}
+
+// labelTranscript aligns whisper transcript segments with speaker diarization
+// segments (from the separate pyannote microservice — see diarizeAudio) and
+// returns speaker-labelled content and the number of distinct speakers.
+//
+// This alignment step exists ONLY because whisper transcript segments and
+// pyannote diarization segments are two INDEPENDENTLY timestamped sequences
+// with no guaranteed shared boundaries — they must be reconciled by
+// time-interval overlap. Native diarization (gpt-4o-transcribe-diarize) has
+// no such problem and does NOT go through this function; see
+// nativeDiarizedSegsToRawLabelled for why re-alignment would be actively
+// wrong for that path.
+//
+// Alignment strategy:
+//   - For each whisper segment, find the diarization speaker whose time
+//     interval has the maximum overlap (overlap = max(0, min(ends)-max(starts))).
+//   - When no diarization segment overlaps a whisper segment at all, the
+//     nearest diarization speaker by midpoint distance is assigned.
+//
+// The resulting (speaker, text) pairs are rendered via renderSpeakerBlocks,
+// which performs the 화자N first-appearance numbering and consecutive-block
+// grouping shared with the native diarization path. This preserves the
+// original labelTranscript output byte-for-byte — only the block-rendering
+// half was extracted into a shared helper.
+//
+// If whisperSegs or diarSegs is empty the function returns ("", 0) so callers
+// can fall back to the plain transcript text.
+func labelTranscript(whisperSegs []whisperSegment, diarSegs []diarSegment) (content string, speakerCount int) {
+	if len(whisperSegs) == 0 || len(diarSegs) == 0 {
+		return "", 0
 	}
 
 	// assignSpeaker returns the diarization speaker for a given whisper segment.
@@ -167,51 +344,14 @@ func labelTranscript(whisperSegs []whisperSegment, diarSegs []diarSegment) (cont
 		return bestSpeaker
 	}
 
-	// Assign each whisper segment a speaker label.
-	type labelledSeg struct {
-		speaker string
-		text    string
-	}
-	labelled := make([]labelledSeg, len(whisperSegs))
+	// Assign each whisper segment a (raw) speaker via overlap alignment, then
+	// hand off to the shared renderer for 화자N numbering and block grouping.
+	segs := make([]rawLabelledSeg, len(whisperSegs))
 	for i, ws := range whisperSegs {
-		raw := assignSpeaker(ws)
-		labelled[i] = labelledSeg{
-			speaker: speakerLabel(raw),
-			text:    strings.TrimSpace(ws.Text),
-		}
+		segs[i] = rawLabelledSeg{speaker: assignSpeaker(ws), text: ws.Text}
 	}
 
-	// Group consecutive segments with the same speaker into blocks.
-	var sb strings.Builder
-	blockSpeaker := labelled[0].speaker
-	var blockTexts []string
-
-	flushBlock := func() {
-		if len(blockTexts) == 0 {
-			return
-		}
-		if sb.Len() > 0 {
-			sb.WriteByte('\n')
-		}
-		sb.WriteString("[")
-		sb.WriteString(blockSpeaker)
-		sb.WriteString("] ")
-		sb.WriteString(strings.Join(blockTexts, " "))
-	}
-
-	for _, seg := range labelled {
-		if seg.speaker != blockSpeaker {
-			flushBlock()
-			blockSpeaker = seg.speaker
-			blockTexts = blockTexts[:0]
-		}
-		if seg.text != "" {
-			blockTexts = append(blockTexts, seg.text)
-		}
-	}
-	flushBlock()
-
-	return sb.String(), len(speakerOrder)
+	return renderSpeakerBlocks(segs)
 }
 
 // Filename patterns for recording timestamps.
@@ -530,9 +670,17 @@ func isPrivateOrLinkLocalIP(ip net.IP) bool {
 }
 
 // isLocalWhisperEndpoint reports whether the given URL host resolves to a
-// loopback, Docker-internal, or RFC-1918 private address. Call-transcription
-// data MUST stay local (issue #100). Misconfiguration producing a cloud endpoint
-// is logged as a prominent warning but does not hard-fail the collector.
+// loopback, Docker-internal, or RFC-1918 private address.
+//
+// Historically (issue #100) call-transcription data was required to stay
+// local; that policy has since been reversed by explicit user decision — this
+// collector now defaults to OpenAI's gpt-4o-transcribe-diarize (a cloud
+// endpoint). This function is retained because CollectStream still needs to
+// know whether the endpoint is local for two purposes unrelated to the old
+// local-only mandate: (1) log level selection for the cloud-endpoint guard
+// (see cfg.WhisperCloudAllowed), and (2) the 25 MiB hard file-size cap that
+// only OpenAI's hosted API enforces (whisperCloudMaxFileBytes). A non-local
+// endpoint no longer hard-fails or blocks the collector either way.
 //
 // Locality detection strategy (#153):
 //  1. Well-known literal aliases (localhost, 127.0.0.1, ::1, host.docker.internal).
@@ -620,8 +768,20 @@ const whisperStreamBatchSize = 5
 // regardless of mtime (fixes late-arriving files on OneDrive FUSE mounts).
 //
 // Cloud-endpoint guard: if the configured Whisper endpoint resolves to a
-// non-local host, a prominent warning is logged on every collect call.
-// Issue #100 mandates call transcription stays LOCAL.
+// non-local host, a message is logged on every collect call — Info when
+// cfg.WhisperCloudAllowed acknowledges the policy exception, Warn otherwise.
+// Issue #100 originally mandated that call transcription stay LOCAL; this
+// collector now defaults to OpenAI's gpt-4o-transcribe-diarize (a cloud
+// endpoint) by design, with cfg.WhisperCloudAllowed documenting that the
+// exception was explicit rather than accidental misconfiguration. The guard
+// never blocks the request either way — it is observability, not enforcement.
+//
+// Cloud file-size guard: OpenAI's /v1/audio/transcriptions endpoint hard-caps
+// uploads at 25 MiB (whisperCloudMaxFileBytes, verified against the live
+// API). When the resolved endpoint is non-local, files over this limit are
+// skipped (not quarantined — they are valid audio, just too large for a
+// single request) and the walk continues; see CollectStream for the exact
+// placement and the transcription-ledger interaction.
 //
 // Partial success: individual transcription failures are logged as warnings and
 // the walk continues. The final error is nil as long as the directory walk
@@ -646,10 +806,10 @@ func (c *WhisperCollector) Collect(ctx context.Context, since time.Time) ([]mode
 //
 // Pipeline:
 //   - Phase 1 (SEQUENTIAL walk): every filter (ext, cutover, authoritative
-//     index-skip, size cap, failedQuarantine skip-set, header check +
-//     quarantine) runs single-goroutine inside WalkDir, preserving the
-//     single-writer safety of the failedQuarantine map (no mutex). Files that
-//     pass become `pending`.
+//     index-skip, cloud 25 MiB size cap, local size cap, failedQuarantine
+//     skip-set, header check + quarantine) runs single-goroutine inside
+//     WalkDir, preserving the single-writer safety of the failedQuarantine map
+//     (no mutex). Files that pass become `pending`.
 //   - Phase 2 (CONCURRENT transcription): a worker pool of c.concurrency()
 //     workers transcribes pending files and sends each completed document to a
 //     results channel. A SINGLE drain goroutine receives from that channel,
@@ -672,11 +832,20 @@ func (c *WhisperCollector) CollectStream(ctx context.Context, since time.Time, o
 		return fmt.Errorf("whisper: CollectStream requires non-nil onBatch")
 	}
 
-	// LOW: cloud-endpoint guard (issue #100).
-	if !isLocalWhisperEndpoint(c.baseURL) {
-		slog.Warn("whisper: endpoint does not appear to be local — call transcription data may be sent to a cloud API; set WhisperAPIURL to a localhost or private-network address",
-			"endpoint", c.baseURL,
-		)
+	// Cloud-endpoint guard (issue #100 policy exception). isLocal is computed
+	// once here and reused below by the Phase 1 walk for the 25 MiB cloud
+	// file-size cap, which applies only to non-local endpoints.
+	isLocal := isLocalWhisperEndpoint(c.baseURL)
+	if !isLocal {
+		if c.cfg.WhisperCloudAllowed {
+			slog.Info("whisper: call audio is intentionally sent to a cloud transcription endpoint (issue #100 policy exception acknowledged)",
+				"endpoint", c.baseURL,
+			)
+		} else {
+			slog.Warn("whisper: endpoint does not appear to be local — call transcription data may be sent to a cloud API; set WHISPER_CLOUD_ALLOWED=true to acknowledge this is intentional, or WHISPER_API_URL to a localhost/private-network address",
+				"endpoint", c.baseURL,
+			)
+		}
 	}
 
 	now := time.Now().UTC()
@@ -772,6 +941,44 @@ func (c *WhisperCollector) CollectStream(ctx context.Context, since time.Time, o
 			if !mtimeNew {
 				return nil
 			}
+		}
+
+		// Cloud API hard limit (25 MiB): applies only to non-local endpoints
+		// (isLocal, captured once above CollectStream's walk). Unlike the
+		// configurable c.maxFileBytes cap below (a local disk-usage guard),
+		// this reflects a fixed server-side constraint — OpenAI rejects larger
+		// uploads outright. Submitting an oversized file anyway would waste a
+		// network round-trip and log a spurious API error, so it is caught
+		// here first.
+		//
+		// The file is valid audio, not corrupt, so it is skipped (walk
+		// continues) WITHOUT quarantine and WITHOUT emitting a Document —
+		// chunking oversized files for the cloud API is out of scope for this
+		// change.
+		//
+		// Ledger interaction: skipped files here are NEVER passed to the
+		// scheduler's onBatch, so they are never recorded in the transcription
+		// ledger either (RecordTranscribed only runs over documents that
+		// actually reach a batch). This means an oversized file re-triggers
+		// this same WARN on every future collection cycle until it either
+		// shrinks, moves under a local endpoint, or is chunked externally —
+		// deliberately mirroring the existing c.maxFileBytes cap immediately
+		// below, which has always skipped without ledgering (a pre-existing,
+		// accepted trade-off, not one introduced by this change). Doing
+		// anything else here (e.g. ledgering a skip so the WARN fires only
+		// once) would require plumbing store/ledger access into
+		// WhisperCollector, which today only produces model.Document values
+		// and has no store dependency at all — out of scope for this change,
+		// and unlike the original infinite-retry bug (#158) this cost is a
+		// single log line per cycle, not a repeated expensive network/CPU
+		// operation.
+		if !isLocal && info.Size() > whisperCloudMaxFileBytes {
+			slog.Warn("whisper: skipping file over cloud API 25 MiB limit",
+				"path", path,
+				"size_bytes", info.Size(),
+				"limit_bytes", whisperCloudMaxFileBytes,
+			)
+			return nil
 		}
 
 		// Per-file size cap: skip files that exceed the configured limit.
@@ -877,8 +1084,8 @@ type pendingTranscription struct {
 //   - THIS goroutine is the single drain/emitter: it receives from `results`,
 //     buffers documents, and calls onBatch once per whisperStreamBatchSize
 //     (plus a final partial flush). Funnelling every onBatch call through ONE
-//     goroutine is REQUIRED because the scheduler's processBatch (ledger record
-//     + embed + upsert) is not concurrency-safe.
+//     goroutine is REQUIRED because the scheduler's processBatch (ledger
+//     record, embed, upsert) is not concurrency-safe.
 //
 // Each completed document is sent exactly once and received by exactly one drain
 // iteration, so every file appears in exactly one batch (no duplicates, no
@@ -1045,12 +1252,50 @@ func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTransc
 	// Use the plain transcript as the default content.
 	content := txResult.text
 
-	// Diarization post-processing (feature-flagged OFF by default).
-	// Only attempted when:
-	//   1. DiarizationEnabled=true AND DiarizationAPIURL is set
-	//   2. Whisper returned at least one segment (verbose_json)
-	// On any error the warning is logged and the plain transcript is used.
-	if c.cfg.DiarizationEnabled && c.cfg.DiarizationAPIURL != "" && len(txResult.segments) > 0 {
+	// Diarization post-processing.
+	//
+	// Native-diarizing models (gpt-4o-transcribe-diarize) ALWAYS return
+	// speaker-labelled segments in the transcription response itself —
+	// transcribeFile ALWAYS requests response_format=diarized_json for them,
+	// unconditionally of cfg.DiarizationEnabled (see transcribeFile doc
+	// comment for why: the model cannot transcribe without also diarizing, so
+	// gating on the flag would mean paying the full cloud-transcription cost
+	// while discarding the speaker labels we already received — the worst of
+	// both worlds, and a silent one). No second API call is made or needed
+	// here; this branch is the replacement for the local pyannote microservice
+	// for these models.
+	//
+	// Non-native models (e.g. local whisper.cpp deployments) fall through to
+	// the pyannote alignment path, gated by cfg.DiarizationEnabled as before
+	// (unchanged since #111): a second request is sent to DiarizationAPIURL
+	// and the result is aligned against the verbose_json segments via
+	// labelTranscript. This is the ONLY branch where DiarizationEnabled still
+	// has meaning.
+	//
+	// Both paths converge on the same renderSpeakerBlocks formatter so stored
+	// content is identical in shape ("[화자N] text" grouped blocks) regardless
+	// of which path produced it; meta["diarization"] records which one did,
+	// for observability. The native path does NOT go through labelTranscript's
+	// overlap alignment — each diarizedSegment already carries its own
+	// authoritative speaker, so alignment would only introduce error (see
+	// nativeDiarizedSegsToRawLabelled doc comment).
+	switch {
+	case modelSupportsNativeDiarization(c.cfg.WhisperModel):
+		if len(txResult.diarized) > 0 {
+			labelled, nSpeakers := renderSpeakerBlocks(nativeDiarizedSegsToRawLabelled(txResult.diarized))
+			if labelled != "" {
+				content = labelled
+				meta["speaker_count"] = nSpeakers
+				meta["diarization"] = "native"
+			} else {
+				slog.Warn("whisper: renderSpeakerBlocks produced empty output for native diarization — using plain transcript",
+					"path", item.path)
+			}
+		}
+		// len(txResult.diarized) == 0: transcribeFile already warned and
+		// content already defaults to the flat text — nothing more to do.
+
+	case c.cfg.DiarizationEnabled && c.cfg.DiarizationAPIURL != "" && len(txResult.segments) > 0:
 		audioBytes, readErr := os.ReadFile(item.path)
 		if readErr != nil {
 			slog.Warn("whisper: diarization skipped — cannot re-read audio file",
@@ -1066,6 +1311,7 @@ func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTransc
 				if labelled != "" {
 					content = labelled
 					meta["speaker_count"] = nSpeakers
+					meta["diarization"] = "pyannote"
 				} else {
 					slog.Warn("whisper: labelTranscript produced empty output — using plain transcript",
 						"path", item.path)
@@ -1202,29 +1448,63 @@ func checkAudioFileHeader(path, ext string) error {
 
 // transcribeFileResult holds the output of a transcription call.
 type transcribeFileResult struct {
-	text     string           // flat transcript text
-	segments []whisperSegment // time-stamped segments; may be nil/empty for older servers
+	text     string            // flat transcript text
+	segments []whisperSegment  // time-stamped segments (verbose_json / pyannote path); may be nil/empty for older servers
+	diarized []diarizedSegment // speaker-labelled segments (diarized_json / native-diarizing models); nil unless requested
 }
 
 // transcribeFile posts the audio file at path to the Whisper transcription
-// endpoint and returns the transcript text and, when diarization is enabled,
-// time-stamped segments.
+// endpoint and returns the transcript text plus, depending on which request
+// shape was used, either time-stamped segments (verbose_json — pyannote
+// alignment path) or speaker-labelled segments (diarized_json — native
+// diarization path).
 //
 // The request is a multipart/form-data POST to {baseURL}/audio/transcriptions
-// with the following fields:
-//   - file: audio file bytes (filename preserved for MIME detection by the server)
-//   - model: cfg.WhisperModel
-//   - language: cfg.WhisperLanguage (omitted when empty)
-//   - response_format: "verbose_json" (ONLY when cfg.DiarizationEnabled is true)
+// with the "file", "model", and "language" fields always present (language
+// omitted when empty). The remaining fields are chosen in priority order:
 //
-// When DiarizationEnabled is false the request is identical to the pre-diarization
-// implementation: no response_format field, plain {"text":"..."} response parsed
-// via whisperTranscribeResponse. This ensures zero behaviour change for deployments
-// running with the flag off.
+//  1. modelSupportsNativeDiarization(cfg.WhisperModel): ALWAYS
+//     response_format=diarized_json, chunking_strategy=cfg.WhisperChunkingStrategy
+//     (field OMITTED entirely when the config value is empty string — NOT sent
+//     as an empty value) — regardless of cfg.DiarizationEnabled.
 //
-// When DiarizationEnabled is true, response_format=verbose_json is added and the
-// response is parsed via whisperVerboseResponse to extract per-segment timestamps
-// needed for speaker alignment.
+//     cfg.DiarizationEnabled is deliberately NOT consulted here. For a
+//     native-diarizing model, transcription and diarization are the same API
+//     call — there is no cheaper "just transcribe" request to fall back to
+//     when the flag is off. Gating this branch on the flag (as an earlier
+//     version of this function did) would mean: with DIARIZATION_ENABLED at
+//     its default false, every call recording still gets sent to the cloud
+//     model (that decision is made by WHISPER_API_URL + WHISPER_MODEL, not by
+//     this flag) but the code would deliberately request response_format
+//     other than diarized_json, discarding the speaker labels the model
+//     already computed as part of that same request. That is full privacy
+//     cost for zero benefit, and it fails silently — no error, just
+//     unlabelled text. So: if the model is native-diarizing, always ask for
+//     diarized_json.
+//
+//     chunking_strategy is REQUIRED by the live API for the response to
+//     contain a "segments" array at all: verified against the real OpenAI
+//     endpoint, omitting it yields a text-only response and the model
+//     degenerates into repeating text. The response is parsed via
+//     diarizedResponse; speaker values are "A", "B", … per the verified
+//     response shape.
+//
+//  2. Non-native model AND cfg.DiarizationEnabled (e.g. a local whisper.cpp
+//     server that understands verbose_json but not diarized_json, paired with
+//     the pyannote microservice): response_format=verbose_json, parsed via
+//     whisperVerboseResponse. IDENTICAL to the #111 behaviour.
+//     cfg.DiarizationEnabled retains its original meaning ONLY for this
+//     branch — it gates the legacy pyannote alignment path, not native
+//     diarization.
+//
+//  3. Neither: no response_format field at all, plain {"text":"..."} response
+//     parsed via whisperTranscribeResponse. IDENTICAL to the original
+//     pre-#111 implementation — this preserves zero behaviour change for
+//     local whisper.cpp deployments running with the flag off.
+//
+// Cases 2 and 3 exist so local whisper.cpp deployments (which do not speak
+// diarized_json) are byte-for-byte unaffected by the introduction of the
+// native diarization path.
 //
 // The Authorization header is set only when cfg.WhisperAPIKey is non-empty,
 // enabling use with local whisper.cpp servers that do not require authentication.
@@ -1233,6 +1513,11 @@ func (c *WhisperCollector) transcribeFile(ctx context.Context, path string) (tra
 	if err != nil {
 		return transcribeFileResult{}, fmt.Errorf("read audio file: %w", err)
 	}
+
+	// See doc comment above: native diarization is requested unconditionally
+	// of cfg.DiarizationEnabled, which retains its original meaning only for
+	// the legacy pyannote path (case 2 below).
+	nativeDiarize := modelSupportsNativeDiarization(c.cfg.WhisperModel)
 
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
@@ -1258,14 +1543,27 @@ func (c *WhisperCollector) transcribeFile(ctx context.Context, path string) (tra
 		}
 	}
 
-	// response_format=verbose_json is only added when diarization is enabled.
-	// When the flag is off this field is absent, preserving the original
-	// request format byte-for-byte.
-	if c.cfg.DiarizationEnabled {
+	switch {
+	case nativeDiarize:
+		// diarized_json is the only format that returns speaker labels for
+		// native-diarizing models. See doc comment above for why
+		// chunking_strategy is required.
+		if err := mw.WriteField("response_format", "diarized_json"); err != nil {
+			return transcribeFileResult{}, fmt.Errorf("write response_format field: %w", err)
+		}
+		if c.cfg.WhisperChunkingStrategy != "" {
+			if err := mw.WriteField("chunking_strategy", c.cfg.WhisperChunkingStrategy); err != nil {
+				return transcribeFileResult{}, fmt.Errorf("write chunking_strategy field: %w", err)
+			}
+		}
+	case c.cfg.DiarizationEnabled:
+		// Legacy pyannote-alignment path: verbose_json gives per-segment
+		// timestamps, unchanged since #111.
 		if err := mw.WriteField("response_format", "verbose_json"); err != nil {
 			return transcribeFileResult{}, fmt.Errorf("write response_format field: %w", err)
 		}
 	}
+	// Neither branch taken: no response_format field — original pre-#111 shape.
 
 	if err := mw.Close(); err != nil {
 		return transcribeFileResult{}, fmt.Errorf("close multipart writer: %w", err)
@@ -1299,34 +1597,70 @@ func (c *WhisperCollector) transcribeFile(ctx context.Context, path string) (tra
 		return transcribeFileResult{}, fmt.Errorf("whisper API returned %d: %s", resp.StatusCode, body)
 	}
 
-	// Parse response according to the requested format.
-	// Flag OFF: plain {"text":"..."} — identical to the original pre-#111 path.
-	// Flag ON:  verbose_json {"text":"...","segments":[...]} for diarization alignment.
-	if !c.cfg.DiarizationEnabled {
+	// Parse response according to the request shape actually sent above.
+	switch {
+	case nativeDiarize:
+		var result diarizedResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return transcribeFileResult{}, fmt.Errorf("decode response JSON: %w", err)
+		}
+		if len(result.Segments) == 0 {
+			// Observed when chunking_strategy is missing/misconfigured, or for
+			// very short clips the model chooses not to segment. Fall back to
+			// the flat text rather than erroring — buildDocument still
+			// produces a (non-diarized) document rather than dropping the
+			// file entirely.
+			slog.Warn("whisper: diarized_json response had zero segments — falling back to flat text",
+				"path", path, "model", c.cfg.WhisperModel)
+			return transcribeFileResult{text: result.Text}, nil
+		}
+		return transcribeFileResult{text: result.Text, diarized: result.Segments}, nil
+
+	case !c.cfg.DiarizationEnabled:
+		// Plain {"text":"..."} — identical to the original pre-#111 path.
 		var result whisperTranscribeResponse
 		if err := json.Unmarshal(body, &result); err != nil {
 			return transcribeFileResult{}, fmt.Errorf("decode response JSON: %w", err)
 		}
 		return transcribeFileResult{text: result.Text}, nil
-	}
 
-	var result whisperVerboseResponse
-	if err := json.Unmarshal(body, &result); err != nil {
-		return transcribeFileResult{}, fmt.Errorf("decode response JSON: %w", err)
+	default:
+		// verbose_json {"text":"...","segments":[...]} for pyannote alignment.
+		var result whisperVerboseResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return transcribeFileResult{}, fmt.Errorf("decode response JSON: %w", err)
+		}
+		return transcribeFileResult{
+			text:     result.Text,
+			segments: result.Segments,
+		}, nil
 	}
-	return transcribeFileResult{
-		text:     result.Text,
-		segments: result.Segments,
-	}, nil
 }
 
 // isTPhoneCallPath reports whether path looks like a TPhoneCallRecords audio
-// file based on the reTPhone filename pattern. When true, the diarization
-// request is sent with num_speakers=2 (phone calls are always two-party).
+// file based on the reTPhone filename pattern. When true, the LEGACY pyannote
+// diarization request (diarizeAudio) is sent with num_speakers=2 (phone calls
+// are always two-party).
 //
-// Heuristic: the TPhone pattern requires a phone-number prefix followed by
-// a 14-digit timestamp (see reTPhone). Voice memos and other recordings do
-// not match, so num_speakers is omitted for them.
+// Heuristic: the TPhone pattern requires ANY prefix followed by a 14-digit
+// timestamp (see reTPhone — it anchors only on the trailing
+// "_YYYYMMDDHHMMSS[-N].ext" suffix, not on the prefix's content). This still
+// matches the post-#164 upload filename scheme
+// ("{numHash}_YYYYMMDDHHMMSS.ext", where the raw phone number was replaced by
+// its one-way hash to stop plaintext-number persistence): only the prefix
+// changed, and the function never inspected the prefix. Voice memos and other
+// recordings without a trailing 14-digit timestamp do not match, so
+// num_speakers is omitted for them.
+//
+// This function (and reTPhone, which recordingTime's Pattern B also uses to
+// extract the recording timestamp) is NOT dead code, but it is only ever
+// CALLED from the legacy pyannote branch in buildDocument. A native-diarizing
+// model (gpt-4o-transcribe-diarize) never reaches that branch — see the
+// buildDocument switch — because the model returns per-segment speakers
+// directly and has no num_speakers-style hint parameter to feed. So for
+// audio files transcribed via the cloud native-diarize path specifically,
+// this function is simply never invoked; it remains load-bearing for the
+// local-inference (`local-inference` compose profile) pyannote fallback.
 func isTPhoneCallPath(path string) bool {
 	return reTPhone.MatchString(filepath.Base(path))
 }

--- a/internal/collector/whisper_native_diarization_test.go
+++ b/internal/collector/whisper_native_diarization_test.go
@@ -1,0 +1,820 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/collector/smsmap"
+	"github.com/baekenough/second-brain/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// modelSupportsNativeDiarization unit tests
+// ---------------------------------------------------------------------------
+
+func TestModelSupportsNativeDiarization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"exact OpenAI native-diarize model", "gpt-4o-transcribe-diarize", true},
+		{"case-insensitive match", "GPT-4O-TRANSCRIBE-DIARIZE", true},
+		{"mixed case substring", "Gpt-4o-Transcribe-Diarize-Preview", true},
+		{"legacy whisper-1 model", "whisper-1", false},
+		{"local whisper.cpp large-v3", "large-v3", false},
+		{"plain transcribe model without diarize", "gpt-4o-transcribe", false},
+		{"empty model", "", false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := modelSupportsNativeDiarization(tc.model); got != tc.want {
+				t.Errorf("modelSupportsNativeDiarization(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// diarized_json request/response integration tests
+// ---------------------------------------------------------------------------
+
+// diarizedJSONServer returns an httptest.Server that responds to
+// POST /audio/transcriptions with the given diarizedResponse, and captures
+// the multipart form fields of the last request for assertion.
+func diarizedJSONServer(t *testing.T, resp diarizedResponse) (*httptest.Server, *capturedRequest) {
+	t.Helper()
+	captured := &capturedRequest{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		_, params, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			http.Error(w, "bad content-type", http.StatusBadRequest)
+			return
+		}
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		captured.fields = make(map[string]string)
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				http.Error(w, "multipart error", http.StatusBadRequest)
+				return
+			}
+			data, _ := io.ReadAll(p)
+			name := p.FormName()
+			if name == "file" {
+				captured.filename = p.FileName()
+				captured.fileSize = len(data)
+			} else {
+				captured.fields[name] = string(data)
+			}
+			p.Close()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+// TestWhisperCollector_NativeDiarization_LabelledContent verifies that a
+// native-diarizing model (gpt-4o-transcribe-diarize) produces speaker-labelled
+// content via the SAME renderSpeakerBlocks formatter used by the pyannote
+// path (labelTranscript calls it too, but the native path does not go through
+// labelTranscript itself — see nativeDiarizedSegsToRawLabelled), without ever
+// calling a separate diarization service, and tags the document with
+// meta["diarization"]="native".
+func TestWhisperCollector_NativeDiarization_LabelledContent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	srv, _ := diarizedJSONServer(t, diarizedResponse{
+		Text: "안녕 거기서 전화해",
+		Task: "transcribe",
+		Segments: []diarizedSegment{
+			{Type: "transcript.text.segment", Text: "안녕", Speaker: "A", Start: 0.0, End: 2.0, ID: "seg_0"},
+			{Type: "transcript.text.segment", Text: "거기서 전화해", Speaker: "B", Start: 3.0, End: 5.0, ID: "seg_1"},
+		},
+	})
+
+	// Diarization microservice must NOT be called for a native model.
+	diarCalled := false
+	diarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		diarCalled = true
+		http.Error(w, "must not be called for native diarization", http.StatusInternalServerError)
+	}))
+	defer diarSrv.Close()
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto",
+		DiarizationEnabled:      true,
+		DiarizationAPIURL:       diarSrv.URL,
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+	doc := docs[0]
+
+	if !strings.Contains(doc.Content, "[화자1]") || !strings.Contains(doc.Content, "안녕") {
+		t.Errorf("Content missing [화자1] 안녕 block; content: %q", doc.Content)
+	}
+	if !strings.Contains(doc.Content, "[화자2]") || !strings.Contains(doc.Content, "거기서 전화해") {
+		t.Errorf("Content missing [화자2] block; content: %q", doc.Content)
+	}
+	if v, ok := doc.Metadata["speaker_count"]; !ok || v != 2 {
+		t.Errorf("Metadata[speaker_count] = %v, want 2", v)
+	}
+	if v, ok := doc.Metadata["diarization"]; !ok || v != "native" {
+		t.Errorf("Metadata[diarization] = %v, want %q", v, "native")
+	}
+	if diarCalled {
+		t.Error("pyannote diarization microservice was called for a native-diarizing model")
+	}
+}
+
+// TestWhisperCollector_NativeDiarization_IgnoresDiarizationEnabledFlag is the
+// critical regression guard for the DiarizationEnabled gating bug: a
+// native-diarizing model MUST request response_format=diarized_json (+
+// chunking_strategy=auto) and produce [화자N]-labelled content with
+// meta["diarization"]=="native" even when cfg.DiarizationEnabled=false (the
+// default). DIARIZATION_ENABLED defaults to false, and whether audio leaves
+// the machine is decided by WHISPER_API_URL + WHISPER_MODEL — not by this
+// flag. Gating native diarization on it would mean paying the full
+// cloud-transcription cost while silently discarding the speaker labels the
+// model already computed as part of the same request: full privacy cost, zero
+// benefit, no error. cfg.DiarizationEnabled retains its original meaning
+// ONLY for the legacy pyannote path (non-native model + DiarizationAPIURL).
+func TestWhisperCollector_NativeDiarization_IgnoresDiarizationEnabledFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	srv, captured := diarizedJSONServer(t, diarizedResponse{
+		Text: "안녕 거기서 전화해",
+		Task: "transcribe",
+		Segments: []diarizedSegment{
+			{Type: "transcript.text.segment", Text: "안녕", Speaker: "A", Start: 0.0, End: 2.0, ID: "seg_0"},
+			{Type: "transcript.text.segment", Text: "거기서 전화해", Speaker: "B", Start: 3.0, End: 5.0, ID: "seg_1"},
+		},
+	})
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto",
+		DiarizationEnabled:      false, // default — must NOT gate native diarization
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+	doc := docs[0]
+
+	// Request must still carry diarized_json + chunking_strategy=auto.
+	if got := captured.fields["response_format"]; got != "diarized_json" {
+		t.Errorf("response_format = %q, want %q even with DiarizationEnabled=false", got, "diarized_json")
+	}
+	if got := captured.fields["chunking_strategy"]; got != "auto" {
+		t.Errorf("chunking_strategy = %q, want %q even with DiarizationEnabled=false", got, "auto")
+	}
+
+	// Content must still be speaker-labelled.
+	if !strings.Contains(doc.Content, "[화자1]") || !strings.Contains(doc.Content, "안녕") {
+		t.Errorf("Content missing [화자1] 안녕 block despite DiarizationEnabled=false; content: %q", doc.Content)
+	}
+	if !strings.Contains(doc.Content, "[화자2]") || !strings.Contains(doc.Content, "거기서 전화해") {
+		t.Errorf("Content missing [화자2] block despite DiarizationEnabled=false; content: %q", doc.Content)
+	}
+	if v, ok := doc.Metadata["speaker_count"]; !ok || v != 2 {
+		t.Errorf("Metadata[speaker_count] = %v, want 2 even with DiarizationEnabled=false", v)
+	}
+	if v, ok := doc.Metadata["diarization"]; !ok || v != "native" {
+		t.Errorf("Metadata[diarization] = %v, want %q even with DiarizationEnabled=false", v, "native")
+	}
+}
+
+// TestWhisperCollector_NativeDiarization_OverlappingSegmentsKeepOwnSpeaker is
+// the regression guard for the re-alignment bug: native diarize segments must
+// keep their OWN speaker label even when one segment's time interval fully
+// contains another's. The API's diarized_json segments are authoritative per
+// segment — there is no alignment step to perform, unlike the pyannote path
+// where labelTranscript must align two independently-timestamped sequences
+// by overlap.
+//
+// seg0 (speaker A, 0.0-10.0) fully contains seg1 (speaker B, 2.0-5.0) — a
+// shape that is plausible at chunking_strategy=auto chunk boundaries. Routing
+// these segments back through labelTranscript's overlap-based assignSpeaker
+// would silently mis-attribute seg1's text to speaker A (the first segment
+// with maximal — here, total — overlap, since assignSpeaker uses a strict
+// `>` comparison and ties go to whichever segment was evaluated first),
+// because assignSpeaker considers ALL diarSegs including seg1's own interval
+// as "candidates" for seg0 and vice versa, rather than trusting seg1's own
+// authoritative Speaker field. This test asserts seg1's text is correctly
+// attributed to 화자2 (speaker B, its own label), not merged into 화자1.
+func TestWhisperCollector_NativeDiarization_OverlappingSegmentsKeepOwnSpeaker(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	srv, _ := diarizedJSONServer(t, diarizedResponse{
+		Text: "긴 발화 짧은 발화",
+		Task: "transcribe",
+		Segments: []diarizedSegment{
+			// seg0 fully contains seg1's time interval.
+			{Type: "transcript.text.segment", Text: "긴 발화", Speaker: "A", Start: 0.0, End: 10.0, ID: "seg_0"},
+			{Type: "transcript.text.segment", Text: "짧은 발화", Speaker: "B", Start: 2.0, End: 5.0, ID: "seg_1"},
+		},
+	})
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto",
+		DiarizationEnabled:      true,
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+	doc := docs[0]
+
+	if v, ok := doc.Metadata["speaker_count"]; !ok || v != 2 {
+		t.Fatalf("Metadata[speaker_count] = %v, want 2 (two distinct speakers, even though intervals overlap)", v)
+	}
+
+	// seg1's text must appear in an explicit [화자2] block of its own — it
+	// must NOT be silently merged into [화자1]'s block (which would happen if
+	// the overlap-based aligner mis-attributed it to speaker A).
+	var found bool
+	for _, line := range strings.Split(doc.Content, "\n") {
+		if strings.HasPrefix(line, "[화자2]") && strings.Contains(line, "짧은 발화") {
+			found = true
+		}
+		if strings.HasPrefix(line, "[화자1]") && strings.Contains(line, "짧은 발화") {
+			t.Errorf("seg1 text mis-attributed to [화자1] (speaker A) instead of its own speaker B; line: %q", line)
+		}
+	}
+	if !found {
+		t.Errorf("expected a [화자2] block containing '짧은 발화' (seg1's own speaker); content: %q", doc.Content)
+	}
+}
+
+// TestWhisperCollector_NativeDiarization_RequestFields verifies that the
+// actual multipart request sent to a native-diarizing model carries
+// response_format=diarized_json AND chunking_strategy=auto — both are
+// required by the live OpenAI API for segments to be returned at all
+// (ground truth: verified against the real API, see whisper.go doc comments).
+func TestWhisperCollector_NativeDiarization_RequestFields(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	srv, captured := diarizedJSONServer(t, diarizedResponse{
+		Text: "필드 검증",
+		Segments: []diarizedSegment{
+			{Text: "필드 검증", Speaker: "A", Start: 0.0, End: 2.0, ID: "seg_0"},
+		},
+	})
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto",
+		DiarizationEnabled:      true,
+		DiarizationAPIURL:       "http://unused.invalid", // never called for native models
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	_, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+
+	if got := captured.fields["response_format"]; got != "diarized_json" {
+		t.Errorf("response_format = %q, want %q", got, "diarized_json")
+	}
+	if got := captured.fields["chunking_strategy"]; got != "auto" {
+		t.Errorf("chunking_strategy = %q, want %q", got, "auto")
+	}
+	if got := captured.fields["model"]; got != "gpt-4o-transcribe-diarize" {
+		t.Errorf("model = %q, want %q", got, "gpt-4o-transcribe-diarize")
+	}
+}
+
+// TestWhisperCollector_NativeDiarization_ChunkingStrategyOmittedWhenEmpty
+// verifies that setting WhisperChunkingStrategy to the empty string omits the
+// field entirely (escape hatch documented in config.go), rather than sending
+// chunking_strategy="".
+func TestWhisperCollector_NativeDiarization_ChunkingStrategyOmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	srv, captured := diarizedJSONServer(t, diarizedResponse{
+		Text: "청킹 전략 생략",
+		Segments: []diarizedSegment{
+			{Text: "청킹 전략 생략", Speaker: "A", Start: 0.0, End: 2.0, ID: "seg_0"},
+		},
+	})
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "", // explicit escape hatch — omit the field
+		DiarizationEnabled:      true,
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	_, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+
+	if v, present := captured.fields["chunking_strategy"]; present {
+		t.Errorf("chunking_strategy field present when WhisperChunkingStrategy is empty: %q", v)
+	}
+}
+
+// TestWhisperCollector_NonNativeModel_LegacyRequestShape_NeverSendsChunkingStrategy
+// is a regression guard: a non-native model (local whisper.cpp) with
+// DiarizationEnabled=true must still send the legacy verbose_json request
+// shape and must NEVER send chunking_strategy or diarized_json — those are
+// native-model-only fields/formats.
+func TestWhisperCollector_NonNativeModel_LegacyRequestShape_NeverSendsChunkingStrategy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	var capturedFields map[string]string
+	whisperSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		_, params, _ := mime.ParseMediaType(contentType)
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		capturedFields = make(map[string]string)
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				break
+			}
+			data, _ := io.ReadAll(p)
+			if p.FormName() != "file" {
+				capturedFields[p.FormName()] = string(data)
+			}
+			p.Close()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(whisperVerboseResponse{
+			Text: "로컬 whisper 전사",
+			Segments: []whisperSegment{
+				{Start: 0.0, End: 3.0, Text: "로컬 whisper 전사"},
+			},
+		})
+	}))
+	defer whisperSrv.Close()
+
+	diarSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(diarizeResponse{
+			Segments: []diarSegment{{Start: 0.0, End: 3.0, Speaker: "SPEAKER_00"}},
+		})
+	}))
+	defer diarSrv.Close()
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           whisperSrv.URL,
+		WhisperModel:            "whisper-1", // NOT a native-diarizing model
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto", // set, but must still be omitted for non-native models
+		DiarizationEnabled:      true,
+		DiarizationAPIURL:       diarSrv.URL,
+	}
+	c := makeWhisperCollector(cfg, whisperSrv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+
+	if got := capturedFields["response_format"]; got != "verbose_json" {
+		t.Errorf("response_format = %q, want %q (legacy shape)", got, "verbose_json")
+	}
+	if v, present := capturedFields["chunking_strategy"]; present {
+		t.Errorf("chunking_strategy field present for non-native model: %q — must never be sent", v)
+	}
+	if v, ok := docs[0].Metadata["diarization"]; !ok || v != "pyannote" {
+		t.Errorf("Metadata[diarization] = %v, want %q (pyannote path)", v, "pyannote")
+	}
+}
+
+// TestWhisperCollector_NativeDiarization_EmptySegmentsFallsBackToText verifies
+// that a diarized_json response with zero segments (observed in practice when
+// chunking_strategy is missing/misconfigured, or for very short clips) does
+// not crash the collector and instead falls back to the flat transcript text,
+// with no speaker_count/diarization metadata set.
+func TestWhisperCollector_NativeDiarization_EmptySegmentsFallsBackToText(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const wantText = "세그먼트 없는 다이어라이즈 응답"
+
+	srv, _ := diarizedJSONServer(t, diarizedResponse{
+		Text:     wantText,
+		Task:     "transcribe",
+		Segments: nil, // empty — must fall back, not crash
+	})
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto",
+		DiarizationEnabled:      true,
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+	doc := docs[0]
+
+	if doc.Content != wantText {
+		t.Errorf("Content = %q, want flat fallback %q", doc.Content, wantText)
+	}
+	if _, ok := doc.Metadata["speaker_count"]; ok {
+		t.Error("speaker_count must not be set when diarized_json returned zero segments")
+	}
+	if _, ok := doc.Metadata["diarization"]; ok {
+		t.Error("diarization metadata must not be set when diarized_json returned zero segments")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 25 MiB cloud file-size cap
+// ---------------------------------------------------------------------------
+
+// rewriteTransport routes all outbound requests to target while leaving the
+// request's original URL (as constructed by transcribeFile from
+// cfg.WhisperAPIURL) untouched for isLocalWhisperEndpoint's classification.
+// This lets tests use a deliberately non-resolvable "cloud" hostname for
+// cfg.WhisperAPIURL (so the collector treats the endpoint as non-local) while
+// still routing the actual HTTP traffic to a local httptest.Server.
+type rewriteTransport struct {
+	target *url.URL
+}
+
+func (rt *rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	out := req.Clone(req.Context())
+	out.URL.Scheme = rt.target.Scheme
+	out.URL.Host = rt.target.Host
+	out.Host = rt.target.Host
+	return http.DefaultTransport.RoundTrip(out)
+}
+
+// makeCloudWhisperCollector builds a WhisperCollector whose baseURL resolves
+// to a non-local, non-resolvable hostname (".test" TLD — reserved by RFC 2606
+// to never resolve, per isLocalWhisperEndpoint's DNS-resolution-failure ==
+// non-local rule) while actually routing requests to srv.
+func makeCloudWhisperCollector(t *testing.T, cfg *config.Config, srv *httptest.Server) *WhisperCollector {
+	t.Helper()
+	target, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse srv.URL: %v", err)
+	}
+	const cloudBaseURL = "https://cloud.example.test"
+	cfg.WhisperAPIURL = cloudBaseURL
+	c := NewWhisperCollector(cfg)
+	c.baseURL = cloudBaseURL
+	c.httpClient = &http.Client{Transport: &rewriteTransport{target: target}}
+	return c
+}
+
+// writeSparseM4A creates a valid-header, sparse (mostly-zero-filled-on-disk)
+// .m4a file of exactly sizeBytes, so multi-megabyte test fixtures do not
+// consume real disk I/O time or space. A valid ISOBMFF "ftyp" box is written
+// at the start so the file would pass the audio integrity pre-check if it
+// were not skipped earlier by the cloud size cap.
+func writeSparseM4A(t *testing.T, dir, name string, sizeBytes int64, mtime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", name, err)
+	}
+	header := make([]byte, 32)
+	copy(header[4:8], "ftyp")
+	if _, err := f.Write(header); err != nil {
+		f.Close()
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := f.Seek(sizeBytes-1, io.SeekStart); err != nil {
+		f.Close()
+		t.Fatalf("seek: %v", err)
+	}
+	if _, err := f.Write([]byte{0}); err != nil {
+		f.Close()
+		t.Fatalf("write trailing byte: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return path
+}
+
+// TestWhisperCollector_CloudEndpoint_OversizeFileSkipped verifies that,
+// against a non-local (cloud) endpoint, a file over the 25 MiB hard API limit
+// is skipped (no HTTP call, no Document, no quarantine) while the walk
+// continues and a normal-size file in the same directory is still
+// transcribed.
+func TestWhisperCollector_CloudEndpoint_OversizeFileSkipped(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const wantTranscript = "정상 크기 파일 전사"
+
+	serverCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverCalls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(whisperTranscribeResponse{Text: wantTranscript})
+	}))
+	defer srv.Close()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Oversized file: 26 MiB > 25 MiB cloud cap. Sorted before the small file
+	// alphabetically so the walk visits it first (regression guard: an early
+	// skip must not abort the walk for subsequent files).
+	writeSparseM4A(t, dir, "aaa_oversized.m4a", 26<<20, now)
+
+	// Normal-size file: well under the cap, must still be transcribed.
+	smallPath := filepath.Join(dir, "bbb_normal.m4a")
+	smallData := make([]byte, 64)
+	copy(smallData[4:8], "ftyp")
+	if err := os.WriteFile(smallPath, smallData, 0o600); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+	if err := os.Chtimes(smallPath, now, now); err != nil {
+		t.Fatalf("chtimes small file: %v", err)
+	}
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperModel:    "whisper-1",
+		WhisperLanguage: "ko",
+	}
+	c := makeCloudWhisperCollector(t, cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1 (oversized file skipped, normal file transcribed)", len(docs))
+	}
+	if docs[0].SourceID != "transcript:bbb_normal.m4a" {
+		t.Errorf("SourceID = %q, want transcript:bbb_normal.m4a", docs[0].SourceID)
+	}
+	if docs[0].Content != wantTranscript {
+		t.Errorf("Content = %q, want %q", docs[0].Content, wantTranscript)
+	}
+	if serverCalls != 1 {
+		t.Errorf("server called %d times, want 1 (oversized file must never reach the HTTP endpoint)", serverCalls)
+	}
+}
+
+// TestWhisperCollector_LocalEndpoint_OversizeFileNotSubjectToCloudCap verifies
+// that the 25 MiB cloud cap does NOT apply to a local endpoint — only the
+// configurable WhisperMaxFileBytes (which defaults to unlimited when unset in
+// tests) governs local deployments.
+func TestWhisperCollector_LocalEndpoint_OversizeFileNotSubjectToCloudCap(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srv, _ := newWhisperTestServer(t, "로컬 대용량 파일 전사")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// 26 MiB — over the cloud cap, but the endpoint here is local (srv.URL is
+	// 127.0.0.1), so the cloud cap must not apply.
+	writeSparseM4A(t, dir, "huge_local.m4a", 26<<20, now)
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "whisper-1",
+		WhisperLanguage: "ko",
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Errorf("Collect() returned %d docs, want 1 (local endpoint is exempt from the 25 MiB cloud cap)", len(docs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WhisperCloudAllowed guard log-level behaviour (smoke test — behaviour is
+// observable only via log output, so this test asserts the non-blocking
+// contract: Collect() must succeed identically regardless of the flag).
+// ---------------------------------------------------------------------------
+
+func TestWhisperCollector_CloudAllowedFlag_DoesNotBlockCollection(t *testing.T) {
+	t.Parallel()
+
+	for _, cloudAllowed := range []bool{true, false} {
+		cloudAllowed := cloudAllowed
+		t.Run(map[bool]string{true: "allowed", false: "not_allowed"}[cloudAllowed], func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			const wantTranscript = "클라우드 허용 플래그 무관 정상 동작"
+			srv, _ := newWhisperTestServer(t, wantTranscript)
+
+			mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+			writeDummyAudio(t, dir, "call.m4a", mtime)
+
+			cfg := &config.Config{
+				WhisperAudioDir:     dir,
+				WhisperModel:        "whisper-1",
+				WhisperLanguage:     "ko",
+				WhisperCloudAllowed: cloudAllowed,
+			}
+			c := makeCloudWhisperCollector(t, cfg, srv)
+
+			docs, err := c.Collect(context.Background(), time.Time{})
+			if err != nil {
+				t.Fatalf("Collect() error: %v", err)
+			}
+			if len(docs) != 1 || docs[0].Content != wantTranscript {
+				t.Errorf("Collect() = %+v, want 1 doc with content %q regardless of WhisperCloudAllowed=%v",
+					docs, wantTranscript, cloudAllowed)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PII redaction pin for native-diarized content (highest-value test in this
+// change — a regression here writes unredacted call content to the DB).
+// ---------------------------------------------------------------------------
+
+// TestWhisperCollector_NativeDiarization_RedactsPII verifies that a native
+// diarized_json transcript carrying a Korean phone number in one speaker's
+// segment and a plausible RRN in another's comes out fully redacted in
+// Document.Content, with the [화자N] labels intact. buildDocument applies
+// smsmap.RedactPII to `content` AFTER the diarization switch (see
+// buildDocument), so this pins that the native branch assigns its rendered,
+// speaker-labelled text to that SAME content variable rather than bypassing
+// redaction via some other path.
+func TestWhisperCollector_NativeDiarization_RedactsPII(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// 900101-1234567: YYMMDD=900101 (plausible date) + gender digit '1' (1-8)
+	// — satisfies redactRRNIfPlausible's date/gender-digit checks.
+	srv, _ := diarizedJSONServer(t, diarizedResponse{
+		Text: "제 번호는 010-1234-5678 입니다 주민번호는 900101-1234567 이에요",
+		Task: "transcribe",
+		Segments: []diarizedSegment{
+			{Type: "transcript.text.segment", Text: "제 번호는 010-1234-5678 입니다", Speaker: "A", Start: 0.0, End: 3.0, ID: "seg_0"},
+			{Type: "transcript.text.segment", Text: "주민번호는 900101-1234567 이에요", Speaker: "B", Start: 3.5, End: 6.0, ID: "seg_1"},
+		},
+	})
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call-native-pii.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir:         dir,
+		WhisperAPIURL:           srv.URL,
+		WhisperModel:            "gpt-4o-transcribe-diarize",
+		WhisperLanguage:         "ko",
+		WhisperChunkingStrategy: "auto",
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+	content := docs[0].Content
+
+	if strings.Contains(content, "010-1234-5678") {
+		t.Errorf("Content = %q, phone number was not redacted", content)
+	}
+	if strings.Contains(content, "900101-1234567") {
+		t.Errorf("Content = %q, RRN was not redacted", content)
+	}
+	if !strings.Contains(content, smsmap.PIIRedactionToken) {
+		t.Errorf("Content = %q, want %q marker present", content, smsmap.PIIRedactionToken)
+	}
+
+	// Speaker labels must survive redaction untouched.
+	if !strings.Contains(content, "[화자1]") {
+		t.Errorf("Content missing [화자1] label after redaction; content: %q", content)
+	}
+	if !strings.Contains(content, "[화자2]") {
+		t.Errorf("Content missing [화자2] label after redaction; content: %q", content)
+	}
+
+	if v, ok := docs[0].Metadata["diarization"]; !ok || v != "native" {
+		t.Errorf("Metadata[diarization] = %v, want %q", v, "native")
+	}
+
+	// Dedup identity (SourceID) must be unaffected by content redaction.
+	if docs[0].SourceID != "transcript:call-native-pii.m4a" {
+		t.Errorf("SourceID = %q, want %q (must not be affected by redaction)",
+			docs[0].SourceID, "transcript:call-native-pii.m4a")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,22 +151,53 @@ type Config struct {
 	// WHISPER_API_KEY: OpenAI (or compatible) API key
 	// WHISPER_API_URL: base URL (default: "https://api.openai.com/v1")
 	// WHISPER_AUDIO_DIR: directory containing audio files to transcribe
-	// WHISPER_MODEL: model identifier (default: "whisper-1")
+	// WHISPER_MODEL: model identifier (default: "gpt-4o-transcribe-diarize" —
+	// OpenAI's combined transcription + speaker-diarization model, which
+	// performs transcription AND diarization in a single API call; see
+	// collector.modelSupportsNativeDiarization). This reverses the local-only
+	// whisper.cpp default that predated the #100 policy exception below — a
+	// local whisper.cpp deployment must now set WHISPER_MODEL=whisper-1 (or
+	// similar) explicitly.
 	// WHISPER_LANGUAGE: BCP-47 language hint (default: "ko")
 	// WHISPER_MAX_FILE_BYTES: per-file size cap (bytes, int64, default: 100 MiB).
 	// Set 0 to disable the cap entirely (no limit). Invalid values use the default.
+	// This is a LOCAL disk/network-usage guard, distinct from the fixed 25 MiB
+	// hard limit OpenAI's hosted API enforces server-side (whisperCloudMaxFileBytes
+	// in collector/whisper.go, applied only when the resolved endpoint is
+	// non-local; not configurable, since it reflects a third-party constraint,
+	// not an operational preference).
 	// WHISPER_HTTP_TIMEOUT: per-request HTTP timeout for transcription calls
 	// (Go duration string, default: "2h"). Raise for long audio files that exceed
 	// the previous hardcoded 10-minute limit. Invalid values use the 2h default.
 	// A zero duration (e.g. "0") falls back to the 2h default so a misconfigured
 	// value never produces an infinite (zero) timeout.
-	WhisperAPIKey       string
-	WhisperAPIURL       string
-	WhisperAudioDir     string
-	WhisperModel        string
-	WhisperLanguage     string
-	WhisperMaxFileBytes int64
-	WhisperHTTPTimeout  time.Duration
+	// WHISPER_CHUNKING_STRATEGY: value sent as the chunking_strategy multipart
+	// field, ONLY when the resolved model supports native diarization (default:
+	// "auto"). Sent UNCONDITIONALLY of DIARIZATION_ENABLED for such models — see
+	// DiarizationEnabled doc comment below for why. Required by the live
+	// gpt-4o-transcribe-diarize API for the response to contain a "segments"
+	// array at all: verified against the real API — omitting it yields a
+	// text-only response and the model degenerates into repeating text. Set to
+	// the empty string to omit the field entirely (escape hatch for future API
+	// changes; not recommended for the default native-diarize model).
+	// WHISPER_CLOUD_ALLOWED: set "true" to acknowledge that call/recording audio
+	// is intentionally sent to a non-local (cloud) transcription endpoint. This
+	// is the policy-exception flag for issue #100, which originally mandated
+	// call transcription stay on a local whisper.cpp server — a mandate this
+	// collector's cloud-by-default configuration deliberately reverses. Setting
+	// this to true only changes the log level of the cloud-endpoint guard in
+	// WhisperCollector.CollectStream (Info instead of Warn); it never blocks or
+	// gates the request — the request is sent regardless either way. Default
+	// false.
+	WhisperAPIKey           string
+	WhisperAPIURL           string
+	WhisperAudioDir         string
+	WhisperModel            string
+	WhisperLanguage         string
+	WhisperMaxFileBytes     int64
+	WhisperHTTPTimeout      time.Duration
+	WhisperChunkingStrategy string
+	WhisperCloudAllowed     bool
 	// WhisperConcurrency is the number of audio files transcribed in parallel by
 	// the whisper collector. Sourced from WHISPER_CONCURRENCY (default 1, clamped
 	// to >= 1). Values >1 enable 2-node load balancing across whisper backends
@@ -184,6 +215,18 @@ type Config struct {
 	// The collector POSTs audio bytes to {DIARIZATION_API_URL}/diarize and
 	// receives speaker-segment JSON. When empty, diarization is disabled even
 	// if DIARIZATION_ENABLED=true.
+	//
+	// IMPORTANT: this flag does NOT gate diarization for a native-diarizing
+	// model (WhisperModel containing "diarize", e.g. the default
+	// gpt-4o-transcribe-diarize) — those models ALWAYS request and use
+	// diarized_json output, unconditionally of this flag. Whether call audio
+	// leaves the machine is decided entirely by WHISPER_API_URL + WHISPER_MODEL,
+	// not by DIARIZATION_ENABLED; gating native diarization on this flag would
+	// mean paying the full cloud-transcription cost while silently discarding
+	// the speaker labels the model already computed as part of that same
+	// request — full privacy cost, zero benefit, and no error to surface it.
+	// DiarizationEnabled retains its original meaning ONLY for the legacy local
+	// pyannote path (non-native model + DiarizationAPIURL).
 	DiarizationEnabled bool   // DIARIZATION_ENABLED — default false
 	DiarizationAPIURL  string // DIARIZATION_API_URL — default ""
 
@@ -460,14 +503,16 @@ func Load() (*Config, error) {
 		SMSSourceDir:    os.Getenv("SMS_SOURCE_DIR"),
 		SMSMaxFileBytes: smsMaxFileBytes(),
 
-		WhisperAPIKey:       os.Getenv("WHISPER_API_KEY"),
-		WhisperAPIURL:       getenv("WHISPER_API_URL", "https://api.openai.com/v1"),
-		WhisperAudioDir:     os.Getenv("WHISPER_AUDIO_DIR"),
-		WhisperModel:        getenv("WHISPER_MODEL", "whisper-1"),
-		WhisperLanguage:     getenv("WHISPER_LANGUAGE", "ko"),
-		WhisperMaxFileBytes: whisperMaxFileBytes(),
-		WhisperHTTPTimeout:  whisperHTTPTimeout(),
-		WhisperConcurrency:  whisperConcurrency(),
+		WhisperAPIKey:           os.Getenv("WHISPER_API_KEY"),
+		WhisperAPIURL:           getenv("WHISPER_API_URL", "https://api.openai.com/v1"),
+		WhisperAudioDir:         os.Getenv("WHISPER_AUDIO_DIR"),
+		WhisperModel:            getenv("WHISPER_MODEL", "gpt-4o-transcribe-diarize"),
+		WhisperLanguage:         getenv("WHISPER_LANGUAGE", "ko"),
+		WhisperMaxFileBytes:     whisperMaxFileBytes(),
+		WhisperHTTPTimeout:      whisperHTTPTimeout(),
+		WhisperChunkingStrategy: getenv("WHISPER_CHUNKING_STRATEGY", "auto"),
+		WhisperCloudAllowed:     os.Getenv("WHISPER_CLOUD_ALLOWED") == "true",
+		WhisperConcurrency:      whisperConcurrency(),
 
 		DiarizationEnabled: os.Getenv("DIARIZATION_ENABLED") == "true",
 		DiarizationAPIURL:  os.Getenv("DIARIZATION_API_URL"),


### PR DESCRIPTION
## 요약

- 전사(transcription)와 화자분리(diarization)를 **단일 API 호출**로 처리 (`gpt-4o-transcribe-diarize`). 기본 경로에서 별도 pyannote 마이크로서비스 왕복이 더 이상 사용되지 않음
- `chunking_strategy=auto`는 **필수** — 실제 API로 확인한 결과, 이 파라미터 없이는 200 응답에 `segments` 배열 자체가 없고 모델이 텍스트를 반복 생성하며 열화됨
- diarization 지원 모델일 경우 네이티브 화자분리를 **무조건** 요청. `DIARIZATION_ENABLED`는 이제 로컬 pyannote(레거시) 경로 선택 여부만 결정 — 조건부로 걸면 클라우드 전사 비용은 전액 지불하고 화자 라벨은 버리는 셈이 됨
- 네이티브 세그먼트는 `labelTranscript`로 재정렬하지 않음 — API가 세그먼트별로 반환하는 화자가 authoritative하며, max-overlap 정렬 방식은 앞선 세그먼트에 포함된 세그먼트를 잘못 귀속시킬 수 있음. 블록 렌더링은 공용 헬퍼로 추출하여 두 경로 모두 동일한 `[화자N]` 포맷을 출력하도록 함
- `smsmap.RedactPII`는 네이티브 diarize 콘텐츠에도 그대로 적용됨 (테스트로 고정)
- 25MiB 초과 파일은 non-local 엔드포인트에서 경고와 함께 스킵 (OpenAI 하드 리밋); 격리(quarantine)나 원장(ledger) 기록은 하지 않음
- 신규 env: `WHISPER_CHUNKING_STRATEGY` (기본값 auto), `WHISPER_CLOUD_ALLOWED` (로그 레벨 용도만). `WHISPER_MODEL` 기본값이 diarize 모델로 변경
- 로컬 `whisper`/`diarization` compose 서비스는 `local-inference` profile 뒤로 이동, opt-in 폴백으로 유지

## 정책 변경 (명시)

이 변경은 #100에서 확립한 "로컬 전용" 방침을 전사 경로에 한해 **의도적으로 뒤집습니다** — 통화 음성이 이제 OpenAI로 전송됩니다. 사용자가 명시적으로 승인함. diarization 엔드포인트의 locality guard(#165/#169)와 리다이렉트 거부 로직은 손대지 않았고 해당 경로에는 그대로 적용됩니다.

## 검증 근거

- `go build ./...` 통과
- `go test -count=1 ./internal/collector/... ./internal/config/...` 통과
- `gofmt -l` 대상 3개 파일 clean
- `docker compose -f docker-compose.local.yml config --quiet` 통과

리스크가 높은 동작을 고정하는 테스트:
- `TestWhisperCollector_NativeDiarization_RedactsPII` — 네이티브 경로에서도 PII 리댁션 유지
- `TestWhisperCollector_NativeDiarization_OverlappingSegmentsKeepOwnSpeaker` — 겹치는 세그먼트에서 자기 화자 유지 (재정렬 misattribution 방지)
- `TestWhisperCollector_NativeDiarization_IgnoresDiarizationEnabledFlag` — 네이티브 diarize 요청이 `DIARIZATION_ENABLED` 플래그와 무관하게 항상 발생
- `TestWhisperCollector_CloudEndpoint_OversizeFileSkipped` / `TestWhisperCollector_LocalEndpoint_OversizeFileNotSubjectToCloudCap` — 25MiB 캡이 클라우드에만 적용됨

## 배포 참고

이 브랜치는 아직 배포되지 않은 보안 관련 커밋 7건(#163~#169, #166 등 phone-number PII/diarization locality/dial-time 검증 관련) 위에 올라가 있습니다. 이 PR을 머지 후 배포하면 해당 보안 수정들도 함께 prod에 반영됩니다.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>