### PR TITLE
curation PII 정책 전환 + ollama 제거 + summarizer 원격 LLM 대응

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -85,11 +85,27 @@ func run() error {
 	var wg sync.WaitGroup
 
 	// drainTimeout is the maximum time to wait for in-flight ticks to finish
-	// after the shutdown signal is received.  10 s is long enough to let a
-	// running UpdateSummary or embedding call complete; if the LLM is slow the
-	// tick exits cleanly because it uses context.WithoutCancel internally and
-	// the WaitGroup drain acts as the hard ceiling.
-	const drainTimeout = 10 * time.Second
+	// after the shutdown signal is received.
+	//
+	// It is derived from cfg.SummarizerDocTimeout (default 30s) rather than a
+	// bare constant: SummarizerWorker detaches an in-flight document's LLM
+	// call + embed + UpdateSummary write from SIGTERM (context.WithoutCancel)
+	// so the write is never truncated mid-write, and bounds that work only by
+	// SummarizerDocTimeout (#170, was a fixed 8s "maxTickDuration" tuned for a
+	// fast local LLM — see summarizer.go doc comments). If drainTimeout were
+	// still a hardcoded value shorter than the configured doc timeout, a
+	// SIGTERM during an in-flight document could be killed by drainTimeout
+	// before the detached UpdateSummary write completes, defeating the whole
+	// point of detaching it. The +10s margin covers goroutine
+	// scheduling/cleanup overhead on top of the LLM/embed/write budget itself.
+	//
+	// The entity-extraction and extraction-retry workers use the raw
+	// (non-detached) shutdown context directly, so they are cancelled
+	// near-instantly and do not drive this timeout.
+	drainTimeout := cfg.SummarizerDocTimeout + 10*time.Second
+	if drainTimeout < 15*time.Second {
+		drainTimeout = 15 * time.Second
+	}
 
 	// --- Extraction retry worker ---
 	// Periodically re-attempts failed file extractions.
@@ -152,8 +168,10 @@ func run() error {
 		Store:           docStore,
 		LLM:             llmClient,
 		Embedder:        embedClient,
-		Interval:        5 * time.Minute,
-		BatchSize:       10,
+		Interval:        cfg.SummarizerInterval,
+		BatchSize:       cfg.SummarizerBatchSize,
+		DocTimeout:      cfg.SummarizerDocTimeout,
+		Concurrency:     cfg.SummarizerConcurrency,
 		BackfillEnabled: &cfg.SummarizerBackfillEnabled,
 	})
 	wg.Add(1)
@@ -212,7 +230,8 @@ func run() error {
 		collector.NewTelegramCollector(cfg.TelegramBotToken, cfg.TelegramChatIDs),
 		collector.NewGmailCollector(cfg),
 		collector.NewCalendarCollector(cfg),
-		collector.NewSMSCollector(cfg.SMSSourceDir, cfg.SMSMaxFileBytes),
+		collector.NewSMSCollector(cfg.SMSSourceDir, cfg.SMSMaxFileBytes).
+			WithNumberHashingEnabled(cfg.PIINumberHashingEnabled),
 		collector.NewWhisperCollector(cfg),
 	}
 	if cfg.FilesystemEnabled && cfg.FilesystemPath != "" {
@@ -311,9 +330,10 @@ func run() error {
 	// Bounded drain: give in-flight goroutines (summarizer, retry worker) time
 	// to finish their current tick before the process exits.
 	//
-	// SummarizerWorker uses maxTickDuration (8 s) which is shorter than
-	// drainTimeout (10 s), so in-flight ticks always complete before the
-	// drain window closes (#65).
+	// SummarizerWorker bounds any in-flight document to SummarizerDocTimeout
+	// (default 30 s), and drainTimeout is derived from that same value above,
+	// so in-flight documents always complete before the drain window closes
+	// (#65, #170).
 	//
 	// The drainDone channel is buffered so that the wg.Wait() goroutine can
 	// send without blocking even when the drain timeout fires first — this

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -118,6 +118,7 @@ func run() error {
 			reindexStateStore,
 		)).
 		WithIngestFile(docStore, chunkStore, embedClient, cfg.IngestMaxFileBytes).
+		WithPIINumberHashing(cfg.PIINumberHashingEnabled).
 		WithIngestMessages(docStore, chunkStore, embedClient, cfg.IngestMaxBatchMessages, cfg.CollectorCutover).
 		WithIngestRecording(docStore, cfg.IngestRecordingDir, cfg.IngestMaxFileBytes, cfg.CollectorCutover)
 	httpServer := &http.Server{

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -87,8 +87,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      ollama:
-        condition: service_started
     volumes:
       - ${LLM_MEMORY_DB_HOST_PATH:-/Users/user/workspace/llm-memory/data/memory.sqlite}:/data/llm-memory.sqlite:ro
       - ${GMAIL_HOST_PATH:-/Users/user/workspace/private/secretary/gmail}:/data/gmail:ro
@@ -101,7 +99,10 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # ollama — 로컬 LLM 서버 (내부 포트 11434).
+  # ollama — 로컬 LLM 서버 (내부 포트 11434). 기본적으로 기동되지 않는다.
+  #   기본 LLM 백엔드는 원격 API(DeepSeek, LLM_API_URL=https://api.deepseek.com/v1)이며,
+  #   Go 코드베이스 어디에도 ollama 를 참조하는 곳이 없다 (레거시 잔재).
+  #   완전히 opt-in 서비스로만 유지한다: `docker compose --profile local-inference up -d`.
   #   gemma3:12b-it-qat 모델을 사용한다. macOS arm64 CPU 전용 (느림).
   #   모델 파일은 named volume ollama_models 에 영속된다.
   #   첫 기동 후: docker exec second-brain-ollama ollama pull gemma3:12b-it-qat
@@ -109,6 +110,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     container_name: second-brain-ollama
+    profiles: ["local-inference"]
     volumes:
       - ollama_models:/root/.ollama
     restart: unless-stopped

--- a/docs/superpowers/specs/2026-08-17-ask-capture-design.md
+++ b/docs/superpowers/specs/2026-08-17-ask-capture-design.md
@@ -1,0 +1,516 @@
+# Ask & Capture 설계 명세
+
+**작성일**: 2026-08-17
+**대상**: `web/` (Next.js) + Go API 서버 (`cmd/server`) + 컬렉터 데몬 (`cmd/collector`)
+**상태**: 설계 확정 — 구현 전
+
+---
+
+## 1. 개요
+
+second-brain은 지금까지 SMS·통화·Gmail·Slack·GitHub·파일시스템 등을 자동 수집해 검색 가능한 RAG로 축적해 왔다. 사용자가 직접 이 데이터에게 "질문"하거나 "생각을 남기는" 진입점은 없었다 — `web/`은 대시보드·거버넌스·문서 뷰어이고, 유일한 노트 작성 경로는 MCP `add_note` 도구(AI 에이전트 전용)뿐이다.
+
+본 명세는 두 가지 사용자 대면 기능을 기존 `web/` Next.js 앱에 추가하는 설계를 기술한다.
+
+1. **Ask** — 자연어로 질문하면 사용자 자신의 색인된 데이터에 근거한 LLM 답변을 클릭 가능한 출처와 함께 받는다.
+2. **Capture** — 생각을 적으면 그대로 저장되고, 이후 비동기로 LLM이 제목/요약/태그/엔티티를 정리하고, 암묵지(tacit knowledge)를 별도로 추적되는 추론으로 추출한다.
+
+두 기능 모두 프론트엔드는 `web/`에 있지만, 검색·생성·저장 로직은 전부 Go API 서버(`cmd/server`)와 컬렉터 데몬(`cmd/collector`)에 있다. Next.js는 인증 프록시 이상의 역할을 하지 않는다.
+
+---
+
+## 2. 목표 및 비목표
+
+### 목표
+
+- 46,000+ 문서 코퍼스에 대해 근거 기반 자연어 질의응답을 제공한다(Ask).
+- 순간적인 생각을 마찰 없이 기록하고, 이를 잃어버리지 않으면서도 검색 가능한 지식으로 발전시킨다(Capture).
+- 사용자의 원문과 LLM의 해석(정리/추론)을 스키마 레벨에서 영구히 구분한다.
+- 모바일에서도 Ask·Capture를 편하게 쓸 수 있게 한다.
+- 기존 인증·배포·워커 패턴을 재사용해 새 구조를 만들지 않는다.
+
+### 비목표
+
+- `dashboard`, `governance`, `api-docs`, `login`, `documents/[id]` 다섯 개 기존 페이지의 Cloudscape 마이그레이션 — 후속 작업으로 별도 추적.
+- 노트가 아닌 다른 소스(SMS, 통화, Gmail 등)로부터의 암묵지 추출 — v1은 노트에서만 추론한다(§10).
+- 기존 `llm-memory` 소스(19,933건, MCP `add_note`로 과거 작성된 문서)의 마이그레이션 — 그대로 둔다(§3.3).
+- `brain.baekenough.com` 경로 변경 — 폰의 유일한 ingest 경로이며 건드리지 않는다(§8).
+- 실시간 협업, 노트 편집 UI — 범위 밖. 노트 삭제와 인사이트 검색 노출 정책은 결정되었다(§6.5).
+
+---
+
+## 3. 데이터 세그멘테이션 모델 (핵심)
+
+이 설계의 핵심은 노트를 어떻게 저장하느냐다. 세 계층으로 나누되, UI 라벨이 아니라 **스키마 레벨**에서 분리한다.
+
+| 계층 | 위치 | 내용 | 변경 가능 여부 |
+|------|------|------|----------------|
+| 원문(Raw) | 신규 `SourceNote = "note"` 소스 타입, 문서 `Content` | 사용자가 입력한 그대로 | LLM이 절대 수정하지 않음 |
+| 정리(Organized) | 같은 노트 문서의 `Metadata` | LLM이 생성한 제목/요약/태그/엔티티 | 재생성 가능 |
+| 추론(Inferred) | 별도 문서, 신규 `SourceInsight = "insight"` 소스 타입 | 노트에서 도출한 암묵지 명제 | 원본 노트를 `Metadata`의 provenance로 역참조 |
+
+### 3.1 왜 이렇게 나누는가
+
+- **원문은 영구히 사용자의 것이어야 한다.** "정리" 과정에서 LLM이 문장을 다시 쓰면, 몇 달 후에는 무엇이 사용자의 실제 생각이고 무엇이 모델의 요약인지 아무도 구별할 수 없다. `Content` 필드는 write-once — 정리 파이프라인은 `Content`를 절대 건드리지 않고 `Metadata`에만 쓴다.
+- **추론은 관측이 아니다.** "김대표가 예산 얘기를 피했다"는 관측이고, "자금 사정이 어렵다"는 추론이다. 이 둘을 한 문서에 섞으면, 나중에 추론이 사실로 인용되는 문제가 생긴다. `insight` 문서는 물리적으로 다른 문서다.
+
+### 3.2 에코 체임버 방지
+
+`insight` 문서도 임베딩되어 검색 가능하다 — 즉 하나의 추론이 다음 추론의 근거로 재인용될 수 있다는 뜻이다. 두 가지 가드로 막는다.
+
+1. **insight-of-insight 금지** — `insight` 문서는 그 자체로 다시 enrichment/추출 파이프라인의 입력이 되지 않는다. 정리(§3의 Organized 계층 생성) 및 암묵지 추출(§10의 v1 제약, §6.4의 범위 제한) 모두 `source_type=note`인 문서에만 실행된다.
+2. **`/ask` 프롬프트 내 분리된 레인** — 컨텍스트 조립 시 `insight` 문서는 별도로 라벨링된 섹션에 배치되고, "이것은 가설이며 사실로 인용할 수 없다"는 지시문이 함께 주어진다(§5.2).
+3. **범위 제한 + 감사 가능성** — 추출 가능한 추론의 종류를 명시적으로 제한하고(§6.4), 모든 인사이트에 confidence 값과 원문 노트의 근거 span을 남겨 사후 감사가 가능하게 한다. 노트당 최대 3건으로 상한을 둔다(§6.4).
+4. **`/api/v1/search` 기본 제외(영구 정책)** — `insight` 문서는 일반 검색 API의 기본 결과에서 항상 제외되고, 호출자가 `source_type=insight`를 명시적으로 요청할 때만 반환된다(§6.5). 라벨 없는 일반 검색 결과에 추론이 섞여 나오는 것 자체가 "모델의 추측"이 "내가 알던 사실"로 둔갑하는 경로이기 때문이다.
+
+### 3.3 기존 `llm-memory` 소스와의 관계
+
+`internal/model/document.go`에 정의된 기존 소스 타입은 다음과 같다.
+
+```go
+const (
+    SourceSlack          SourceType = "slack"
+    SourceGitHub         SourceType = "github"
+    SourceGDrive         SourceType = "gdrive"
+    SourceNotion         SourceType = "notion"
+    SourceFilesystem     SourceType = "filesystem"
+    SourceDiscord        SourceType = "discord"
+    SourceTelegram       SourceType = "telegram"
+    SourceSecretary      SourceType = "secretary"
+    SourceLLMMemory      SourceType = "llm-memory"
+    SourceGmail          SourceType = "gmail"
+    SourceCalendar       SourceType = "calendar"
+    SourceSMS            SourceType = "sms"
+    SourceCallLog        SourceType = "call-log"
+    SourceCallTranscript SourceType = "call-transcript"
+    SourceUpload         SourceType = "upload"
+)
+```
+
+여기에 `SourceNote = "note"`와 `SourceInsight = "insight"` 두 개가 추가된다. `llm-memory`는 MCP `add_note` 도구가 지금까지 써온 소스 타입이며, 19,933건이 이미 존재한다. 이 문서들은 **건드리지 않는다** — 마이그레이션도, 재라벨링도 하지 않는다. 이유: `llm-memory` 문서는 3계층 세그멘테이션이 적용되지 않은 채로 저장되어 있어(원문/정리가 한 필드에 섞여 있음) 지금 재분류하려면 각 문서를 사람이 읽고 원문과 정리를 수동으로 분리해야 한다 — 자동화된 마이그레이션은 오분류 위험이 크고, 그 리스크를 감수할 만큼 `llm-memory` 데이터가 활발히 조회되지도 않는다. 새 노트부터 새 모델을 적용하고, 기존 데이터는 별개의 소스로 공존시킨다.
+
+---
+
+## 4. 아키텍처 개요
+
+```
+브라우저 (Cloudscape UI)
+  │  next-auth 세션 쿠키
+  ▼
+Next.js route handlers (web/src/app/api/v1/ask, web/src/app/api/v1/notes)
+  │  Authorization: Bearer ${API_KEY}  (BRAIN_API_URL로 프록시)
+  ▼
+Go API 서버 (cmd/server, internal/api)
+  │
+  ├─ POST /api/v1/ask  → search.Service (검색) + llm.Client (SSE 생성)
+  └─ POST /api/v1/notes → internal/note (동기 저장, 202 반환)
+                              │
+                              ▼
+                        PostgreSQL (documents, chunks)
+                              │
+                              ▼  (비동기, 폴링)
+                    NoteEnrichmentWorker (cmd/collector, internal/worker)
+                        - 정리(title/summary/tags/entities) → Metadata
+                        - 암묵지 추출 → 신규 insight 문서
+```
+
+Ask와 Capture 모두 생성/저장 로직은 Go에 있다. `search.Service`, `llm.Client`, 임베딩 스택(`internal/search.EmbeddingEngine`)은 이미 Go에 있고 MCP 서버(`cmd/mcp`)와 공유된다. RAG 조립("무엇을 검색하고 어떻게 프롬프트할지")을 Go와 TypeScript 두 곳에 만들면 두 구현이 갈라진다 — 그래서 생성 위치는 Go 신규 엔드포인트로 고정한다.
+
+---
+
+## 5. Ask 설계
+
+### 5.1 `POST /api/v1/ask`
+
+기존 `internal/api/router.go`의 Bearer 인증 그룹(`r.Group` + `requireAPIKey`)에 등록되는 신규 라우트다. `internal/api/document.go`, `search.go` 등 기존 핸들러와 마찬가지로 `Server`에 의존성을 주입해 무조건 등록한다(선택적 기능이 아니므로 `search`/`documents`처럼 `if s.X != nil` 조건부 등록 패턴을 쓰지 않는다).
+
+요청:
+
+```json
+{
+  "question": "지난달 김대표랑 예산 얘기 어떻게 됐어?"
+}
+```
+
+응답은 `text/event-stream`(SSE)이다.
+
+```
+event: sources
+data: {"sources":[{"id":"uuid","title":"...","source_type":"sms","score":0.82},{"id":"uuid","title":"...","source_type":"note","score":0.77}]}
+
+event: token
+data: {"text":"김대표는 "}
+
+event: token
+data: {"text":"예산 얘기를 피했고,"}
+
+event: done
+data: {"finish_reason":"stop"}
+```
+
+| 이벤트 | 시점 | 페이로드 |
+|--------|------|---------|
+| `sources` | 검색 완료 직후, 생성 시작 전 | 컨텍스트로 채택된 문서 목록(id, title, source_type, score) — 프론트엔드가 즉시 "출처" 칩을 렌더링할 수 있게 스트림 최초에 1회 전송 |
+| `token` | 생성 중, 반복 | LLM이 생성한 텍스트 조각 |
+| `done` | 생성 완료 | `finish_reason` ("stop" \| "error" \| "no_evidence") |
+| `error` | 오류 발생 시 (연결은 유지하고 이벤트로 알림) | `{"message": "..."}` |
+
+에러 케이스:
+
+| 상황 | 처리 |
+|------|------|
+| 인증 실패 | `401 Unauthorized` (SSE 스트림 시작 전 — 기존 `requireAPIKey` 미들웨어) |
+| 빈 질문 | `400 Bad Request` |
+| 검색 결과 0건 | 스트림은 시작하되 `sources: []` 전송 후, 프롬프트에 "근거 없음"을 명시해 모델이 스스로 "모른다"고 답하게 유도. `done` 이벤트의 `finish_reason`은 `no_evidence` |
+| LLM 클라이언트 미설정(`Enabled()==false`) | 스트림 시작 전 `503 Service Unavailable` |
+| LLM 호출 중 오류 | `error` 이벤트 전송 후 `done` (`finish_reason: "error"`)로 스트림 정상 종료 — SSE 커넥션을 끊지 않고 클라이언트가 후속 재시도를 결정하게 한다 |
+
+### 5.2 컨텍스트 조립
+
+`search.Service.Search`를 **두 번** 호출한다.
+
+1. **본검색**: `SearchQuery{Query: question, ExcludeSourceTypes: []model.SourceType{model.SourceInsight}, Limit: K}` — `insight` 문서를 제외한 일반 검색(§3.2의 가드 1).
+2. **인사이트 검색**: `SearchQuery{Query: question, SourceType: &model.SourceInsight, Limit: M}` — `insight` 문서만 별도로 검색.
+
+K, M은 env var로 조정 가능한 값이며 기본값은 `ASK_CONTEXT_TOP_K=12`(본검색), `ASK_CONTEXT_INSIGHT_M=3`(인사이트 검색)이다. 이 기본값은 시작점이며, 실제 프롬프트 토큰 사용량을 측정한 뒤 튜닝한다(§14) — `gpt-5.6-luna`의 컨텍스트 윈도우 크기나 토큰 단가는 확인된 바 없으므로 본 명세에서 단정하지 않는다.
+
+두 결과는 프롬프트에서 라벨이 다른 두 섹션으로 배치된다.
+
+```
+[관측된 사실]
+1. (sms, 2026-07-14) "예산 얘기 나오니까 말 돌리시더라고요"
+2. (note, 2026-07-15) "김대표 미팅 — 예산 항목만 스킵함"
+...
+
+[추론 — 가설이며 사실로 인용 불가]
+1. (insight, 출처: note #uuid) "자금 사정이 어려울 가능성"
+...
+
+지시: 위 [관측된 사실]에서 답을 찾아라. [추론]은 참고할 수 있으나 그 자체를 사실처럼 서술하지 마라("~할 가능성이 있다는 메모가 있다" 식으로만 인용). 근거가 없으면 "모른다"고 답하라 — 근거 밖으로 추측해서 답하지 마라.
+```
+
+시스템 프롬프트에 다음을 고정한다.
+
+- 답은 반드시 제공된 컨텍스트에 근거해야 한다.
+- 근거가 불충분하면 "모른다"고 명시적으로 답한다 — 컨텍스트 밖 지식으로 채우지 않는다.
+- `insight` 레인의 내용은 가설이며, 사실처럼 인용하지 않는다.
+
+응답 스트림의 `sources` 이벤트에는 본검색 + 인사이트 검색 결과를 합쳐 프론트엔드에서 두 종류를 시각적으로 구분(§7.2)할 수 있도록 `source_type`을 포함한다.
+
+### 5.3 스트리밍 구현
+
+`internal/llm.Client`(`internal/llm/client.go`)의 `Completer` 인터페이스는 현재 다음 두 메서드만 제공한다.
+
+```go
+type Completer interface {
+    Enabled() bool
+    CompleteWithMessages(ctx context.Context, system string, messages []Message) (string, error)
+}
+```
+
+스트리밍 메서드가 없다 — 이번 작업에서 추가해야 한다. `Client`가 이미 OpenAI 호환 `/v1/chat/completions` 엔드포인트를 호출하므로, `stream: true` + SSE 파싱을 추가하는 확장이다. 새 메서드(가칭 `StreamWithMessages`)를 `Completer` 인터페이스에 추가하면 `internal/api`의 `/ask` 핸들러가 콜백 또는 채널을 통해 토큰을 받아 그대로 클라이언트 SSE로 전달(pass-through)한다. 이 인터페이스 변경은 `EntityWorker`, `SummarizerWorker` 등 기존 `Completer` 소비자에게는 영향이 없다(기존 메서드는 유지, 추가만 함).
+
+**모델**: `gpt-5.6-luna`, OpenAI 호환 엔드포인트, 서버 측 API 키(`internal/config`의 `LLM_API_KEY`/`LLM_API_URL`, 기본값은 `EmbeddingAPIKey`/`EmbeddingAPIURL`에서 파생). 키는 브라우저에 절대 노출되지 않는다 — Next.js route handler는 세션만 검증하고, 실제 LLM 호출은 Go 서버 프로세스 내부에서만 일어난다.
+
+**전용 모델 override**: 신규 env var `LLM_ASK_MODEL`(기본값 `gpt-5.6-luna`)을 도입해 `/ask`와 노트 enrichment 워커(§6.3) 둘 다 이 값을 쓴다. 기존 `LLM_MODEL`(기본값 `gpt-4o-mini`)은 엔티티 추출·요약·HyDE·큐레이션 등 기존 기능에 그대로 남는다. 두 노브로 분리하는 이유: 저 기존 기능들은 46,000+ 문서 코퍼스 전체를 대상으로 대량 실행되므로, `LLM_MODEL`을 조용히 더 큰 모델로 바꾸면 비용이 배수로 늘고 아무도 요청하지 않은 방식으로 기존 출력이 바뀐다. 반면 Ask·Capture enrichment는 대화형·저볼륨이면서 품질에 민감한 워크로드다. 워크로드 성격이 다르므로 노브도 다르게 둔다.
+
+---
+
+## 6. Capture 설계
+
+### 6.1 `POST /api/v1/notes`
+
+원문을 동기적으로 저장하고 즉시 응답한다. Enrichment는 별도 워커가 비동기로 처리한다 — 저장이 LLM 가용성이나 지연에 의존하면 안 된다(폰에서 입력한 생각이 OpenAI 장애에도 살아남아야 한다).
+
+요청:
+
+```json
+{
+  "title": "김대표 미팅 메모",
+  "content": "예산 얘기 나오니까 계속 말을 돌리더라. 다음 안건으로 넘어가자고 두 번이나 제안함."
+}
+```
+
+`title`이 비어 있으면 서버가 `content` 앞부분으로 임시 제목을 생성하지 않고, enrichment 워커가 정식 제목을 생성할 때까지 빈 문자열로 둔다(추측 제목을 원문처럼 보이게 만들지 않기 위함 — `Content`뿐 아니라 사용자가 명시적으로 입력한 것만 즉시 필드에 반영한다는 원칙의 연장).
+
+응답: `202 Accepted`
+
+```json
+{
+  "id": "uuid",
+  "status": "pending"
+}
+```
+
+크기 제한은 기존 `add_note`와 동일하게 맞춘다 — `cmd/mcp/main.go`에 정의된 `maxNoteContentBytes = 10 * 1024 * 1024`(10 MiB), `maxNoteTitleBytes = 1024`(1 KiB), `maxEmbedChunks = 2000`. 청크 수가 2000을 넘는 노트는 저장·FTS 색인은 되지만 임베딩은 건너뛴다(기존 `add_note`의 `errEmbedSkipped` 동작과 동일 — 사용자에게 오류로 노출하지 않는다).
+
+에러 케이스:
+
+| 상황 | 처리 |
+|------|------|
+| 인증 실패 | `401 Unauthorized` |
+| `content` 비어있음 | `400 Bad Request` |
+| `content` > 10 MiB | `413 Request Entity Too Large` |
+| `title` > 1 KiB | `400 Bad Request` |
+| DB 저장 실패 | `500 Internal Server Error` |
+
+Enrichment 상태는 노트 문서의 `Metadata`에 기록된다.
+
+```json
+{
+  "enrichment_status": "pending",   // "pending" | "done" | "failed"
+  "enrichment_attempts": 0,          // 시도 횟수, 최대 3
+  "enrichment_last_error": null      // failed일 때만 채워짐
+}
+```
+
+`Document.Status`(`"active"`/`"deleted"`/`"moved"`)는 문서 생명주기 필드로 이미 용도가 정해져 있어(`internal/model/document.go` 주석 참조) enrichment 진행 상태를 여기에 얹지 않는다 — `Metadata.enrichment_status`로 분리해 재시도 가능하고 UI에서 조회 가능하게 한다. 재시도 정책과 `enrichment_attempts`의 소비 방식은 §6.3.
+
+### 6.2 코드 재사용 — `internal/note` 패키지 추출
+
+`cmd/mcp/main.go`(537번 줄)의 `handleAddNote`와 그 헬퍼들은 이미 좁은 인터페이스로 분리되어 있다.
+
+```go
+// cmd/mcp/main.go
+type NoteDocumentUpserter interface {
+    Upsert(ctx context.Context, doc *model.Document) error
+}
+type NoteChunkWriter interface {
+    ReplaceDocument(ctx context.Context, documentID uuid.UUID, chunks []store.Chunk) error
+    ListByDocument(ctx context.Context, documentID uuid.UUID) ([]store.Chunk, error)
+    UpdateChunkEmbeddings(ctx context.Context, embeddings []store.ChunkEmbedding) error
+}
+type NoteEmbedder interface {
+    Enabled() bool
+    EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+}
+```
+
+이 세 인터페이스와 `handleAddNote`, `embedNoteChunks`, 관련 상수(`maxNoteContentBytes`, `maxNoteTitleBytes`, `maxEmbedChunks`, `errEmbedSkipped`)를 신규 패키지 `internal/note`로 추출한다. MCP `add_note` 도구와 신규 `POST /api/v1/notes` 핸들러가 동일한 코드를 호출하게 된다.
+
+**소스 타입 변경**: 현재 `handleAddNote`는 `model.SourceLLMMemory`를 하드코딩한다(`cmd/mcp/main.go:573`). `internal/note`로 옮기면서 소스 타입을 파라미터화해 `SourceNote`를 기본값으로 쓴다. `add_note` MCP 도구는 하위 호환을 위해 계속 `SourceLLMMemory`를 명시적으로 넘긴다 — MCP를 통해 AI 에이전트가 쓰는 메모리와, 사람이 Capture UI로 쓰는 노트는 계속 별개 소스로 유지한다(§3.3). `POST /api/v1/notes`는 `SourceNote`를 넘긴다.
+
+청킹은 기존과 동일하게 `chunker.Split(content, chunker.SelectOptions(*doc))`를 그대로 쓴다.
+
+### 6.3 Enrichment 워커
+
+`internal/worker/entity_worker.go`의 패턴(리스터 인터페이스 + `Run`/`tick`/`markProcessed` + claim 방식)을 따른다. 이 워커도 `internal/worker/summarizer.go`, `entity_worker.go`와 마찬가지로 **컬렉터 데몬**(`cmd/collector/main.go`)에서 기동된다 — API 서버 프로세스가 아니다. 기존 워커들이 전부 `cmd/collector`에서 등록·실행되는 구조를 그대로 따른다.
+
+```go
+// internal/worker/note_enrichment_worker.go (신규)
+type NoteEnrichmentLister interface {
+    ListPendingNotes(ctx context.Context, limit int) ([]*model.Document, error)
+    MarkNoteEnriched(ctx context.Context, documentID uuid.UUID, metadata map[string]any) error
+    MarkNoteEnrichmentAttemptFailed(ctx context.Context, documentID uuid.UUID, attempts int, reason string) error
+    MarkNoteEnrichmentTerminal(ctx context.Context, documentID uuid.UUID, reason string) error
+}
+```
+
+**단일 LLM 호출 구조**: 노트당 LLM 호출은 **한 번**이다. 정리 필드(제목/요약/태그/엔티티)와 암묵지 후보(§6.4)를 모두 포함하는 구조화된 JSON 스키마를 한 번의 호출로 받는다 — 컨텍스트(노트 원문)를 두 번 보내지 않고, 비용도 노트당 호출 1회로 상한이 걸린다. 엔티티는 응답 JSON의 `entities` 필드로 받아 기존 `internal/worker/entity_extractor.go`의 `model.Entity` 스키마와 동일한 형태로 매핑한 뒤, `EntityLinker.UpsertAndLinkEntities`(기존 `EntityWorker`가 쓰는 저장/연결 경로)로 연결한다 — 즉 엔티티 **추출** 자체는 이번 단일 호출의 일부이고, 엔티티 **저장/링킹** 메커니즘만 기존 코드를 재사용한다(`ExtractEntities`를 별도로 다시 호출하지 않는다).
+
+한 틱에서 처리하는 노트마다:
+
+1. 단일 LLM 호출 → 구조화된 JSON(제목/요약/태그/엔티티/암묵지 후보 최대 3건, §6.4) 파싱.
+2. 성공 시: 정리 필드를 노트 문서 `Metadata`에 병합, 엔티티는 `UpsertAndLinkEntities`로 연결, 암묵지 후보는 각각 새 `insight` 문서로 저장(§6.5) → `MarkNoteEnriched`로 `enrichment_status: "done"`.
+3. 실패 시(LLM 오류, JSON 파싱 실패 등): `enrichment_attempts`를 증가시키고 `MarkNoteEnrichmentAttemptFailed` 호출.
+   - **3회 미만**: 지수 백오프(예: 1분/5분/30분) 후 다음 틱에서 재시도 대상에 다시 포함.
+   - **3회 도달**: `MarkNoteEnrichmentTerminal`로 `enrichment_status: "failed"` 확정(터미널 상태) + `enrichment_last_error`에 사유 기록. 이후 워커는 이 노트를 자동으로 재큐잉하지 않는다.
+4. **수동 재시도**: 터미널 `failed` 노트는 UI에서 재시도 버튼으로 노출된다(§7.3). 재시도는 `POST /api/v1/notes/{id}/retry-enrichment`(신규, 기존 `requireAPIKey` 그룹에 등록)로 `enrichment_attempts`를 0으로, `enrichment_status`를 `pending`으로 되돌려 다음 워커 틱에서 다시 처리되게 한다.
+
+무제한 재시도는 절대 끝나지 않는 LLM 비용 누수이고, 재시도 0회는 일시적인 429나 네트워크 오류에도 노트가 영구히 미정리 상태로 남는다 — 3회 상한 + 수동 재시도로 두 극단을 피한다.
+
+### 6.4 암묵지 추출 범위 (중요)
+
+암묵지 추출은 "흥미로워 보이는 건 뭐든 추론"하는 방식으로 두면 가장 빠르게 코퍼스를 오염시킨다 — 잘못된 추론도 똑같이 임베딩되고 검색되며, 1년 뒤에는 좋은 추론과 구별되지 않는다. 그래서 추출 범위를 명시적으로 제한한다.
+
+**허용되는 추론**:
+- 노트가 암묵적으로 내포하는 사실의 재서술.
+- 사용자 자신의 여러 노트에 걸쳐 반복되는 패턴.
+- 노트가 전제하고 있지만 명시하지 않은 전제(unstated premise).
+- 후속 행동 후보(follow-up action candidate).
+
+**금지되는 추론**:
+- 제3자의 감정·동기·성격에 대한 단정.
+- 단 한 번의 관찰로부터의 인과관계 단정.
+- 노트 표면에 근거가 없는, 특정 인물에 대한 주장.
+
+**감사 가능성**: 모든 인사이트는 `confidence` 값과 원본 노트 내 근거 span(예: 문자 오프셋 범위 또는 인용 문장)을 함께 가져야 한다 — 나중에 "이 추론이 어디서 나왔는지"를 감사할 수 있어야 한다.
+
+**상한**: 노트당 인사이트는 **최대 3건**. 상한이 없으면 모델은 항상 "하나 더" 추론을 찾아내려 하고, 저품질 추론의 양이 늘어나는 것은 아예 없는 것보다 나쁘다 — 검색에서 진짜 근거를 밀어낸다.
+
+### 6.5 `insight` 문서 생성 규칙
+
+- `SourceType: SourceInsight`, `Content`는 추론 명제 자체(예: "자금 사정이 어려울 가능성").
+- `Metadata.confidence`(§6.4의 confidence 값), `Metadata.source_span`(근거 span).
+- `Metadata.provenance.source_note_id`로 원본 노트를 역참조.
+- 임베딩됨 — 검색 가능(§3.2 가드로 재귀 방지).
+- **enrichment 파이프라인의 재입력이 되지 않음**: `ListPendingNotes`는 `source_type=note`만 조회하므로 `insight` 문서는 애초에 워커의 처리 대상이 아니다.
+- **원본 노트 삭제 시 연쇄 소프트 삭제(영구 정책)**: 노트가 소프트 삭제(`Status: "deleted"`)되면, `Metadata.provenance.source_note_id`로 해당 노트를 가리키는 모든 `insight` 문서도 함께 소프트 삭제된다. 근거가 사라진 추론은 반증 불가능하고 감사 불가능하다 — 고아 인사이트를 남겨두는 것은 형태만 다른 provenance 붕괴다.
+- **`/api/v1/search` 기본 결과에서 항상 제외(영구 정책)**: 호출자가 `SourceType: &model.SourceInsight`로 명시적으로 요청하지 않는 한 일반 검색 결과에 포함되지 않는다. `/ask`만이 `insight`를 쓰는 유일한 경로이며, 거기서도 항상 별도 라벨링된 레인으로만 등장한다(§5.2).
+
+---
+
+## 7. 프론트엔드 설계
+
+### 7.1 Cloudscape 도입
+
+`web/`(Next.js 16.2.3, React 19.2.5)의 현재 커스텀 UI 컴포넌트는 `web/src/components/ui/`의 `Card`, `Badge`, `Button`, `Spinner` 네 개뿐이다. AWS Cloudscape Design System을 통째로 도입한다. 이번 작업 범위는 Ask·Capture 화면과 앱 셸(내비게이션, 레이아웃 프레임)뿐이다 — 기존 다섯 페이지(`dashboard`, `governance`, `api-docs`, `login`, `documents/[id]`)의 Cloudscape 전환은 하지 않는다(후속 작업).
+
+### 7.2 Ask 화면
+
+**데스크톱**: Cloudscape 기본 컴포지션(`AppLayout` + `SpaceBetween` + `Chat`류 패턴) — 질문 입력, 스트리밍 답변, 하단에 출처 카드 목록. 출처 카드는 `source_type`에 따라 시각적으로 구분한다(`insight`는 별도 배지로 "추론" 표시, 클릭 시 원본 노트로 이동 가능하도록 `provenance.source_note_id` 활용).
+
+**모바일**: Cloudscape는 데스크톱 콘솔 지향의 정보 밀도가 높은 시스템이라 기본 컴포지션이 폰 화면에서 그대로 동작하지 않는다. 의도적으로 Cloudscape 기본값에서 벗어나, 세로 스택 레이아웃 + 화면 하단 고정 입력창으로 구성한다.
+
+### 7.3 Capture 화면
+
+**데스크톱**: 단일 텍스트 영역 + 저장 버튼. 저장 후 enrichment 상태(`pending`/`done`/`failed`)를 노트 목록에서 확인 가능. 터미널 `failed`(3회 실패) 노트는 실패 사유와 함께 재시도 버튼이 노출되며, 클릭 시 `POST /api/v1/notes/{id}/retry-enrichment`를 호출한다(§6.3).
+
+**모바일**: 입력 마찰을 최소화하기 위해 필드 하나 + 큰 저장 버튼만 노출한다. 이 역시 Cloudscape 기본 데스크톱 폼 컴포지션에서 의도적으로 벗어난 구성이다.
+
+### 7.4 인증
+
+기존 패턴을 그대로 재사용한다 — 새 인증 메커니즘을 만들지 않는다.
+
+- 브라우저는 next-auth 세션을 보유(`web/src/auth.ts`) — GitHub OAuth(`GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`) + `ALLOWED_GITHUB_USERS` 화이트리스트.
+- `web/src/app/api/v1/ask/route.ts`, `web/src/app/api/v1/notes/route.ts` 두 신규 route handler가 세션을 검증한 뒤, 기존 `web/src/app/api/search/route.ts` 패턴과 동일하게 `BRAIN_API_URL`(컨테이너 내부에서는 `http://server:8080`) + `Authorization: Bearer ${API_KEY}`로 Go 서버에 프록시한다. `/ask`는 SSE 스트림이므로 route handler는 응답 바디를 버퍼링하지 않고 그대로 pass-through 해야 한다(Next.js Route Handler의 `ReadableStream` 응답으로 구현).
+
+---
+
+## 8. 배포
+
+- 신규 호스트네임 `sb.baekenough.com`을 Mac mini의 `~/.cloudflared/second-brain.yml`에 ingress 엔트리 하나로 추가하고, `web` 컨테이너로 라우팅한다.
+- `brain.baekenough.com`은 **변경하지 않는다** — 계속 Go 서버(`localhost:8081`, `docker-compose.local.yml`에서 `server` 서비스가 `8081:8080`으로 바인딩됨)를 직접 가리킨다. 이 경로는 폰(second-brain-push 앱)의 유일한 ingest 진입점이며, 2026년 8월 prod 점검에서 `web` 컨테이너가 폰의 유일한 인터넷 진입점 역할을 하고 있었다는 것이 실측으로 드러나 의도적으로 분리한 구조다(§`feedback_container_hidden_dependency` 참조). `web`을 다시 그 경로에 끼워 넣으면 동일한 단일 장애점이 재현된다.
+- `web` 컨테이너는 현재 `docker-compose.local.yml`에 정의는 되어 있으나 prod에서 기동되고 있지 않다(8월 축소 당시 제거됨). 본 작업으로 다시 기동한다.
+
+---
+
+## 9. 오류 처리
+
+### 9.1 `/api/v1/ask`
+
+| 상황 | 처리 |
+|------|------|
+| 검색 0건 | `sources: []` + `no_evidence` 종료 |
+| LLM 스트리밍 중 네트워크 오류 | `error` 이벤트 + `done(finish_reason: "error")`, 커넥션은 정상 종료 |
+| 클라이언트 연결 조기 종료 | 서버는 `ctx.Done()`을 감지해 LLM 호출을 취소(컨텍스트 전파) |
+
+### 9.2 `/api/v1/notes`
+
+| 상황 | 처리 |
+|------|------|
+| enrichment LLM 실패(1~2회차) | `enrichment_attempts` 증가, 지수 백오프 후 다음 틱에서 재시도. 노트 원문·저장은 영향 없음 |
+| enrichment LLM 실패(3회차, 터미널) | `enrichment_status: "failed"` 확정 + `enrichment_last_error` 기록, 자동 재큐잉 중단. UI 수동 재시도로만 재개(§6.3) |
+| 임베딩 청크 수 초과(2000) | `errEmbedSkipped`와 동일하게 조용히 스킵 — 사용자 오류 아님 |
+| `POST /api/v1/notes/{id}/retry-enrichment` 대상 노트가 터미널 `failed`가 아님 | `409 Conflict`(이미 진행 중이거나 완료된 노트에 대한 불필요한 재시도 방지) |
+
+---
+
+## 10. 보안 / 프라이버시
+
+- LLM API 키는 서버 프로세스 내부에만 존재 — `LLM_API_KEY`가 브라우저·Next.js 클라이언트 번들에 노출되지 않는다(Next.js route handler는 서버 사이드에서만 실행되고 브라우저로 키를 전달하지 않는다).
+- 노트는 사용자 본인이 직접 입력한 텍스트이므로, SMS/통화 전사에 적용되는 OTP 리댁션 같은 처리는 해당하지 않는다.
+- **v1 제약**: 암묵지 추출은 `source_type=note` 문서에서만 수행한다. SMS·통화 전사 등 다른 소스로부터 인사이트를 추론하지 않는다 — 다른 소스는 이미 전사 단계에서 OTP 등을 리댁션했는데, 만약 그 소스에서 인사이트를 추론하면 리댁션된 내용이 인사이트 문서를 통해 다시 표면화될 위험이 있다. 이 위험을 v1 범위에서 원천 차단한다.
+- `insight` 문서는 `Metadata.provenance.source_note_id`로 원본을 추적 가능하며, 원본 노트가 소프트 삭제되면 연쇄 소프트 삭제된다(§6.5, 영구 정책).
+- `insight` 문서는 `/api/v1/search` 기본 결과에서 항상 제외되고, `/ask`의 별도 레인에서만 사용된다(§6.5, 영구 정책) — 라벨 없는 추론이 사실처럼 검색 결과에 섞여 나오는 경로를 스키마 레벨에서 차단한다.
+- 암묵지 추출 자체의 허용/금지 범위(제3자 감정·동기·성격 단정 금지, 단일 관찰로부터의 인과 단정 금지 등)는 §6.4 참조 — 이 또한 넓은 의미의 프라이버시 가드다.
+
+---
+
+## 11. 테스트 전략
+
+### 11.1 Go 핸들러 테스트
+
+기존 `internal/api/ingest_messages_test.go` 패턴(`httptest.NewRequest` + `srv.Handler().ServeHTTP` + 스텁 구현체)을 따른다.
+
+| 대상 | 테스트 케이스 |
+|------|--------------|
+| `POST /api/v1/ask` | 인증 없음 → 401 / 빈 질문 → 400 / 검색 0건 → `no_evidence` / 정상 흐름에서 `sources` → `token`* → `done` 이벤트 순서 검증(가짜 `Completer`로 스트리밍 모킹) / LLM 미설정 → 503 |
+| `POST /api/v1/notes` | 인증 없음 → 401 / 빈 content → 400 / 10 MiB 초과 → 413 / 정상 저장 → 202 + `enrichment_status: pending` |
+| `internal/note` 패키지 | 기존 `handleAddNote` 테스트(`cmd/mcp/main_test.go`)를 이관, 소스 타입 파라미터화 검증(기본 `SourceNote`, MCP 경로는 `SourceLLMMemory`) |
+
+### 11.2 노트 파이프라인 테스트
+
+| 대상 | 테스트 케이스 |
+|------|--------------|
+| `NoteEnrichmentWorker` | `entity_worker_test.go` 패턴 — 가짜 `NoteEnrichmentLister` + 가짜 `Completer`로 tick 단위 처리 검증. 단일 호출 성공 시 `Metadata` 병합 + 엔티티 링킹 + insight 문서 생성이 모두 한 틱에서 일어나는지 확인 |
+| 재시도 정책 | 1~2회 실패 시 `enrichment_attempts` 증가 + 비터미널 상태 유지, 3회째 실패 시 `enrichment_status: failed`(터미널) + 자동 재큐잉 중단 확인 |
+| 인사이트 상한 | LLM이 4건 이상의 후보를 반환해도 상위 3건만 저장되는지 확인(§6.4) |
+| 에코 체임버 가드 | `ListPendingNotes`가 `source_type=note`만 반환하는지, `insight` 문서가 절대 조회 대상에 포함되지 않는지 단위 테스트로 고정 |
+| `/api/v1/search` 기본 제외 | `source_type` 미지정 검색 결과에 `insight` 문서가 나타나지 않는지, `source_type=insight` 명시 시에만 반환되는지 확인(§6.5) |
+| `POST /api/v1/notes/{id}/retry-enrichment` | 터미널 `failed` 노트 → `enrichment_attempts`가 0으로 리셋되고 `pending`으로 전환 / 비터미널 상태 노트 → `409 Conflict` |
+
+### 11.3 수동 검증
+
+- 모바일 레이아웃(Ask 하단 고정 입력창, Capture 단일 필드)은 실기기/에뮬레이터에서 수동 확인 — 자동화된 시각 회귀 테스트는 범위 밖.
+- SSE 스트리밍의 실제 토큰 지연/청크 분할은 브라우저 Network 탭에서 수동 확인.
+
+---
+
+## 12. 파일 레이아웃
+
+```
+second-brain/
+├── internal/
+│   ├── note/                        # 신규 — cmd/mcp/main.go에서 추출
+│   │   ├── note.go                  # handleAddNote, embedNoteChunks 이관 (소스 타입 파라미터화)
+│   │   ├── note_test.go
+│   │   └── limits.go                # maxNoteContentBytes, maxNoteTitleBytes, maxEmbedChunks
+│   ├── api/
+│   │   ├── router.go                # 수정 — /api/v1/ask, /api/v1/notes, /api/v1/notes/{id}/retry-enrichment 라우트 추가
+│   │   ├── ask.go                   # 신규 — SSE 핸들러, 컨텍스트 조립
+│   │   ├── ask_test.go
+│   │   ├── notes.go                 # 신규 — POST /api/v1/notes + POST /api/v1/notes/{id}/retry-enrichment 핸들러
+│   │   └── notes_test.go
+│   ├── llm/
+│   │   └── client.go                # 수정 — StreamWithMessages 추가, Completer 인터페이스 확장
+│   ├── worker/
+│   │   ├── note_enrichment_worker.go   # 신규 — entity_worker.go 패턴
+│   │   └── note_enrichment_worker_test.go
+│   ├── model/
+│   │   └── document.go              # 수정 — SourceNote, SourceInsight 추가
+│   └── config/
+│       └── config.go                # 수정 — LLM_ASK_MODEL, ASK_CONTEXT_TOP_K, ASK_CONTEXT_INSIGHT_M 추가
+├── cmd/
+│   ├── mcp/main.go                  # 수정 — internal/note 호출로 교체, SourceLLMMemory 유지
+│   └── collector/main.go            # 수정 — NoteEnrichmentWorker 등록
+└── web/
+    └── src/
+        ├── app/
+        │   ├── ask/page.tsx                     # 신규
+        │   ├── capture/page.tsx                 # 신규
+        │   └── api/v1/
+        │       ├── ask/route.ts                 # 신규 — SSE pass-through 프록시
+        │       └── notes/route.ts               # 신규 — 프록시
+        └── components/
+            └── cloudscape/                      # 신규 — Cloudscape 기반 앱 셸 + Ask/Capture 전용 컴포넌트
+```
+
+---
+
+## 13. 미결 사항
+
+이전 초안에서 미결이었던 6개 항목(모델 override, enrichment 재시도 정책, 인사이트 검색 노출, 노트 삭제 시 파생 insight 처리, enrichment 호출 구조, Ask 컨텍스트 크기)은 모두 결정되어 해당 섹션에 반영되었다 — §5.2(K/M 기본값), §5.3(`LLM_ASK_MODEL`), §6.3(단일 호출 구조 + 재시도 정책), §6.4(암묵지 추출 범위), §6.5(insight 검색 노출·삭제 연쇄). 아래는 그 결정들을 반영한 뒤에도 남는, 구현 단계에서 확정해야 할 세부 사항이다.
+
+### 13.1 Confidence 값의 스케일과 임계값
+
+§6.4에서 모든 인사이트에 `confidence` 값을 요구하기로 했지만, 이 값이 0–1 사이의 연속값인지 저/중/고 같은 범주형인지, `/ask` 프롬프트에서 특정 임계값 미만의 인사이트를 아예 컨텍스트에서 제외할지는 정하지 않았다.
+
+### 13.2 재시도 백오프의 정확한 간격
+
+§6.3에서 3회 상한 + 지수 백오프로 정책은 확정했지만, 구체적인 대기 시간(예: 1분/5분/30분)은 예시일 뿐 확정값이 아니다. 실제 LLM 오류율과 워커 틱 주기를 보고 정한다.
+
+### 13.3 `retry-enrichment` 엔드포인트의 남용 방지
+
+수동 재시도 액션(§6.3, §7.3)에 별도의 속도 제한을 둘지, 아니면 기존 Bearer 인증만으로 충분하다고 볼지는 정하지 않았다.
+
+---
+
+## 14. 출시 계획
+
+1. **Go 서버 먼저**: `internal/note` 패키지 추출(기존 `add_note` 동작 회귀 없음을 `cmd/mcp` 테스트로 확인) → `SourceNote`/`SourceInsight` 모델 추가 → `LLM_ASK_MODEL`/`ASK_CONTEXT_TOP_K`/`ASK_CONTEXT_INSIGHT_M` config 추가 → `POST /api/v1/notes` 구현 → `llm.Client.StreamWithMessages` 추가 → `POST /api/v1/ask` 구현 → 핸들러 테스트 통과.
+2. **워커**: `NoteEnrichmentWorker` 구현(단일 LLM 호출 + 3회 재시도 정책 + 인사이트 3건 상한, §6.3–§6.4) → `POST /api/v1/notes/{id}/retry-enrichment` 구현 → `cmd/collector`에 등록 → `EntityLinker.UpsertAndLinkEntities` 재사용 검증.
+3. **프롬프트 검증(실측 단계)**: 실제 노트 샘플로 enrichment 프롬프트의 출력 품질(정리 필드 정확도, 암묵지 후보가 §6.4 허용 범위를 벗어나지 않는지)과 노트당 비용·지연을 측정한다 — 결과에 따라 `LLM_ASK_MODEL` 프롬프트 템플릿을 조정한다. `ASK_CONTEXT_TOP_K`/`ASK_CONTEXT_INSIGHT_M`(기본 12/3)도 실제 프롬프트 토큰 사용량을 측정해 튜닝한다(§5.2). 이 단계 전까지는 §13의 세부 사항(백오프 간격, confidence 임계값)도 확정하지 않는다.
+4. **프론트엔드**: Cloudscape 도입(앱 셸만) → Ask/Capture 페이지 구현(데스크톱 우선, 실패 노트 재시도 UI 포함) → 모바일 레이아웃 추가 → route handler 프록시(SSE pass-through 포함) 구현.
+5. **배포**: `docker-compose.local.yml`의 `web` 서비스 재기동 → `sb.baekenough.com` cloudflared ingress 추가 → `brain.baekenough.com` 무변경 확인 → Mac mini 배포·검증.
+6. **후속**: 기존 5개 페이지 Cloudscape 마이그레이션(별도 작업), §13 잔여 세부 사항 순차 확정.

--- a/internal/api/ingest_messages.go
+++ b/internal/api/ingest_messages.go
@@ -152,7 +152,7 @@ func (s *Server) ingestMessagesHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		doc := smsmap.MapSMS(rec.Address, rec.Body, rec.DateMs, rec.Type, rec.ContactName)
+		doc := smsmap.MapSMS(rec.Address, rec.Body, rec.DateMs, rec.Type, rec.ContactName, s.piiNumberHashingEnabled)
 
 		// Cutover floor: skip records that pre-date the cutover.
 		if !s.messagesCutover.IsZero() && doc.OccurredAt != nil && doc.OccurredAt.Before(s.messagesCutover) {
@@ -181,7 +181,7 @@ func (s *Server) ingestMessagesHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		doc := smsmap.MapCall(rec.Number, rec.DateMs, rec.DurationSec, rec.Type, rec.ContactName)
+		doc := smsmap.MapCall(rec.Number, rec.DateMs, rec.DurationSec, rec.Type, rec.ContactName, s.piiNumberHashingEnabled)
 
 		// Cutover floor: skip records that pre-date the cutover.
 		if !s.messagesCutover.IsZero() && doc.OccurredAt != nil && doc.OccurredAt.Before(s.messagesCutover) {

--- a/internal/api/ingest_recording.go
+++ b/internal/api/ingest_recording.go
@@ -286,31 +286,38 @@ func (s *Server) ingestRecordingHandler(w http.ResponseWriter, r *http.Request) 
 			audioFilename = fmt.Sprintf("voice-memo_%s%s", timestampStr, ext)
 		}
 	default: // "call"
-		// Mirrors smsmap.MapCall SourceID format. Computed BEFORE audioFilename
-		// so the filename can reuse the same one-way hash (issue #164/#165
-		// follow-up) — see the audioFilename comment below. This does not
-		// change the SourceID itself, so already-ingested call-log documents
-		// keep an identical SourceID after this change (dedup/upsert identity
-		// is unaffected).
+		// Mirrors smsmap.MapCall SourceID format. This hashing is UNCONDITIONAL
+		// — independent of s.piiNumberHashingEnabled — since changing the
+		// SourceID scheme would orphan every already-ingested call-log document
+		// (dedup/upsert identity). numHash is also reused below for the
+		// audioFilename when hashing IS enabled (see the audioFilename comment).
 		numHash = smsmap.ShortHash(number)
 		durHash := smsmap.BodyShortHash(fmt.Sprintf("%d", durationSec))
 		sourceID = fmt.Sprintf("call-log:%d:%s:%s", dateMs, numHash, durHash)
 
-		// Format: {numHash}_{YYYYMMDDHHMMSS}{ext}
+		// Format when s.piiNumberHashingEnabled: {numHash}_{YYYYMMDDHHMMSS}{ext}
+		// Format when disabled (default, issue #164 policy reversal):
+		// {sanitizePhoneNumber(number)}_{YYYYMMDDHHMMSS}{ext} — the pre-#164
+		// behaviour, restored verbatim via sanitizePhoneNumber (digits/+/- only).
 		//
-		// Security: previously this embedded sanitizePhoneNumber(number) — the
-		// raw phone number with only punctuation stripped — directly in the
-		// on-disk filename, leaking PII into filesystem paths, logs, backups,
-		// and any sync tooling that mirrors the recording directory. numHash
-		// is already computed above for the SourceID, so reusing it here for
-		// the filename is free and keeps the two identifiers consistent.
+		// Security note (retained for the hashing-enabled path): embedding
+		// numHash instead of the raw number keeps PII out of filesystem paths,
+		// logs, backups, and any sync tooling that mirrors the recording
+		// directory. With hashing disabled this protection is intentionally
+		// traded away — see PIINumberHashingEnabled's doc comment in
+		// internal/config/config.go for the owner's rationale.
 		//
 		// WhisperCollector.recordingTime() (reTPhone) only parses the trailing
 		// "_YYYYMMDDHHMMSS[-N]" timestamp suffix and does not care what
-		// precedes it, so this rename is fully transparent to the cutover /
-		// watermark logic and to isTPhoneCallPath's diarization heuristic.
+		// precedes it, so either naming choice is fully transparent to the
+		// cutover / watermark logic and to isTPhoneCallPath's diarization
+		// heuristic.
+		filenamePrefix := numHash
+		if !s.piiNumberHashingEnabled {
+			filenamePrefix = sanitizePhoneNumber(number)
+		}
 		audioFilename = fmt.Sprintf("%s_%s%s",
-			numHash,
+			filenamePrefix,
 			timestampStr,
 			ext,
 		)
@@ -327,12 +334,19 @@ func (s *Server) ingestRecordingHandler(w http.ResponseWriter, r *http.Request) 
 	// audioBytes was validated above; write from memory to disk.
 	destPath := filepath.Join(s.recordingDir, audioFilename)
 	if err := os.WriteFile(destPath, audioBytes, 0o644); err != nil {
-		// Security: log only the basename, never the full destPath. audioFilename
-		// is hash-based for kind=call as of this change (see numHash above), but
-		// logging the basename rather than the directory-qualified path is kept
-		// as defence-in-depth against any future/legacy naming path that still
-		// embeds raw PII.
-		slog.Error("ingest_recording: write audio file", "filename", filepath.Base(destPath), "error", err)
+		// Security (issue #164): when hashing is enabled, log only the basename,
+		// never the full destPath — audioFilename is hash-based for kind=call in
+		// that mode, but logging just the basename is kept as defence-in-depth
+		// against any future/legacy naming path that still embeds raw PII. When
+		// hashing is disabled (default), the number is already embedded in
+		// audioFilename regardless, so restricting the log to the basename would
+		// only hide the directory context without protecting anything — log the
+		// full destPath instead.
+		if s.piiNumberHashingEnabled {
+			slog.Error("ingest_recording: write audio file", "filename", filepath.Base(destPath), "error", err)
+		} else {
+			slog.Error("ingest_recording: write audio file", "path", destPath, "error", err)
+		}
 		writeError(w, http.StatusInternalServerError, "internal server error")
 		return
 	}
@@ -349,28 +363,47 @@ func (s *Server) ingestRecordingHandler(w http.ResponseWriter, r *http.Request) 
 	// doc already succeeded, and missing sidecars are handled gracefully by
 	// WhisperCollector (historical files have no sidecar).
 	//
-	// Security (issue #164): the counterpart phone number is never written to
-	// the sidecar in plaintext. Only its ShortHash (numHash, already computed
-	// above for the SourceID) is stored, under the number_hash key. This is a
-	// one-way hash — the sidecar cannot be used to recover the raw number.
+	// Security (issue #164), now conditional on s.piiNumberHashingEnabled: when
+	// enabled, the counterpart phone number is never written to the sidecar in
+	// plaintext — only its ShortHash (numHash, already computed above for the
+	// SourceID) is stored, under the number_hash key, a one-way hash the
+	// sidecar cannot be used to recover the raw number from. When disabled
+	// (default, policy reversal), the raw number is written under the "number"
+	// key instead — number_hash is omitted entirely — so WhisperCollector's
+	// sidecar reader (readRecordingSidecar in internal/collector/whisper.go)
+	// can additively surface it as Metadata["number"] on the eventual
+	// call-transcript document (see that function's doc comment).
 	sidecarDirection := ""
 	if kind == "call" {
 		sidecarDirection = "incoming"
 	}
 	sidecar := recordingSidecar{
 		ContactName:     contactName,
-		NumberHash:      numHash,
 		Direction:       sidecarDirection,
 		RecordingType:   kind,
 		DurationSeconds: durationSec,
 		DateMs:          dateMs,
 		Kind:            kind,
 	}
+	if s.piiNumberHashingEnabled {
+		sidecar.NumberHash = numHash
+	} else if kind == "call" {
+		sidecar.Number = number
+	}
 	if sidecarData, marshalErr := json.Marshal(sidecar); marshalErr != nil {
-		// Security: basename only — see the write-audio-file log above.
-		slog.Warn("ingest_recording: marshal sidecar", "filename", filepath.Base(destPath), "error", marshalErr)
+		// Security: basename only when hashing is enabled — see the
+		// write-audio-file log above for the same disabled-hashing rationale.
+		if s.piiNumberHashingEnabled {
+			slog.Warn("ingest_recording: marshal sidecar", "filename", filepath.Base(destPath), "error", marshalErr)
+		} else {
+			slog.Warn("ingest_recording: marshal sidecar", "path", destPath, "error", marshalErr)
+		}
 	} else if writeErr := os.WriteFile(destPath+".meta.json", sidecarData, 0o644); writeErr != nil {
-		slog.Warn("ingest_recording: write sidecar", "filename", filepath.Base(destPath)+".meta.json", "error", writeErr)
+		if s.piiNumberHashingEnabled {
+			slog.Warn("ingest_recording: write sidecar", "filename", filepath.Base(destPath)+".meta.json", "error", writeErr)
+		} else {
+			slog.Warn("ingest_recording: write sidecar", "path", destPath+".meta.json", "error", writeErr)
+		}
 	}
 
 	// --- Build document title, content, and metadata by kind ---
@@ -399,16 +432,22 @@ func (s *Server) ingestRecordingHandler(w http.ResponseWriter, r *http.Request) 
 			"transcription":    "pending",
 		}
 	default: // "call"
-		// Security: when the caller supplies no contact_name, NEVER fall back
-		// to the raw phone number for Title/Content — unlike SourceID, these
-		// are plaintext user-facing fields and would leak PII. Fall back to a
-		// short, one-way hashed label built from numHash (already computed
-		// above for the SourceID/filename), matching the "number_hash" naming
-		// used elsewhere (sidecar, SourceID) so the fallback is consistent
-		// and non-reversible rather than a partial mask of the real number.
+		// Security (issue #164), now conditional on s.piiNumberHashingEnabled:
+		// when enabled AND the caller supplies no contact_name, never fall back
+		// to the raw phone number for Title/Content — unlike SourceID, these are
+		// plaintext user-facing fields. Fall back to a short, one-way hashed
+		// label built from numHash (already computed above for the
+		// SourceID/filename), matching the "number_hash" naming used elsewhere
+		// (sidecar, SourceID). When hashing is disabled (default, policy
+		// reversal), fall back to the raw number instead — that's the point of
+		// disabling the flag.
 		contact := contactName
 		if contact == "" {
-			contact = "상대 " + numHash[:8]
+			if s.piiNumberHashingEnabled {
+				contact = "상대 " + numHash[:8]
+			} else {
+				contact = number
+			}
 		}
 		title = fmt.Sprintf("incoming 통화 %s", contact)
 		content = fmt.Sprintf("상대방: %s\n통화 방향: incoming\n통화 시간: %ds\n[TRANSCRIPTION PENDING]",
@@ -420,6 +459,15 @@ func (s *Server) ingestRecordingHandler(w http.ResponseWriter, r *http.Request) 
 			"duration_seconds": durationSec,
 			"audio_file":       audioFilename,
 			"transcription":    "pending",
+		}
+		// Additive (issue #164 policy reversal, not part of the original #164
+		// behaviour): when hashing is disabled, also surface the raw number in
+		// Metadata so it is searchable/visible in the UI — the point of turning
+		// hashing off. Verified against prod: 0 of 1,759 existing call/sms
+		// documents carry "number" or "number_hash" in Metadata today, so this
+		// is a forward-only addition with no backfill implication.
+		if !s.piiNumberHashingEnabled {
+			meta["number"] = number
 		}
 	}
 
@@ -459,14 +507,24 @@ func (s *Server) ingestRecordingHandler(w http.ResponseWriter, r *http.Request) 
 // (e.g. contact_name for an anonymous call, direction for a voice-memo) are
 // omitted from the sidecar rather than stored as empty strings.
 //
-// Security note (issue #164): the counterpart phone number is intentionally
-// NOT stored in plaintext. NumberHash carries smsmap.ShortHash(number) instead
-// — a one-way SHA-256-derived hash, matching the hash already embedded in the
-// call-log document's SourceID. WhisperCollector's sidecar reader
-// (readRecordingSidecar in internal/collector/whisper.go) does not parse a
-// "number" key today, so this rename carries no consumer-contract risk.
+// Security note (issue #164), now policy-flagged via cfg.PIINumberHashingEnabled:
+// when the flag is true, the counterpart phone number is NOT stored in
+// plaintext — NumberHash carries smsmap.ShortHash(number) instead, a one-way
+// SHA-256-derived hash matching the hash already embedded in the call-log
+// document's SourceID, and Number is left empty (omitted from the JSON).
+// When the flag is false (the new default — see PIINumberHashingEnabled's doc
+// comment in internal/config/config.go for the owner's rationale), Number
+// carries the raw phone number instead and NumberHash is left empty. The
+// handler (ingestRecordingHandler) only ever populates one of the two fields
+// for a given upload, never both. WhisperCollector's sidecar reader
+// (readRecordingSidecar in internal/collector/whisper.go) parses the "number"
+// key and, when present, additively surfaces it as Metadata["number"] on the
+// eventual call-transcript document — NumberHash is intentionally NOT
+// surfaced there, since the whole point of the raw-number addition is
+// searchability, which a hash does not provide.
 type recordingSidecar struct {
 	ContactName     string `json:"contact_name,omitempty"`
+	Number          string `json:"number,omitempty"`
 	NumberHash      string `json:"number_hash,omitempty"`
 	Direction       string `json:"direction,omitempty"`
 	RecordingType   string `json:"recording_type,omitempty"`

--- a/internal/api/ingest_recording_test.go
+++ b/internal/api/ingest_recording_test.go
@@ -52,6 +52,14 @@ func validM4ABytes(n int) []byte {
 
 // newRecordingTestServer creates a Server wired for the ingest-recording handler.
 // If recordingDir is empty a temp dir is created and its path returned.
+//
+// PII number hashing (issue #164) is explicitly turned ON here so every
+// existing test in this file — written when hashing was the only behaviour —
+// keeps passing unmodified. Tests exercising the new default (hashing OFF,
+// raw number surfaced) build their own Server directly with
+// WithPIINumberHashing(false) instead of using this helper; see
+// TestIngestRecording_AnonymousCallTitleRawNumberWhenHashingDisabled and
+// TestIngestRecording_FilenameUsesRawNumberWhenHashingDisabled.
 func newRecordingTestServer(
 	t *testing.T,
 	upserter IngestRecordingUpserter,
@@ -63,7 +71,8 @@ func newRecordingTestServer(
 	if recordingDir == "" {
 		recordingDir = t.TempDir()
 	}
-	srv := NewServer(nil, nil, nil, nil, nil, "", "test-key")
+	srv := NewServer(nil, nil, nil, nil, nil, "", "test-key").
+		WithPIINumberHashing(true)
 	srv.WithIngestRecording(upserter, recordingDir, maxFileBytes, cutover)
 	return srv, recordingDir
 }
@@ -433,6 +442,60 @@ func TestIngestRecording_FilenameEncoding(t *testing.T) {
 	}
 }
 
+// TestIngestRecording_FilenameUsesRawNumberWhenHashingDisabled is the mirror
+// of TestIngestRecording_FilenameEncoding for the default
+// (PIINumberHashingEnabled=false) case: the saved audio filename embeds the
+// sanitized raw number instead of its hash (issue #164 policy reversal), and
+// the sidecar carries "number" (raw) rather than "number_hash".
+func TestIngestRecording_FilenameUsesRawNumberWhenHashingDisabled(t *testing.T) {
+	t.Parallel()
+
+	upserter := &stubIngestUpserter{}
+	recordingDir := t.TempDir()
+	srv := NewServer(nil, nil, nil, nil, nil, "", "test-key")
+	srv.WithIngestRecording(upserter, recordingDir, 0, time.Time{})
+
+	number := "01012345678"
+	// 2024-01-15 09:30:00 UTC
+	dateMs := int64(1705311000000)
+	localTime := time.Unix(1705311000, 0).In(time.Local)
+	expectedTimestamp := localTime.Format("20060102150405")
+
+	body, ct := buildRecordingForm(t, "call.m4a", validM4ABytes(32), number, dateMs)
+	rr := doRecordingPost(t, srv, body, ct, "Bearer test-key")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", rr.Code, rr.Body.String())
+	}
+
+	audioFiles := audioFilesInDir(t, recordingDir)
+	if len(audioFiles) != 1 {
+		t.Fatalf("expected 1 audio file, got %d", len(audioFiles))
+	}
+	audioFile := audioFiles[0]
+
+	wantName := fmt.Sprintf("%s_%s.m4a", sanitizePhoneNumber(number), expectedTimestamp)
+	if audioFile != wantName {
+		t.Errorf("audio filename=%q, want %q", audioFile, wantName)
+	}
+
+	// Sidecar must carry "number" (raw), not "number_hash".
+	sidecarPath := filepath.Join(recordingDir, audioFile+".meta.json")
+	sidecarData, err := os.ReadFile(sidecarPath)
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	var sidecar map[string]any
+	if err := json.Unmarshal(sidecarData, &sidecar); err != nil {
+		t.Fatalf("unmarshal sidecar: %v", err)
+	}
+	if sidecar["number"] != number {
+		t.Errorf("sidecar number = %v, want %q", sidecar["number"], number)
+	}
+	if _, ok := sidecar["number_hash"]; ok {
+		t.Errorf("sidecar must not contain number_hash when hashing is disabled, got %v", sidecar["number_hash"])
+	}
+}
+
 // TestIngestRecording_NotConfigured verifies that the endpoint returns 503 when
 // not wired up.
 func TestIngestRecording_NotConfigured(t *testing.T) {
@@ -713,6 +776,56 @@ func TestIngestRecording_AnonymousCallTitleNeverContainsRawNumber(t *testing.T) 
 	// explicitly so a future change doesn't silently reintroduce one.
 	if contactName, _ := doc.Metadata["contact_name"].(string); contactName != "" {
 		t.Errorf("metadata[contact_name] = %q, want empty", contactName)
+	}
+}
+
+// TestIngestRecording_AnonymousCallTitleRawNumberWhenHashingDisabled is the
+// mirror of TestIngestRecording_AnonymousCallTitleNeverContainsRawNumber for
+// the default (PIINumberHashingEnabled=false) case: Title/Content fall back
+// to the raw number instead of a hashed label, and the raw number is
+// additionally surfaced in Metadata["number"] so it stays searchable (issue
+// #164 policy reversal). SourceID stays hashed regardless.
+func TestIngestRecording_AnonymousCallTitleRawNumberWhenHashingDisabled(t *testing.T) {
+	t.Parallel()
+
+	upserter := &stubIngestUpserter{}
+	recordingDir := t.TempDir()
+	srv := NewServer(nil, nil, nil, nil, nil, "", "test-key")
+	srv.WithIngestRecording(upserter, recordingDir, 0, time.Time{})
+
+	number := "010-5555-6666"
+	dateMs := time.Now().Add(-time.Hour).UnixMilli()
+
+	// contact_name intentionally omitted.
+	body, ct := buildRecordingForm(t, "anon.m4a", validM4ABytes(32), number, dateMs,
+		"duration_sec", "30",
+	)
+	rr := doRecordingPost(t, srv, body, ct, "Bearer test-key")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body: %s", rr.Code, rr.Body.String())
+	}
+
+	if len(upserter.upserted) != 1 {
+		t.Fatalf("expected 1 upserted doc, got %d", len(upserter.upserted))
+	}
+	doc := upserter.upserted[0]
+
+	if !strings.Contains(doc.Title, number) {
+		t.Errorf("Title = %q should contain the raw phone number %q when hashing is disabled", doc.Title, number)
+	}
+	if !strings.Contains(doc.Content, number) {
+		t.Errorf("Content = %q should contain the raw phone number %q when hashing is disabled", doc.Content, number)
+	}
+
+	gotNumber, _ := doc.Metadata["number"].(string)
+	if gotNumber != number {
+		t.Errorf("metadata[number] = %q, want %q", gotNumber, number)
+	}
+
+	// SourceID must still be hashed — this flag never touches dedup identity.
+	wantNumHash := smsmap.ShortHash(number)
+	if !strings.Contains(doc.SourceID, wantNumHash) {
+		t.Errorf("SourceID = %q should still contain the hashed number %q regardless of the flag", doc.SourceID, wantNumHash)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -87,6 +87,15 @@ type Server struct {
 	// route is registered. Set via WithCollectStatus before calling Handler().
 	collectStatus CollectionStatusProvider
 
+	// piiNumberHashingEnabled mirrors cfg.PIINumberHashingEnabled (issue #164
+	// policy reversal). Zero value (false) is the new default and is used by
+	// both ingestMessagesHandler (smsmap.MapSMS/MapCall) and
+	// ingestRecordingHandler (sidecar/filename/anonymous-title logic): the raw
+	// phone number is written instead of a hash, and (additively) into
+	// Metadata["number"] so it stays searchable. Set via
+	// WithPIINumberHashing before calling Handler().
+	piiNumberHashingEnabled bool
+
 	// handlerOnce ensures buildHandler is called exactly once per Server so
 	// that the graphql-go schema (and its package-level type objects) are
 	// constructed a single time regardless of how many goroutines call Handler.
@@ -113,6 +122,20 @@ func NewServer(
 		filesystemPath: filesystemPath,
 		apiKey:         apiKey,
 	}
+}
+
+// WithPIINumberHashing sets the phone-number hashing policy (issue #164;
+// cfg.PIINumberHashingEnabled) shared by the ingest-messages and
+// ingest-recording handlers. Default false (zero value): the raw number is
+// used instead of smsmap.ShortHash / a hashed label, and is additionally
+// written into the document Metadata under "number" so it is
+// searchable/visible. Pass true to restore the original #164 behaviour
+// byte-for-byte. Must be called before the first call to Handler() (though
+// the value is read per-request, not at wiring time, so ordering relative to
+// the other With* builders does not matter).
+func (s *Server) WithPIINumberHashing(enabled bool) *Server {
+	s.piiNumberHashingEnabled = enabled
+	return s
 }
 
 // Handler returns the root http.Handler for the application. It is safe to

--- a/internal/collector/sms.go
+++ b/internal/collector/sms.go
@@ -37,6 +37,14 @@ type SMSCollector struct {
 	indexedIDs   map[string]struct{} // nil = mtime-only mode
 	maxFileBytes int64               // per-file size cap; 0 or negative means no limit
 	cutover      time.Time           // zero = floor disabled (no behaviour change)
+
+	// numberHashingEnabled mirrors cfg.PIINumberHashingEnabled (issue #164
+	// policy reversal). Zero value (false) is the new default: MapSMS/MapCall
+	// write the raw number into Metadata["number"] and MapCall's
+	// anonymous-caller fallback uses the raw number instead of a hash. Set via
+	// WithNumberHashingEnabled. Does NOT affect SourceID hashing, which stays
+	// unconditional (see smsmap.MapSMS / smsmap.MapCall doc comments).
+	numberHashingEnabled bool
 }
 
 // NewSMSCollector returns an SMSCollector that reads XML exports from sourceDir.
@@ -65,6 +73,16 @@ func (c *SMSCollector) WithIndexedIDs(ids map[string]struct{}) {
 // Zero t disables the floor (no behaviour change).
 func (c *SMSCollector) WithCutover(t time.Time) {
 	c.cutover = t
+}
+
+// WithNumberHashingEnabled sets the phone-number hashing policy (issue #164;
+// cfg.PIINumberHashingEnabled). Default false (zero value) — MapSMS/MapCall
+// then write the raw number into Metadata and MapCall's anonymous-caller
+// fallback uses the raw number rather than a hash. Pass true to restore the
+// original #164 behaviour byte-for-byte.
+func (c *SMSCollector) WithNumberHashingEnabled(enabled bool) *SMSCollector {
+	c.numberHashingEnabled = enabled
+	return c
 }
 
 // smsStreamBatchSize is the maximum number of documents accumulated before
@@ -234,7 +252,7 @@ func (c *SMSCollector) streamSMSFile(ctx context.Context, path string, since tim
 			continue
 		}
 
-		doc := smsmap.MapSMS(rec.Address, rec.Body, rec.Date, rec.Type, rec.ContactName)
+		doc := smsmap.MapSMS(rec.Address, rec.Body, rec.Date, rec.Type, rec.ContactName, c.numberHashingEnabled)
 		batch = append(batch, doc)
 
 		if len(batch) >= smsStreamBatchSize {
@@ -316,7 +334,7 @@ func (c *SMSCollector) streamCallsFile(ctx context.Context, path string, since t
 			continue
 		}
 
-		doc := smsmap.MapCall(rec.Number, rec.Date, int(rec.Duration), rec.Type, rec.ContactName)
+		doc := smsmap.MapCall(rec.Number, rec.Date, int(rec.Duration), rec.Type, rec.ContactName, c.numberHashingEnabled)
 		batch = append(batch, doc)
 
 		if len(batch) >= smsStreamBatchSize {
@@ -525,7 +543,7 @@ func (c *SMSCollector) parseSMSFile(ctx context.Context, path string, since time
 			continue
 		}
 
-		doc := smsmap.MapSMS(rec.Address, rec.Body, rec.Date, rec.Type, rec.ContactName)
+		doc := smsmap.MapSMS(rec.Address, rec.Body, rec.Date, rec.Type, rec.ContactName, c.numberHashingEnabled)
 		docs = append(docs, doc)
 	}
 	return docs, nil
@@ -604,7 +622,7 @@ func (c *SMSCollector) parseCallsFile(ctx context.Context, path string, since ti
 			continue
 		}
 
-		doc := smsmap.MapCall(rec.Number, rec.Date, int(rec.Duration), rec.Type, rec.ContactName)
+		doc := smsmap.MapCall(rec.Number, rec.Date, int(rec.Duration), rec.Type, rec.ContactName, c.numberHashingEnabled)
 		docs = append(docs, doc)
 	}
 	return docs, nil

--- a/internal/collector/smsmap/smsmap.go
+++ b/internal/collector/smsmap/smsmap.go
@@ -12,8 +12,8 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
 )
 
 // authLikeRe matches SMS bodies that look like authentication / OTP messages.
@@ -31,13 +31,21 @@ var otpDigitsRe = regexp.MustCompile(`\b\d{4,8}\b`)
 //
 // SourceID format: sms:{dateMs}:{sha256(addr)[:16]}:{direction}
 // Phone numbers (addr) are hashed so raw PII is not stored in the SourceID.
+// This hashing is UNCONDITIONAL — independent of numberHashingEnabled — since
+// changing the SourceID scheme would orphan every already-ingested document
+// (see the numberHashingEnabled parameter doc below for why that's out of
+// scope for this flag).
 // direction (received/sent/draft/…) replaces the old bodyHash discriminator so
 // that the SourceID is stable across body edits — enabling ON CONFLICT UPDATE
 // (upsert) to overwrite content rather than inserting a duplicate document.
 // Two messages from the same address at the same millisecond with different
 // directions (e.g. a simultaneous inbound + outbound) are still uniquely
 // identified because the direction segment differs.
-// Auth-like bodies have their OTP digit runs replaced with [REDACTED].
+// Auth-like bodies have their OTP digit runs replaced with [REDACTED]. This
+// OTP redaction is a distinct mechanism from smsmap.RedactPII / issue #163's
+// PIIRedactionEnabled flag and is NOT gated by it — it targets short-lived
+// authentication codes rather than structured personal-identity PII, and
+// remains unconditional regardless of PII_REDACTION_ENABLED.
 // OccurredAt is time.UnixMilli(dateMs).UTC().
 //
 // Parameters mirror the SMS Backup & Restore XML <sms> element attributes and
@@ -48,7 +56,13 @@ var otpDigitsRe = regexp.MustCompile(`\b\d{4,8}\b`)
 //   - typ:         SMS Backup & Restore type code (1=received, 2=sent, 3=draft,
 //     4=outbox, 5=failed, 6=queued)
 //   - contactName: display name of the contact (may be empty; falls back to addr)
-func MapSMS(addr, body string, dateMs int64, typ int, contactName string) model.Document {
+//   - numberHashingEnabled: issue #164's phone-number hashing policy flag
+//     (cfg.PIINumberHashingEnabled). Does NOT affect the SourceID (see above).
+//     When false (the default), the raw address is additionally written into
+//     Metadata["number"] so it is searchable/visible — this is the point of
+//     disabling hashing; when true, Metadata carries no number field at all,
+//     matching the pre-existing (pre-this-change) behaviour byte-for-byte.
+func MapSMS(addr, body string, dateMs int64, typ int, contactName string, numberHashingEnabled bool) model.Document {
 	occurredAt := time.UnixMilli(dateMs).UTC()
 	addrHash := shortHash(addr)
 	direction := smsDirection(typ)
@@ -68,6 +82,9 @@ func MapSMS(addr, body string, dateMs int64, typ int, contactName string) model.
 		"direction":    direction,
 		"is_auth_like": isAuth,
 	}
+	if !numberHashingEnabled {
+		meta["number"] = addr
+	}
 
 	t := occurredAt
 	return model.Document{
@@ -86,6 +103,10 @@ func MapSMS(addr, body string, dateMs int64, typ int, contactName string) model.
 //
 // SourceID format: call-log:{dateMs}:{sha256(number)[:16]}:{sha256(durationStr)[:8]}
 // Phone numbers (number) are hashed so raw PII is not stored in the SourceID.
+// This hashing is UNCONDITIONAL — independent of numberHashingEnabled — since
+// changing the SourceID scheme would orphan every already-ingested document
+// (see the numberHashingEnabled parameter doc below for why that's out of
+// scope for this flag).
 // OccurredAt is time.UnixMilli(dateMs).UTC().
 //
 // Parameters mirror the SMS Backup & Restore XML <call> element attributes and
@@ -96,7 +117,18 @@ func MapSMS(addr, body string, dateMs int64, typ int, contactName string) model.
 //   - typ:         SMS Backup & Restore call type code (1=incoming, 2=outgoing,
 //     3=missed, 4=voicemail, 5=rejected, 6=blocked)
 //   - contactName: display name of the contact (may be empty; falls back to number)
-func MapCall(number string, dateMs int64, durationSec int, typ int, contactName string) model.Document {
+//   - numberHashingEnabled: issue #164's phone-number hashing policy flag
+//     (cfg.PIINumberHashingEnabled). Does NOT affect the SourceID (see above).
+//     Controls two things:
+//     1. The anonymous-caller (empty contactName) Title/Content fallback:
+//     true reproduces the original #164 behaviour byte-for-byte (a
+//     one-way hashed label, "상대 " + numHash[:8]); false falls back to
+//     the raw number instead.
+//     2. Metadata["number"]: present with the raw number when false (this is
+//     the point of disabling hashing — the number becomes searchable/
+//     visible); absent entirely when true, matching pre-existing metadata
+//     shape.
+func MapCall(number string, dateMs int64, durationSec int, typ int, contactName string, numberHashingEnabled bool) model.Document {
 	occurredAt := time.UnixMilli(dateMs).UTC()
 	numHash := shortHash(number)
 	durationStr := fmt.Sprintf("%d", durationSec)
@@ -104,16 +136,24 @@ func MapCall(number string, dateMs int64, durationSec int, typ int, contactName 
 	sourceID := fmt.Sprintf("call-log:%d:%s:%s", dateMs, numHash, durationHash)
 
 	direction := callDirection(typ)
-	// Security (issue #164 follow-up): when contactName is empty, never fall
-	// back to the raw phone number for Title/Content — unlike SourceID, these
-	// are plaintext user-facing fields. Fall back to a short, one-way hashed
-	// label built from numHash (already computed above for the SourceID),
-	// matching the same "상대 " + hash[:8] convention used by the
-	// ingest-recording handler (internal/api/ingest_recording.go) for the
-	// identical anonymous-caller case. SourceID and Metadata are untouched.
+	// Security (issue #164 follow-up), now conditional on numberHashingEnabled:
+	// when contactName is empty AND hashing is enabled, never fall back to the
+	// raw phone number for Title/Content — unlike SourceID, these are
+	// plaintext user-facing fields. Fall back to a short, one-way hashed label
+	// built from numHash (already computed above for the SourceID), matching
+	// the same "상대 " + hash[:8] convention used by the ingest-recording
+	// handler (internal/api/ingest_recording.go) for the identical
+	// anonymous-caller case. When hashing is disabled (default), fall back to
+	// the raw number instead — the whole point of the flag is that the owner
+	// of this personal knowledge base wants the number, not an opaque hash.
+	// SourceID is untouched either way.
 	contact := contactName
 	if contact == "" {
-		contact = "상대 " + numHash[:8]
+		if numberHashingEnabled {
+			contact = "상대 " + numHash[:8]
+		} else {
+			contact = number
+		}
 	}
 	title := fmt.Sprintf("%s 통화 %s", direction, contact)
 
@@ -125,6 +165,9 @@ func MapCall(number string, dateMs int64, durationSec int, typ int, contactName 
 		"contact_name":     contactName,
 		"direction":        direction,
 		"duration_seconds": durationSec,
+	}
+	if !numberHashingEnabled {
+		meta["number"] = number
 	}
 
 	t := occurredAt

--- a/internal/collector/smsmap/smsmap_test.go
+++ b/internal/collector/smsmap/smsmap_test.go
@@ -19,7 +19,7 @@ func TestMapSMS_SourceIDFormat(t *testing.T) {
 	body := "hello"
 	dateMs := int64(1705311000000)
 	// typ=1 → direction="received"
-	doc := smsmap.MapSMS(addr, body, dateMs, 1, "Alice")
+	doc := smsmap.MapSMS(addr, body, dateMs, 1, "Alice", true)
 
 	wantAddrHash := smsmap.ShortHash(addr)
 	// SourceID now uses direction (stable) instead of bodyHash.
@@ -36,7 +36,7 @@ func TestMapSMS_SourceIDFormat(t *testing.T) {
 
 func TestMapSMS_SourceType(t *testing.T) {
 	t.Parallel()
-	doc := smsmap.MapSMS("010-0000-0001", "test", time.Now().UnixMilli(), 1, "")
+	doc := smsmap.MapSMS("010-0000-0001", "test", time.Now().UnixMilli(), 1, "", true)
 	if doc.SourceType != model.SourceSMS {
 		t.Errorf("SourceType=%q, want %q", doc.SourceType, model.SourceSMS)
 	}
@@ -49,7 +49,7 @@ func TestMapSMS_OccurredAt(t *testing.T) {
 	dateMs := int64(1705311000000)
 	want := time.Unix(1705311000, 0).UTC()
 
-	doc := smsmap.MapSMS("010-0000-0001", "test", dateMs, 1, "")
+	doc := smsmap.MapSMS("010-0000-0001", "test", dateMs, 1, "", true)
 	if doc.OccurredAt == nil {
 		t.Fatal("OccurredAt is nil")
 	}
@@ -78,7 +78,7 @@ func TestMapSMS_DirectionMapping(t *testing.T) {
 		tc := tc
 		t.Run(tc.wantDir, func(t *testing.T) {
 			t.Parallel()
-			doc := smsmap.MapSMS("010-0000-0001", "body", time.Now().UnixMilli(), tc.typ, "")
+			doc := smsmap.MapSMS("010-0000-0001", "body", time.Now().UnixMilli(), tc.typ, "", true)
 			dir, _ := doc.Metadata["direction"].(string)
 			if dir != tc.wantDir {
 				t.Errorf("direction=%q, want %q", dir, tc.wantDir)
@@ -112,7 +112,7 @@ func TestMapSMS_AuthLikeRedaction(t *testing.T) {
 		tc := tc
 		t.Run(tc.body, func(t *testing.T) {
 			t.Parallel()
-			doc := smsmap.MapSMS("010-0000-0001", tc.body, time.Now().UnixMilli(), 1, "")
+			doc := smsmap.MapSMS("010-0000-0001", tc.body, time.Now().UnixMilli(), 1, "", true)
 			isAuth, _ := doc.Metadata["is_auth_like"].(bool)
 			if isAuth != tc.wantAuth {
 				t.Errorf("body=%q: is_auth_like=%v, want %v", tc.body, isAuth, tc.wantAuth)
@@ -133,13 +133,13 @@ func TestMapSMS_ContactNameFallback(t *testing.T) {
 
 	addr := "010-5555-1234"
 	// Empty contact name → title should contain the address.
-	doc := smsmap.MapSMS(addr, "hello", time.Now().UnixMilli(), 1, "")
+	doc := smsmap.MapSMS(addr, "hello", time.Now().UnixMilli(), 1, "", true)
 	if !strings.Contains(doc.Title, addr) {
 		t.Errorf("title=%q should contain address %q when contact name is empty", doc.Title, addr)
 	}
 
 	// Non-empty contact name → title should contain contact, not addr.
-	doc2 := smsmap.MapSMS(addr, "hello", time.Now().UnixMilli(), 1, "Alice")
+	doc2 := smsmap.MapSMS(addr, "hello", time.Now().UnixMilli(), 1, "Alice", true)
 	if !strings.Contains(doc2.Title, "Alice") {
 		t.Errorf("title=%q should contain contact name 'Alice'", doc2.Title)
 	}
@@ -148,7 +148,7 @@ func TestMapSMS_ContactNameFallback(t *testing.T) {
 func TestMapSMS_TitleFormat(t *testing.T) {
 	t.Parallel()
 
-	doc := smsmap.MapSMS("010-0000-0001", "test", time.Now().UnixMilli(), 1, "Bob")
+	doc := smsmap.MapSMS("010-0000-0001", "test", time.Now().UnixMilli(), 1, "Bob", true)
 	if doc.Title != "SMS received Bob" {
 		t.Errorf("Title=%q, want %q", doc.Title, "SMS received Bob")
 	}
@@ -157,11 +157,39 @@ func TestMapSMS_TitleFormat(t *testing.T) {
 func TestMapSMS_MetadataKeys(t *testing.T) {
 	t.Parallel()
 
-	doc := smsmap.MapSMS("010-0000-0001", "hello", time.Now().UnixMilli(), 2, "Carol")
+	doc := smsmap.MapSMS("010-0000-0001", "hello", time.Now().UnixMilli(), 2, "Carol", true)
 	for _, key := range []string{"contact_name", "direction", "is_auth_like"} {
 		if _, ok := doc.Metadata[key]; !ok {
 			t.Errorf("metadata missing key %q", key)
 		}
+	}
+}
+
+// TestMapSMS_MetadataNumber_HashingDisabled verifies that when
+// numberHashingEnabled=false (the default), the raw address is written into
+// Metadata["number"] so it is searchable/visible — the point of disabling
+// phone-number hashing (issue #164 reversal).
+func TestMapSMS_MetadataNumber_HashingDisabled(t *testing.T) {
+	t.Parallel()
+
+	addr := "010-1111-2222"
+	doc := smsmap.MapSMS(addr, "hello", time.Now().UnixMilli(), 1, "", false)
+
+	gotNumber, _ := doc.Metadata["number"].(string)
+	if gotNumber != addr {
+		t.Errorf("metadata[number]=%q, want %q", gotNumber, addr)
+	}
+}
+
+// TestMapSMS_MetadataNumber_HashingEnabled verifies that Metadata carries no
+// "number" key at all when numberHashingEnabled=true, matching the
+// pre-#164-reversal metadata shape byte-for-byte.
+func TestMapSMS_MetadataNumber_HashingEnabled(t *testing.T) {
+	t.Parallel()
+
+	doc := smsmap.MapSMS("010-1111-2222", "hello", time.Now().UnixMilli(), 1, "", true)
+	if _, ok := doc.Metadata["number"]; ok {
+		t.Errorf("metadata should not contain \"number\" when numberHashingEnabled=true, got %v", doc.Metadata["number"])
 	}
 }
 
@@ -172,8 +200,8 @@ func TestMapSMS_Deterministic(t *testing.T) {
 	body := "test message"
 	dateMs := int64(1705311000000)
 
-	doc1 := smsmap.MapSMS(addr, body, dateMs, 1, "Test")
-	doc2 := smsmap.MapSMS(addr, body, dateMs, 1, "Test")
+	doc1 := smsmap.MapSMS(addr, body, dateMs, 1, "Test", true)
+	doc2 := smsmap.MapSMS(addr, body, dateMs, 1, "Test", true)
 
 	if doc1.SourceID != doc2.SourceID {
 		t.Errorf("MapSMS is not deterministic: %q != %q", doc1.SourceID, doc2.SourceID)
@@ -189,7 +217,7 @@ func TestMapCall_SourceIDFormat(t *testing.T) {
 	durationSec := 90
 	dateMs := int64(1705311000000)
 
-	doc := smsmap.MapCall(number, dateMs, durationSec, 2, "Eve")
+	doc := smsmap.MapCall(number, dateMs, durationSec, 2, "Eve", true)
 
 	wantNumHash := smsmap.ShortHash(number)
 	wantDurHash := smsmap.BodyShortHash(fmt.Sprintf("%d", durationSec))
@@ -206,7 +234,7 @@ func TestMapCall_SourceIDFormat(t *testing.T) {
 
 func TestMapCall_SourceType(t *testing.T) {
 	t.Parallel()
-	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 30, 1, "")
+	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 30, 1, "", true)
 	if doc.SourceType != model.SourceCallLog {
 		t.Errorf("SourceType=%q, want %q", doc.SourceType, model.SourceCallLog)
 	}
@@ -218,7 +246,7 @@ func TestMapCall_OccurredAt(t *testing.T) {
 	dateMs := int64(1705311000000)
 	want := time.Unix(1705311000, 0).UTC()
 
-	doc := smsmap.MapCall("010-0000-0001", dateMs, 60, 1, "")
+	doc := smsmap.MapCall("010-0000-0001", dateMs, 60, 1, "", true)
 	if doc.OccurredAt == nil {
 		t.Fatal("OccurredAt is nil")
 	}
@@ -247,7 +275,7 @@ func TestMapCall_DirectionMapping(t *testing.T) {
 		tc := tc
 		t.Run(tc.wantDir, func(t *testing.T) {
 			t.Parallel()
-			doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 30, tc.typ, "")
+			doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 30, tc.typ, "", true)
 			dir, _ := doc.Metadata["direction"].(string)
 			if dir != tc.wantDir {
 				t.Errorf("direction=%q, want %q", dir, tc.wantDir)
@@ -259,7 +287,7 @@ func TestMapCall_DirectionMapping(t *testing.T) {
 func TestMapCall_TitleFormat(t *testing.T) {
 	t.Parallel()
 
-	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 60, 1, "Dave")
+	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 60, 1, "Dave", true)
 	if doc.Title != "incoming 통화 Dave" {
 		t.Errorf("Title=%q, want %q", doc.Title, "incoming 통화 Dave")
 	}
@@ -274,7 +302,7 @@ func TestMapCall_TitleFallbackNeverContainsRawNumber(t *testing.T) {
 	t.Parallel()
 
 	number := "010-9999-8888"
-	doc := smsmap.MapCall(number, time.Now().UnixMilli(), 30, 2, "")
+	doc := smsmap.MapCall(number, time.Now().UnixMilli(), 30, 2, "", true)
 
 	if strings.Contains(doc.Title, number) {
 		t.Errorf("Title=%q must not contain the raw phone number %q", doc.Title, number)
@@ -304,7 +332,7 @@ func TestMapCall_TitleFallbackNeverContainsRawNumber(t *testing.T) {
 func TestMapCall_TitleShowsContactNameWhenPresent(t *testing.T) {
 	t.Parallel()
 
-	doc := smsmap.MapCall("010-9999-8888", time.Now().UnixMilli(), 30, 2, "Heidi")
+	doc := smsmap.MapCall("010-9999-8888", time.Now().UnixMilli(), 30, 2, "Heidi", true)
 	if doc.Title != "outgoing 통화 Heidi" {
 		t.Errorf("Title=%q, want %q", doc.Title, "outgoing 통화 Heidi")
 	}
@@ -313,10 +341,56 @@ func TestMapCall_TitleShowsContactNameWhenPresent(t *testing.T) {
 	}
 }
 
+// TestMapCall_TitleFallsBackToRawNumberWhenHashingDisabled is the mirror of
+// TestMapCall_TitleFallbackNeverContainsRawNumber for the numberHashingEnabled=false
+// (default) case: when contact_name is empty, Title/Content fall back to the
+// raw number instead of a hashed label, and Metadata carries the raw number
+// under "number" so it is searchable. SourceID stays hashed regardless (see
+// MapCall doc comment).
+func TestMapCall_TitleFallsBackToRawNumberWhenHashingDisabled(t *testing.T) {
+	t.Parallel()
+
+	number := "010-9999-8888"
+	doc := smsmap.MapCall(number, time.Now().UnixMilli(), 30, 2, "", false)
+
+	if !strings.Contains(doc.Title, number) {
+		t.Errorf("Title=%q should contain the raw phone number %q when hashing is disabled", doc.Title, number)
+	}
+	if !strings.Contains(doc.Content, number) {
+		t.Errorf("Content=%q should contain the raw phone number %q when hashing is disabled", doc.Content, number)
+	}
+
+	gotNumber, _ := doc.Metadata["number"].(string)
+	if gotNumber != number {
+		t.Errorf("metadata[number]=%q, want %q", gotNumber, number)
+	}
+
+	// SourceID must still be hashed — this flag never touches dedup identity.
+	wantNumHash := smsmap.ShortHash(number)
+	if !strings.Contains(doc.SourceID, wantNumHash) {
+		t.Errorf("SourceID=%q should still contain the hashed number %q regardless of the flag", doc.SourceID, wantNumHash)
+	}
+	if strings.Contains(doc.SourceID, number) {
+		t.Errorf("SourceID=%q must never contain the raw phone number %q", doc.SourceID, number)
+	}
+}
+
+// TestMapCall_MetadataNumberAbsentWhenHashingEnabled verifies that Metadata
+// carries no "number" key at all when numberHashingEnabled=true, matching the
+// pre-#164-reversal metadata shape byte-for-byte.
+func TestMapCall_MetadataNumberAbsentWhenHashingEnabled(t *testing.T) {
+	t.Parallel()
+
+	doc := smsmap.MapCall("010-9999-8888", time.Now().UnixMilli(), 30, 2, "Heidi", true)
+	if _, ok := doc.Metadata["number"]; ok {
+		t.Errorf("metadata should not contain \"number\" when numberHashingEnabled=true, got %v", doc.Metadata["number"])
+	}
+}
+
 func TestMapCall_ContentFormat(t *testing.T) {
 	t.Parallel()
 
-	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 120, 2, "Frank")
+	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 120, 2, "Frank", true)
 	for _, want := range []string{"Frank", "outgoing", "120s"} {
 		if !strings.Contains(doc.Content, want) {
 			t.Errorf("content=%q should contain %q", doc.Content, want)
@@ -327,7 +401,7 @@ func TestMapCall_ContentFormat(t *testing.T) {
 func TestMapCall_MetadataKeys(t *testing.T) {
 	t.Parallel()
 
-	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 45, 1, "Grace")
+	doc := smsmap.MapCall("010-0000-0001", time.Now().UnixMilli(), 45, 1, "Grace", true)
 	for _, key := range []string{"contact_name", "direction", "duration_seconds"} {
 		if _, ok := doc.Metadata[key]; !ok {
 			t.Errorf("metadata missing key %q", key)
@@ -346,8 +420,8 @@ func TestMapCall_Deterministic(t *testing.T) {
 	dateMs := int64(1705311000000)
 	durationSec := 90
 
-	doc1 := smsmap.MapCall(number, dateMs, durationSec, 1, "Test")
-	doc2 := smsmap.MapCall(number, dateMs, durationSec, 1, "Test")
+	doc1 := smsmap.MapCall(number, dateMs, durationSec, 1, "Test", true)
+	doc2 := smsmap.MapCall(number, dateMs, durationSec, 1, "Test", true)
 
 	if doc1.SourceID != doc2.SourceID {
 		t.Errorf("MapCall is not deterministic: %q != %q", doc1.SourceID, doc2.SourceID)
@@ -401,7 +475,7 @@ func TestMapSMS_ParityWithSMSCollector(t *testing.T) {
 	wantAddrHash := smsmap.ShortHash(addr)
 	wantSourceID := fmt.Sprintf("sms:%d:%s:received", dateMs, wantAddrHash)
 
-	doc := smsmap.MapSMS(addr, body, dateMs, 1, "Alice")
+	doc := smsmap.MapSMS(addr, body, dateMs, 1, "Alice", true)
 	if doc.SourceID != wantSourceID {
 		t.Errorf("SourceID=%q, want %q", doc.SourceID, wantSourceID)
 	}
@@ -421,7 +495,7 @@ func TestMapCall_ParityWithSMSCollector(t *testing.T) {
 	wantDurHash := smsmap.BodyShortHash(fmt.Sprintf("%d", duration))
 	wantSourceID := fmt.Sprintf("call-log:%d:%s:%s", dateMs, wantNumHash, wantDurHash)
 
-	doc := smsmap.MapCall(number, dateMs, duration, 2, "Bob")
+	doc := smsmap.MapCall(number, dateMs, duration, 2, "Bob", true)
 	if doc.SourceID != wantSourceID {
 		t.Errorf("SourceID=%q, want %q", doc.SourceID, wantSourceID)
 	}

--- a/internal/collector/whisper.go
+++ b/internal/collector/whisper.go
@@ -1320,36 +1320,50 @@ func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTransc
 		}
 	}
 
-	// PII redaction (issue #163): whisper call transcripts carry raw spoken
-	// content and previously had NO redaction at all (unlike SMS, see
-	// smsmap.MapSMS). Redaction is applied unconditionally to ALL whisper
-	// transcript content — not just TPhone call recordings — because voice
-	// memos can equally contain a spoken phone number or account number, and
-	// distinguishing "call" vs "memo" here to redact only one would leave an
-	// unprincipled gap for no real benefit. Applied to Content only:
-	// SourceID (dedup/upsert identity) and Metadata are left untouched so
-	// dedup behaviour is unaffected by redaction.
-	content = smsmap.RedactPII(content)
+	// PII redaction (issue #163), now gated by cfg.PIIRedactionEnabled (default
+	// false — see that flag's doc comment in internal/config/config.go for the
+	// owner's rationale: this is a single-user personal knowledge base, and a
+	// transcript reading "[REDACTED]" instead of the actual phone number is
+	// strictly less useful to the person who owns that data). When enabled,
+	// this reproduces the original #163 behaviour byte-for-byte: redaction is
+	// applied unconditionally to ALL whisper transcript content — not just
+	// TPhone call recordings — because voice memos can equally contain a
+	// spoken phone number or account number, and distinguishing "call" vs
+	// "memo" here to redact only one would leave an unprincipled gap for no
+	// real benefit. Applied to Content only: SourceID (dedup/upsert identity)
+	// and Metadata are left untouched either way so dedup behaviour is
+	// unaffected by this flag.
+	// title defaults to the raw filename stem, unmodified — "stored exactly as
+	// produced" when redaction is disabled. The underscore→space swap below
+	// exists ONLY to make RedactPII's \b-boundary patterns match (see the
+	// comment inside the branch); it is not an independent formatting feature,
+	// so it stays inside the PIIRedactionEnabled branch rather than applying
+	// unconditionally.
+	title := item.title
+	if c.cfg.PIIRedactionEnabled {
+		content = smsmap.RedactPII(content)
 
-	// Title redaction (issue #163 follow-up): item.title is the audio filename
-	// stem, and historical filenames (e.g. TPhoneCallRecords'
-	// "<number>_<timestamp>.ext") embed a raw phone number just as directly as
-	// spoken content does — so Title carries the same PII risk as Content and
-	// must go through the same RedactPII pass.
-	//
-	// RedactPII's structured-PII patterns (koreanPhoneRe, rrnRe) require a
-	// non-word character immediately after the digit run to satisfy their
-	// trailing \b boundary; in a filename stem the digit run instead directly
-	// abuts the timestamp segment's leading "_" (both are word characters),
-	// which defeats \b and would silently leave the number unredacted. Since
-	// underscores in a filename-derived title are purely a display separator
-	// (no semantic meaning worth preserving over the security property),
-	// swapping them for spaces before redaction lets the boundary-sensitive
-	// patterns match without touching the shared smsmap regexes used by other
-	// callers (SMS bodies, spoken transcript content) that don't have this
-	// adjacency problem. This only changes the Title *value* stored on the
-	// document — it does not touch the on-disk filename or SourceID.
-	title := smsmap.RedactPII(strings.ReplaceAll(item.title, "_", " "))
+		// Title redaction (issue #163 follow-up): item.title is the audio
+		// filename stem, and historical filenames (e.g. TPhoneCallRecords'
+		// "<number>_<timestamp>.ext") embed a raw phone number just as
+		// directly as spoken content does — so Title carries the same PII
+		// risk as Content and must go through the same RedactPII pass.
+		//
+		// RedactPII's structured-PII patterns (koreanPhoneRe, rrnRe) require a
+		// non-word character immediately after the digit run to satisfy their
+		// trailing \b boundary; in a filename stem the digit run instead
+		// directly abuts the timestamp segment's leading "_" (both are word
+		// characters), which defeats \b and would silently leave the number
+		// unredacted. Since underscores in a filename-derived title are purely
+		// a display separator (no semantic meaning worth preserving over the
+		// security property), swapping them for spaces before redaction lets
+		// the boundary-sensitive patterns match without touching the shared
+		// smsmap regexes used by other callers (SMS bodies, spoken transcript
+		// content) that don't have this adjacency problem. This only changes
+		// the Title *value* stored on the document — it does not touch the
+		// on-disk filename or SourceID.
+		title = smsmap.RedactPII(strings.ReplaceAll(item.title, "_", " "))
+	}
 
 	return model.Document{
 		ID:          uuid.New(),
@@ -1368,9 +1382,19 @@ func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTransc
 //
 // When the sidecar exists and is valid JSON, the function returns a map
 // containing the recording metadata fields present in the file
-// (contact_name, direction, recording_type, duration_seconds) and true.
-// Only non-empty/non-zero values are included so callers do not overwrite
-// existing metadata with zero-value defaults.
+// (contact_name, direction, recording_type, duration_seconds, and — issue
+// #164 policy reversal, additive — number) and true. Only non-empty/non-zero
+// values are included so callers do not overwrite existing metadata with
+// zero-value defaults.
+//
+// number (issue #164 additive improvement): the sidecar's "number" key is
+// only present when the ingest-recording handler wrote it with
+// PIINumberHashingEnabled=false (see recordingSidecar's doc comment in
+// internal/api/ingest_recording.go). When present, it is surfaced here as
+// Metadata["number"] on the call-transcript document, making the phone number
+// searchable/visible — the point of disabling hashing. The sidecar's
+// "number_hash" key is deliberately NOT parsed into metadata: a hash provides
+// no searchability benefit, so surfacing it would add noise without value.
 //
 // When the sidecar is absent, unreadable, or unparseable, the function returns
 // (nil, false) so the caller can proceed with existing metadata unchanged. This
@@ -1385,6 +1409,7 @@ func readRecordingSidecar(audioPath string) (map[string]any, bool) {
 
 	var raw struct {
 		ContactName     string `json:"contact_name"`
+		Number          string `json:"number"`
 		Direction       string `json:"direction"`
 		RecordingType   string `json:"recording_type"`
 		DurationSeconds int    `json:"duration_seconds"`
@@ -1394,9 +1419,12 @@ func readRecordingSidecar(audioPath string) (map[string]any, bool) {
 		return nil, false
 	}
 
-	result := make(map[string]any, 4)
+	result := make(map[string]any, 5)
 	if raw.ContactName != "" {
 		result["contact_name"] = raw.ContactName
+	}
+	if raw.Number != "" {
+		result["number"] = raw.Number
 	}
 	if raw.Direction != "" {
 		result["direction"] = raw.Direction

--- a/internal/collector/whisper_native_diarization_test.go
+++ b/internal/collector/whisper_native_diarization_test.go
@@ -778,6 +778,10 @@ func TestWhisperCollector_NativeDiarization_RedactsPII(t *testing.T) {
 		WhisperModel:            "gpt-4o-transcribe-diarize",
 		WhisperLanguage:         "ko",
 		WhisperChunkingStrategy: "auto",
+		// Redaction is OFF by default (issue #163/#165/#167 policy reversal) —
+		// this test specifically pins the redaction-ON behaviour, so set the
+		// flag explicitly rather than relying on the (now different) default.
+		PIIRedactionEnabled: true,
 	}
 	c := makeWhisperCollector(cfg, srv)
 

--- a/internal/collector/whisper_pii_test.go
+++ b/internal/collector/whisper_pii_test.go
@@ -29,6 +29,10 @@ func TestWhisperCollector_Collect_RedactsPhoneNumberInContent(t *testing.T) {
 		WhisperAPIURL:   srv.URL,
 		WhisperModel:    "whisper-1",
 		WhisperLanguage: "ko",
+		// Redaction is OFF by default (issue #163/#165/#167 policy reversal) —
+		// this test specifically exercises the redaction-ON behaviour, so set
+		// the flag explicitly rather than relying on the (now different) default.
+		PIIRedactionEnabled: true,
 	}
 	c := makeWhisperCollector(cfg, srv)
 
@@ -78,6 +82,10 @@ func TestWhisperCollector_Collect_RedactsPhoneNumberInTitle(t *testing.T) {
 		WhisperAPIURL:   srv.URL,
 		WhisperModel:    "whisper-1",
 		WhisperLanguage: "ko",
+		// Redaction is OFF by default (issue #163/#165/#167 policy reversal) —
+		// this test specifically exercises the redaction-ON behaviour, so set
+		// the flag explicitly rather than relying on the (now different) default.
+		PIIRedactionEnabled: true,
 	}
 	c := makeWhisperCollector(cfg, srv)
 
@@ -124,6 +132,9 @@ func TestWhisperCollector_Collect_NoFalsePositiveRedaction(t *testing.T) {
 		WhisperAPIURL:   srv.URL,
 		WhisperModel:    "whisper-1",
 		WhisperLanguage: "ko",
+		// Redaction ON: this test guards against over-redaction, which is only
+		// a meaningful assertion when the redaction pass actually runs.
+		PIIRedactionEnabled: true,
 	}
 	c := makeWhisperCollector(cfg, srv)
 
@@ -137,5 +148,53 @@ func TestWhisperCollector_Collect_NoFalsePositiveRedaction(t *testing.T) {
 
 	if docs[0].Content != rawTranscript {
 		t.Errorf("Content = %q, want unchanged %q (no PII present)", docs[0].Content, rawTranscript)
+	}
+}
+
+// TestWhisperCollector_Collect_NoRedactionByDefault verifies the new default
+// (issue #163/#165/#167 policy reversal): with PIIRedactionEnabled left unset
+// (false), Content and Title are stored exactly as produced — the phone
+// number in both the transcript and the filename-derived title survives
+// verbatim, and no PIIRedactionToken marker appears anywhere.
+func TestWhisperCollector_Collect_NoRedactionByDefault(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	const rawTranscript = "안녕하세요 제 번호는 010-1234-5678 입니다 제 주민번호는 901231-1234567 입니다"
+
+	srv, _ := newWhisperTestServer(t, rawTranscript)
+
+	mtime := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	const filename = "010-1234-5678_20260327202518.m4a"
+	writeDummyAudio(t, dir, filename, mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "whisper-1",
+		WhisperLanguage: "ko",
+		// PIIRedactionEnabled intentionally left unset (false) — the default.
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+
+	if docs[0].Content != rawTranscript {
+		t.Errorf("Content = %q, want unchanged (verbatim) %q", docs[0].Content, rawTranscript)
+	}
+	if strings.Contains(docs[0].Content, smsmap.PIIRedactionToken) {
+		t.Errorf("Content = %q must not contain %q when redaction is disabled", docs[0].Content, smsmap.PIIRedactionToken)
+	}
+	if !strings.Contains(docs[0].Title, "010-1234-5678") {
+		t.Errorf("Title = %q should contain the raw phone number when redaction is disabled", docs[0].Title)
+	}
+	if strings.Contains(docs[0].Title, smsmap.PIIRedactionToken) {
+		t.Errorf("Title = %q must not contain %q when redaction is disabled", docs[0].Title, smsmap.PIIRedactionToken)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,6 +260,46 @@ type Config struct {
 	// local LLM to avoid a flood of LLM calls for the pre-existing backlog.
 	SummarizerBackfillEnabled bool // SUMMARIZER_BACKFILL_ENABLED
 
+	// SummarizerBatchSize is the number of documents fetched and processed by
+	// SummarizerWorker per tick.
+	// SUMMARIZER_BATCH_SIZE: default 50. The previous default of 10 was sized
+	// for a local LLM sharing an 8s whole-tick budget; a remote chat-completion
+	// API is latency- not CPU-bound, so a larger batch keeps the bounded
+	// worker pool (SummarizerConcurrency) saturated for the whole tick
+	// interval instead of idling after 10 documents. Invalid values use the default.
+	SummarizerBatchSize int // SUMMARIZER_BATCH_SIZE
+
+	// SummarizerInterval controls how often SummarizerWorker polls for
+	// unsummarized documents.
+	// SUMMARIZER_INTERVAL: Go duration string, default "30s". The previous 5m
+	// default assumed a slow local LLM where polling more often was pointless;
+	// a remote API can clear a full batch in well under 30s, so a short
+	// interval keeps backlog throughput high without busy-looping
+	// (ListUnsummarized is a cheap indexed SELECT once caught up).
+	// Invalid values use the default.
+	SummarizerInterval time.Duration // SUMMARIZER_INTERVAL
+
+	// SummarizerDocTimeout bounds a single document's summarization work
+	// (LLM call + optional embed + UpdateSummary write).
+	// SUMMARIZER_DOC_TIMEOUT: Go duration string, default "30s". Replaces the
+	// old whole-tick ceiling (formerly 8s, tuned for gemma3:4b on local CPU),
+	// which silently truncated a multi-document batch once the LLM backend
+	// became a remote API. Each document is independently idempotent
+	// (UpdateSummary's WHERE title_summary IS NULL guard), so a timed-out
+	// document simply stays unsummarized and is retried on a later tick.
+	// NOTE: cmd/collector's shutdown drain window is derived from this value —
+	// raising it also raises the drain timeout. Invalid values use the default.
+	SummarizerDocTimeout time.Duration // SUMMARIZER_DOC_TIMEOUT
+
+	// SummarizerConcurrency is the number of documents SummarizerWorker
+	// processes in parallel within a single tick, via a bounded worker pool.
+	// SUMMARIZER_CONCURRENCY: default 5. A remote LLM call is latency-bound,
+	// not CPU-bound, so running several requests concurrently is the primary
+	// throughput lever against a remote backend; kept conservative to avoid
+	// tripping a remote provider's rate limit. Clamped to >= 1. Invalid
+	// values use the default.
+	SummarizerConcurrency int // SUMMARIZER_CONCURRENCY
+
 	// Freshness monitoring (issue #159)
 	//
 	// SMSFreshnessMaxAge is the maximum time since the most recent active SMS
@@ -306,6 +346,61 @@ type Config struct {
 	// collector_state watermark table. Defaults to os.Hostname() (or
 	// "default" when that fails) when COLLECTOR_INSTANCE is unset.
 	CollectorInstance string
+
+	// PII redaction (issues #163/#165/#167) and phone-number hashing (issue
+	// #164) are OFF by default. This is a deliberate policy reversal, not an
+	// oversight: second-brain is a single-user personal knowledge base, not a
+	// shared or third-party-facing system, and the owner has explicitly asked
+	// for both mechanisms disabled — a call transcript reading "[REDACTED]"
+	// instead of the actual phone number, or a document searchable only by an
+	// opaque hash, is strictly less useful to the person who OWNS that data
+	// than the raw text/number would be. The redaction/hashing machinery
+	// itself is NOT removed: both flags reactivate the exact prior behaviour
+	// (byte-for-byte, per their respective call sites) when set to "true", so
+	// this remains available for a future multi-tenant deployment or a
+	// compliance requirement without a code revert.
+	//
+	// Forward-only, by necessity: flipping either flag changes behaviour only
+	// for documents ingested AFTER the change. Content stored while
+	// PIIRedactionEnabled=false was never redacted — the raw text is exactly
+	// what is in the database, and there is nothing to "restore" if the flag
+	// is later turned on. Numbers hashed while PIINumberHashingEnabled=true
+	// went through smsmap.ShortHash (SHA-256-derived, one-way) before being
+	// written to the sidecar/filename/title — that hash cannot be reversed
+	// back to the original number, by this codebase or any other, so turning
+	// PIINumberHashingEnabled off later does not and cannot recover numbers
+	// hashed under the old default. There is no migration in either
+	// direction; do not go looking for the old plaintext/original values —
+	// they are simply gone for anything ingested before the flag changed.
+	//
+	// PII_REDACTION_ENABLED: set "true" to redact structured PII (Korean
+	// resident-registration numbers, phone numbers, bank-account-shaped digit
+	// runs — see smsmap.RedactPII) from whisper call-transcript Content and
+	// Title (internal/collector/whisper.go buildDocument). Default false.
+	PIIRedactionEnabled bool // PII_REDACTION_ENABLED — default false
+
+	// PII_NUMBER_HASHING_ENABLED: set "true" to hash the counterpart phone
+	// number (via smsmap.ShortHash) before it is written to:
+	//   1. the ingest-recording sidecar (.meta.json "number_hash" field)
+	//   2. the uploaded call-recording audio filename ({hash}_{timestamp}.ext)
+	//   3. the anonymous-caller Title/Content fallback label ("상대 {hash8}"),
+	//      both in smsmap.MapCall and the ingest-recording handler
+	//   4. ingest-recording error/warn logs, which are restricted to the
+	//      audio file's basename rather than its full (number-bearing) path
+	// Default false: all four write the raw number instead, and (additive,
+	// not part of the original #164 behaviour) the raw number is also written
+	// into the document's Metadata under the "number" key so it is
+	// searchable/visible — hashing it away was making it unrecoverable for no
+	// benefit to a single-user deployment.
+	//
+	// Document SourceIDs (dedup/upsert identity, e.g.
+	// "call-log:{dateMs}:{numHash}:{durHash}" or "sms:{dateMs}:{addrHash}:{direction}")
+	// are NOT affected by this flag in either state — they are always hashed,
+	// independent of PII_NUMBER_HASHING_ENABLED. Changing an established
+	// SourceID scheme would silently orphan every already-ingested document
+	// under a new identity (the exact failure mode #144 was blocked on), so
+	// SourceID hashing is out of scope for this flag entirely.
+	PIINumberHashingEnabled bool // PII_NUMBER_HASHING_ENABLED — default false
 
 	// CollectorCutover is an optional floor time for IndexAware collectors
 	// (SMS, Whisper). When non-zero, the collector will not emit any record
@@ -523,6 +618,10 @@ func Load() (*Config, error) {
 		IngestMaxBatchMessages: ingestMaxBatchMessages(),
 
 		SummarizerBackfillEnabled: summarizerBackfill,
+		SummarizerBatchSize:       summarizerBatchSize(),
+		SummarizerInterval:        summarizerInterval(),
+		SummarizerDocTimeout:      summarizerDocTimeout(),
+		SummarizerConcurrency:     summarizerConcurrency(),
 
 		SMSFreshnessMaxAge:     smsFreshnessMaxAge(),
 		FreshnessCheckInterval: freshnessCheckInterval(),
@@ -536,6 +635,11 @@ func Load() (*Config, error) {
 		// #147 escape hatch: bypasses deletion-ratio guard when set.
 		// See Scheduler.WithDeletionRatioOverride for trade-offs.
 		DeletionRatioOverride: os.Getenv("DELETION_RATIO_OVERRIDE") == "true",
+
+		// #163/#164/#165/#167 policy reversal: both default false. See the
+		// PIIRedactionEnabled / PIINumberHashingEnabled doc comments above.
+		PIIRedactionEnabled:     os.Getenv("PII_REDACTION_ENABLED") == "true",
+		PIINumberHashingEnabled: os.Getenv("PII_NUMBER_HASHING_ENABLED") == "true",
 	}, nil
 }
 
@@ -655,6 +759,87 @@ func whisperConcurrency() int {
 	n, err := strconv.Atoi(v)
 	if err != nil || n < 1 {
 		slog.Warn("config: WHISPER_CONCURRENCY is invalid; using default 1",
+			"value", v,
+			"error", err,
+		)
+		return defaultConcurrency
+	}
+	return n
+}
+
+// summarizerBatchSize parses SUMMARIZER_BATCH_SIZE from the environment.
+// Default is 50 (see SummarizerBatchSize doc comment for rationale).
+// Invalid values are ignored and the default is used.
+func summarizerBatchSize() int {
+	const defaultBatch = 50
+	v := os.Getenv("SUMMARIZER_BATCH_SIZE")
+	if v == "" {
+		return defaultBatch
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		slog.Warn("config: SUMMARIZER_BATCH_SIZE is invalid; using default 50",
+			"value", v,
+			"error", err,
+		)
+		return defaultBatch
+	}
+	return n
+}
+
+// summarizerInterval parses SUMMARIZER_INTERVAL from the environment.
+// Default is 30s (see SummarizerInterval doc comment for rationale).
+// Invalid values are ignored and the default is used.
+func summarizerInterval() time.Duration {
+	const defaultInterval = 30 * time.Second
+	v := os.Getenv("SUMMARIZER_INTERVAL")
+	if v == "" {
+		return defaultInterval
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		slog.Warn("config: SUMMARIZER_INTERVAL is invalid; using default 30s",
+			"value", v,
+			"error", err,
+		)
+		return defaultInterval
+	}
+	return d
+}
+
+// summarizerDocTimeout parses SUMMARIZER_DOC_TIMEOUT from the environment.
+// Default is 30s (see SummarizerDocTimeout doc comment for rationale).
+// Invalid values are ignored and the default is used.
+func summarizerDocTimeout() time.Duration {
+	const defaultTimeout = 30 * time.Second
+	v := os.Getenv("SUMMARIZER_DOC_TIMEOUT")
+	if v == "" {
+		return defaultTimeout
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		slog.Warn("config: SUMMARIZER_DOC_TIMEOUT is invalid; using default 30s",
+			"value", v,
+			"error", err,
+		)
+		return defaultTimeout
+	}
+	return d
+}
+
+// summarizerConcurrency parses SUMMARIZER_CONCURRENCY from the environment.
+// Default is 5 (see SummarizerConcurrency doc comment for rationale).
+// The value is clamped to >= 1: zero, negative, or invalid values fall back
+// to the default so the worker pool always has at least one slot.
+func summarizerConcurrency() int {
+	const defaultConcurrency = 5
+	v := os.Getenv("SUMMARIZER_CONCURRENCY")
+	if v == "" {
+		return defaultConcurrency
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		slog.Warn("config: SUMMARIZER_CONCURRENCY is invalid; using default 5",
 			"value", v,
 			"error", err,
 		)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,154 @@ func TestLoad_SummarizerBackfillEnabled(t *testing.T) {
 	}
 }
 
+// TestLoad_SummarizerBatchSize verifies SUMMARIZER_BATCH_SIZE parsing.
+func TestLoad_SummarizerBatchSize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   int
+	}{
+		{name: "default_when_unset", unset: true, want: 50},
+		{name: "explicit_100", envVal: "100", want: 100},
+		{name: "invalid_string_uses_default", envVal: "notanumber", want: 50},
+		{name: "zero_uses_default", envVal: "0", want: 50},
+		{name: "negative_uses_default", envVal: "-1", want: 50},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "SUMMARIZER_BATCH_SIZE")
+			} else {
+				setenv(t, "SUMMARIZER_BATCH_SIZE", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.SummarizerBatchSize != tc.want {
+				t.Errorf("SummarizerBatchSize = %d, want %d", cfg.SummarizerBatchSize, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_SummarizerInterval verifies SUMMARIZER_INTERVAL parsing.
+func TestLoad_SummarizerInterval(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   time.Duration
+	}{
+		{name: "default_when_unset", unset: true, want: 30 * time.Second},
+		{name: "explicit_1m", envVal: "1m", want: time.Minute},
+		{name: "invalid_string_uses_default", envVal: "notaduration", want: 30 * time.Second},
+		{name: "zero_uses_default", envVal: "0s", want: 30 * time.Second},
+		{name: "negative_uses_default", envVal: "-5s", want: 30 * time.Second},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "SUMMARIZER_INTERVAL")
+			} else {
+				setenv(t, "SUMMARIZER_INTERVAL", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.SummarizerInterval != tc.want {
+				t.Errorf("SummarizerInterval = %v, want %v", cfg.SummarizerInterval, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_SummarizerDocTimeout verifies SUMMARIZER_DOC_TIMEOUT parsing.
+func TestLoad_SummarizerDocTimeout(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   time.Duration
+	}{
+		{name: "default_when_unset", unset: true, want: 30 * time.Second},
+		{name: "explicit_45s", envVal: "45s", want: 45 * time.Second},
+		{name: "invalid_string_uses_default", envVal: "notaduration", want: 30 * time.Second},
+		{name: "zero_uses_default", envVal: "0s", want: 30 * time.Second},
+		{name: "negative_uses_default", envVal: "-5s", want: 30 * time.Second},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "SUMMARIZER_DOC_TIMEOUT")
+			} else {
+				setenv(t, "SUMMARIZER_DOC_TIMEOUT", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.SummarizerDocTimeout != tc.want {
+				t.Errorf("SummarizerDocTimeout = %v, want %v", cfg.SummarizerDocTimeout, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_SummarizerConcurrency verifies SUMMARIZER_CONCURRENCY parsing.
+func TestLoad_SummarizerConcurrency(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   int
+	}{
+		{name: "default_when_unset", unset: true, want: 5},
+		{name: "explicit_10", envVal: "10", want: 10},
+		{name: "invalid_string_uses_default", envVal: "notanumber", want: 5},
+		{name: "zero_uses_default", envVal: "0", want: 5},
+		{name: "negative_uses_default", envVal: "-1", want: 5},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "SUMMARIZER_CONCURRENCY")
+			} else {
+				setenv(t, "SUMMARIZER_CONCURRENCY", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.SummarizerConcurrency != tc.want {
+				t.Errorf("SummarizerConcurrency = %d, want %d", cfg.SummarizerConcurrency, tc.want)
+			}
+		})
+	}
+}
+
 // TestLoad_GmailMaxMessages verifies GMAIL_MAX_MESSAGES parsing.
 func TestLoad_GmailMaxMessages(t *testing.T) {
 	t.Parallel()
@@ -258,6 +406,84 @@ func TestLoad_LLMTimeoutSeconds(t *testing.T) {
 			}
 			if cfg.LLMTimeoutSeconds != tc.want {
 				t.Errorf("LLMTimeoutSeconds = %d, want %d", cfg.LLMTimeoutSeconds, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_PIIRedactionEnabled verifies PII_REDACTION_ENABLED parsing
+// (issue #163/#165/#167 policy reversal — default false, unlike the
+// "false"/"0"-only-disables pattern used by SUMMARIZER_BACKFILL_ENABLED: this
+// flag follows the simpler "only literal 'true' enables" convention already
+// used by WHISPER_CLOUD_ALLOWED / DIARIZATION_ENABLED).
+func TestLoad_PIIRedactionEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   bool
+	}{
+		{name: "default_when_unset", unset: true, want: false},
+		{name: "explicit_true", envVal: "true", want: true},
+		{name: "explicit_false", envVal: "false", want: false},
+		{name: "empty_string_disabled", envVal: "", want: false},
+		{name: "invalid_value_disabled", envVal: "yes", want: false}, // only literal "true" enables
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "PII_REDACTION_ENABLED")
+			} else {
+				setenv(t, "PII_REDACTION_ENABLED", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.PIIRedactionEnabled != tc.want {
+				t.Errorf("PIIRedactionEnabled = %v, want %v", cfg.PIIRedactionEnabled, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_PIINumberHashingEnabled verifies PII_NUMBER_HASHING_ENABLED
+// parsing (issue #164 policy reversal — default false).
+func TestLoad_PIINumberHashingEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   bool
+	}{
+		{name: "default_when_unset", unset: true, want: false},
+		{name: "explicit_true", envVal: "true", want: true},
+		{name: "explicit_false", envVal: "false", want: false},
+		{name: "invalid_value_disabled", envVal: "1", want: false}, // only literal "true" enables
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "PII_NUMBER_HASHING_ENABLED")
+			} else {
+				setenv(t, "PII_NUMBER_HASHING_ENABLED", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.PIINumberHashingEnabled != tc.want {
+				t.Errorf("PIINumberHashingEnabled = %v, want %v", cfg.PIINumberHashingEnabled, tc.want)
 			}
 		})
 	}

--- a/internal/worker/summarizer.go
+++ b/internal/worker/summarizer.go
@@ -5,17 +5,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
 )
 
-// defaultMaxTickDuration is the default hard ceiling for a single summarizer tick.
-// It must be shorter than the drain timeout in cmd/collector/main.go (10 s)
-// so that an in-progress tick can be cancelled before the process exits (#65).
-const defaultMaxTickDuration = 8 * time.Second
+// defaultDocTimeout is the default per-document deadline (LLM call + embed +
+// write). It replaces the old whole-tick maxTickDuration ceiling, which
+// assumed a fast local LLM (gemma3:4b on CPU) and silently truncated
+// multi-document batches once the backend became a remote API — a remote
+// chat-completion call alone can take 1-3s, making a shared 8s budget for an
+// entire BatchSize-document tick impossible to honour.
+const defaultDocTimeout = 30 * time.Second
+
+// defaultConcurrency is the default number of documents processed in
+// parallel per tick. A remote LLM call is latency-bound, not CPU-bound, so
+// running several requests concurrently is the primary throughput lever.
+// Kept conservative to avoid tripping a remote provider's rate limit.
+const defaultConcurrency = 5
 
 // SummaryStore is the persistence interface required by SummarizerWorker.
 //
@@ -31,7 +42,9 @@ type SummaryStore interface {
 	ListUnsummarized(ctx context.Context, limit int) ([]*model.Document, error)
 
 	// UpdateSummary persists the LLM summary for a single document.
-	// Idempotent: a no-op when title_summary is already set.
+	// Idempotent: a no-op when title_summary is already set. Must be safe to
+	// call concurrently for different document IDs — SummarizerWorker calls
+	// it from a bounded worker pool (#170).
 	UpdateSummary(ctx context.Context, id uuid.UUID, titleSummary, bulletSummary string, summaryEmbedding []float32) error
 }
 
@@ -56,17 +69,25 @@ type SummarizerConfig struct {
 	// BatchSize is the number of documents processed per tick.
 	// Defaults to 10 when zero or negative.
 	BatchSize int
-	// MaxTickDuration is the hard ceiling for a single tick (LLM + embed + write).
-	// It must be shorter than the drain timeout in cmd/collector/main.go (10 s).
-	// Defaults to defaultMaxTickDuration (8 s) when zero or negative.
-	MaxTickDuration time.Duration
+	// DocTimeout bounds a single document's summarization work (LLM call +
+	// optional embed + UpdateSummary write). Documents are independently
+	// idempotent (UpdateSummary's WHERE title_summary IS NULL guard), so a
+	// timed-out document simply stays unsummarized and is re-queued by
+	// ListUnsummarized on a later tick.
+	// Defaults to defaultDocTimeout (30 s) when zero or negative.
+	DocTimeout time.Duration
+	// Concurrency is the number of documents processed in parallel within a
+	// single tick via a bounded worker pool. A failure or timeout on one
+	// document never aborts the others.
+	// Defaults to defaultConcurrency (5) when zero or negative.
+	Concurrency int
 	// BackfillEnabled controls whether the worker scans for pre-existing
 	// unsummarized documents (WHERE title_summary IS NULL).
 	// When false, ListUnsummarized is not called and only documents summarized
 	// via an explicit call path are processed (future use).
 	// Defaults to true when not set, preserving existing behaviour.
-	// Set to false when running a slow local LLM (e.g. gemma3:4b on CPU) to
-	// avoid a flood of LLM calls for the pre-existing backlog (SUMMARIZER_BACKFILL_ENABLED=false).
+	// Set to false to skip the pre-existing backlog entirely
+	// (SUMMARIZER_BACKFILL_ENABLED=false).
 	BackfillEnabled *bool
 }
 
@@ -75,8 +96,13 @@ type SummarizerConfig struct {
 // the summary text, and persists the result via UpdateSummary.
 //
 // The worker respects the context lifetime: cancel the context to stop it.
-// An in-progress tick is bounded by maxTickDuration (8 s by default) so that
-// it always completes before the drain timeout in cmd/collector/main.go (#65).
+// Per-tick scheduling (deciding whether to start a NEW document) is governed
+// by the caller-supplied context. Documents already in flight run to
+// completion (or their own docTimeout deadline) on a context detached from
+// parent cancellation, so an in-progress UpdateSummary write is never
+// truncated mid-write — see tick() for the detail. This keeps
+// cmd/collector/main.go's shutdown drain window bounded by docTimeout
+// regardless of BatchSize or Concurrency (#65, #170).
 //
 // Concurrent instance safety relies on two mechanisms:
 //  1. UpdateSummary's idempotency guard (WHERE title_summary IS NULL) prevents
@@ -89,7 +115,8 @@ type SummarizerWorker struct {
 	embedder        Embedder
 	interval        time.Duration
 	batchSize       int
-	maxTickDuration time.Duration
+	docTimeout      time.Duration
+	concurrency     int
 	backfillEnabled bool
 }
 
@@ -110,9 +137,13 @@ func NewSummarizerWorker(cfg SummarizerConfig) *SummarizerWorker {
 	if batchSize <= 0 {
 		batchSize = 10
 	}
-	maxTick := cfg.MaxTickDuration
-	if maxTick <= 0 {
-		maxTick = defaultMaxTickDuration
+	docTimeout := cfg.DocTimeout
+	if docTimeout <= 0 {
+		docTimeout = defaultDocTimeout
+	}
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = defaultConcurrency
 	}
 	// BackfillEnabled defaults to true when not explicitly set (nil), preserving
 	// existing behaviour. Set to false to skip the ListUnsummarized scan.
@@ -126,7 +157,8 @@ func NewSummarizerWorker(cfg SummarizerConfig) *SummarizerWorker {
 		embedder:        cfg.Embedder,
 		interval:        interval,
 		batchSize:       batchSize,
-		maxTickDuration: maxTick,
+		docTimeout:      docTimeout,
+		concurrency:     concurrency,
 		backfillEnabled: backfill,
 	}
 }
@@ -137,13 +169,6 @@ func NewSummarizerWorker(cfg SummarizerConfig) *SummarizerWorker {
 //
 // When the LLM is not configured, a single startup log is emitted and the
 // loop runs without processing any documents (#67).
-//
-// Each tick receives a child context with a maxTickDuration deadline derived
-// from context.WithoutCancel(ctx) so that:
-//   - The tick is not interrupted by the parent SIGTERM (#65 — UpdateSummary
-//     must not be cut mid-write), AND
-//   - The tick is still bounded to maxTickDuration so it finishes well before
-//     the drain window in cmd/collector/main.go (#65).
 func (w *SummarizerWorker) Run(ctx context.Context) {
 	if !w.llm.Enabled() {
 		// #67: emit a single diagnostic log so operators can tell immediately
@@ -153,9 +178,13 @@ func (w *SummarizerWorker) Run(ctx context.Context) {
 		return
 	}
 
-	slog.Info("summarizer worker started", "interval", w.interval, "batch_size", w.batchSize)
-	// Initial tick: detached from parent signal but bounded by maxTickDuration.
-	w.runTick(ctx)
+	slog.Info("summarizer worker started",
+		"interval", w.interval,
+		"batch_size", w.batchSize,
+		"doc_timeout", w.docTimeout,
+		"concurrency", w.concurrency,
+	)
+	w.tick(ctx)
 
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
@@ -166,28 +195,36 @@ func (w *SummarizerWorker) Run(ctx context.Context) {
 			slog.Info("summarizer worker stopped")
 			return
 		case <-ticker.C:
-			w.runTick(ctx)
+			w.tick(ctx)
 		}
 	}
 }
 
-// runTick wraps tick with a bounded context: detached from parent cancellation
-// (so SIGTERM mid-write does not truncate UpdateSummary) but capped at
-// w.maxTickDuration (so the tick always completes before the drain timeout).
-func (w *SummarizerWorker) runTick(ctx context.Context) {
-	tickCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), w.maxTickDuration)
-	defer cancel()
-	w.tick(tickCtx)
-}
-
-// tick processes one batch of unsummarized documents.
-// It uses a plain ListUnsummarized (no row locks / no long-lived transaction).
-// Concurrent instances may process the same document, but UpdateSummary's
-// idempotency guard (WHERE title_summary IS NULL) prevents double-writes (#64).
+// tick processes one batch of unsummarized documents through a bounded
+// worker pool (size w.concurrency). It uses a plain ListUnsummarized (no row
+// locks / no long-lived transaction). Concurrent instances may process the
+// same document, but UpdateSummary's idempotency guard (WHERE title_summary
+// IS NULL) prevents double-writes (#64).
 //
-// When backfillEnabled is false, the ListUnsummarized scan is skipped entirely.
-// This prevents a flood of LLM calls for the pre-existing backlog when running
-// a slow local LLM (e.g. gemma3:4b on CPU) — set SUMMARIZER_BACKFILL_ENABLED=false.
+// Deadline model (#170 — replaces the old whole-tick maxTickDuration):
+//   - ctx (the caller-supplied, cancellable context) governs whether tick
+//     starts NEW document work. Between documents (and while waiting for a
+//     free worker-pool slot) the loop checks ctx.Done() and stops launching
+//     new work as soon as the parent is cancelled.
+//   - Each document that IS launched runs on docCtx, derived from
+//     context.WithoutCancel(ctx) (so SIGTERM never truncates an in-flight
+//     UpdateSummary write) bounded by w.docTimeout (so a hung remote LLM call
+//     cannot block the worker forever).
+//
+// Because at most w.concurrency documents are ever in flight, and each is
+// bounded by w.docTimeout, tick() always returns within roughly one
+// docTimeout of ctx being cancelled — independent of BatchSize. This is what
+// keeps cmd/collector/main.go's shutdown drain window correct (see the
+// drainTimeout derivation there).
+//
+// When backfillEnabled is false, the ListUnsummarized scan is skipped
+// entirely — set SUMMARIZER_BACKFILL_ENABLED=false to opt out of the
+// pre-existing backlog.
 func (w *SummarizerWorker) tick(ctx context.Context) {
 	if !w.backfillEnabled {
 		slog.Debug("summarizer: backfill disabled — skipping ListUnsummarized scan")
@@ -203,22 +240,60 @@ func (w *SummarizerWorker) tick(ctx context.Context) {
 		return
 	}
 
-	slog.Info("summarizer: processing batch", "count", len(docs))
-	succeeded := 0
+	slog.Info("summarizer: processing batch", "count", len(docs), "concurrency", w.concurrency)
+
+	// detachedBase strips ctx's cancellation/deadline so an in-flight
+	// document's LLM call / embed / write is never cut mid-write by parent
+	// SIGTERM (#65). Each document still gets its own bounded deadline below.
+	detachedBase := context.WithoutCancel(ctx)
+
+	var attempted, succeeded int64
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, w.concurrency)
+
+docLoop:
 	for _, doc := range docs {
-		if err := w.summarizeOne(ctx, doc); err != nil {
-			slog.Warn("summarizer: summarize failed",
-				"doc_id", doc.ID,
-				"source_id", doc.SourceID,
-				"error", err)
-			continue
+		// Stop launching NEW work once the parent context is cancelled.
+		// Already-launched documents keep running on detachedBase, bounded
+		// individually by docTimeout.
+		select {
+		case <-ctx.Done():
+			break docLoop
+		default:
 		}
-		succeeded++
+
+		select {
+		case <-ctx.Done():
+			break docLoop
+		case sem <- struct{}{}:
+		}
+
+		atomic.AddInt64(&attempted, 1)
+		wg.Add(1)
+		go func(doc *model.Document) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			docCtx, cancel := context.WithTimeout(detachedBase, w.docTimeout)
+			defer cancel()
+
+			if err := w.summarizeOne(docCtx, doc); err != nil {
+				slog.Warn("summarizer: summarize failed",
+					"doc_id", doc.ID,
+					"source_id", doc.SourceID,
+					"error", err)
+				return
+			}
+			atomic.AddInt64(&succeeded, 1)
+		}(doc)
 	}
 
+	wg.Wait()
+
 	slog.Info("summarizer: batch complete",
-		"processed", len(docs),
-		"succeeded", succeeded,
+		"listed", len(docs),
+		"attempted", atomic.LoadInt64(&attempted),
+		"succeeded", atomic.LoadInt64(&succeeded),
 	)
 }
 

--- a/internal/worker/summarizer_test.go
+++ b/internal/worker/summarizer_test.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
 )
 
 // ---------------------------------------------------------------------------
@@ -18,11 +19,18 @@ import (
 // ---------------------------------------------------------------------------
 
 // mockSummaryStore satisfies SummaryStore using ListUnsummarized (#64 simplified).
+//
+// SummarizerWorker now processes documents from a bounded worker pool
+// (#170), so UpdateSummary can be called concurrently for different document
+// IDs within a single tick — mu guards updateCalls against concurrent
+// appends (go test -race).
 type mockSummaryStore struct {
 	unsummarized []*model.Document
 	listErr      error
-	updateCalls  []updateSummaryCall
 	updateErr    error
+
+	mu          sync.Mutex
+	updateCalls []updateSummaryCall
 }
 
 type updateSummaryCall struct {
@@ -44,6 +52,8 @@ func (m *mockSummaryStore) ListUnsummarized(_ context.Context, limit int) ([]*mo
 }
 
 func (m *mockSummaryStore) UpdateSummary(_ context.Context, id uuid.UUID, titleSummary, bulletSummary string, summaryEmbedding []float32) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.updateCalls = append(m.updateCalls, updateSummaryCall{
 		id:               id,
 		titleSummary:     titleSummary,
@@ -321,36 +331,44 @@ func TestSummarizerWorker_tick_updateErr_continues(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: tick timeout (#65) — tick must complete within maxTickDuration
+// Tests: per-document timeout (#65, #170) — replaces the old whole-tick
+// maxTickDuration ceiling. A single document is bounded by DocTimeout;
+// launching NEW documents stops as soon as the tick's own context is
+// cancelled, independent of DocTimeout.
 // ---------------------------------------------------------------------------
 
-// TestSummarizerWorker_tick_respectsTimeout verifies that tick() honours its
-// context deadline and does not block indefinitely when the LLM is slow.
-func TestSummarizerWorker_tick_respectsTimeout(t *testing.T) {
+// TestSummarizerWorker_tick_respectsDocTimeout verifies that a hung LLM call
+// is bounded by DocTimeout (not the caller's context, which may have no
+// deadline at all) and does not block tick() indefinitely.
+func TestSummarizerWorker_tick_respectsDocTimeout(t *testing.T) {
 	// slowLLM blocks until its context is cancelled.
 	slowLLM := &slowLLMClient{}
 
 	doc := makeDoc("slow content")
 	st := &mockSummaryStore{unsummarized: []*model.Document{doc}}
 
-	w := NewSummarizerWorker(SummarizerConfig{Store: st, LLM: slowLLM, BatchSize: 10})
-
-	// Use a very short deadline to keep the test fast.
-	const tickDeadline = 50 * time.Millisecond
-	tickCtx, cancel := context.WithTimeout(context.Background(), tickDeadline)
-	defer cancel()
+	// Use a very short DocTimeout to keep the test fast. The parent context
+	// (context.Background()) has no deadline of its own — DocTimeout alone
+	// must bound the call.
+	const docTimeout = 50 * time.Millisecond
+	w := NewSummarizerWorker(SummarizerConfig{
+		Store:      st,
+		LLM:        slowLLM,
+		BatchSize:  10,
+		DocTimeout: docTimeout,
+	})
 
 	start := time.Now()
-	w.tick(tickCtx)
+	w.tick(context.Background())
 	elapsed := time.Since(start)
 
-	// The tick must have returned within a reasonable margin of the deadline.
-	if elapsed > tickDeadline*5 {
-		t.Errorf("tick did not respect context deadline: elapsed %s, deadline %s", elapsed, tickDeadline)
+	// The tick must have returned within a reasonable margin of DocTimeout.
+	if elapsed > docTimeout*10 {
+		t.Errorf("tick did not respect DocTimeout: elapsed %s, DocTimeout %s", elapsed, docTimeout)
 	}
 	// The slow LLM must not have produced an UpdateSummary call.
 	if len(st.updateCalls) != 0 {
-		t.Errorf("expected no UpdateSummary call when LLM is cancelled, got %d", len(st.updateCalls))
+		t.Errorf("expected no UpdateSummary call when the document's LLM call times out, got %d", len(st.updateCalls))
 	}
 }
 
@@ -363,34 +381,100 @@ func (s *slowLLMClient) CompleteWithMessages(ctx context.Context, _ string, _ []
 	return "", ctx.Err()
 }
 
-// TestSummarizerWorker_runTick_boundedByMaxTickDuration verifies that runTick
-// returns within the configured MaxTickDuration even when the LLM is slow.
-func TestSummarizerWorker_runTick_boundedByMaxTickDuration(t *testing.T) {
-	slowLLM := &slowLLMClient{}
+// TestSummarizerWorker_tick_stopsLaunchingWhenContextCancelled verifies that
+// tick() does not start any new document work when the caller's context is
+// already cancelled on entry — this is what keeps the shutdown drain window
+// (cmd/collector/main.go) bounded regardless of BatchSize/Concurrency,
+// independent of DocTimeout.
+func TestSummarizerWorker_tick_stopsLaunchingWhenContextCancelled(t *testing.T) {
 	doc := makeDoc("content")
 	st := &mockSummaryStore{unsummarized: []*model.Document{doc}}
+	lm := &callCountingLLM{response: validSummaryJSON("T", "• B")}
 
-	// Use a short MaxTickDuration so the test completes quickly.
-	const shortTick = 50 * time.Millisecond
-	w := NewSummarizerWorker(SummarizerConfig{
-		Store:           st,
-		LLM:             slowLLM,
-		BatchSize:       10,
-		MaxTickDuration: shortTick,
-	})
+	w := NewSummarizerWorker(SummarizerConfig{Store: st, LLM: lm, BatchSize: 10})
 
-	// Parent context is already cancelled — runTick must still return within
-	// MaxTickDuration (bounded by context.WithTimeout(WithoutCancel(ctx), MaxTickDuration)).
 	cancelledCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	start := time.Now()
-	w.runTick(cancelledCtx)
+	w.tick(cancelledCtx)
 	elapsed := time.Since(start)
 
-	// Must complete well within shortTick (with 10× tolerance for slow CI).
-	if elapsed > shortTick*10 {
-		t.Errorf("runTick exceeded expected bound: elapsed %s, MaxTickDuration %s", elapsed, shortTick)
+	// Must return near-instantly — no document work is ever launched.
+	const budget = 200 * time.Millisecond
+	if elapsed > budget {
+		t.Errorf("tick with an already-cancelled context took %s, want < %s", elapsed, budget)
+	}
+	if calls := atomic.LoadInt64(&lm.calls); calls != 0 {
+		t.Errorf("expected 0 LLM calls when context is already cancelled, got %d", calls)
+	}
+	if len(st.updateCalls) != 0 {
+		t.Errorf("expected no UpdateSummary calls when context is already cancelled, got %d", len(st.updateCalls))
+	}
+}
+
+// callCountingLLM counts CompleteWithMessages invocations; safe for
+// concurrent use (tracks max-in-flight for the concurrency test below).
+type callCountingLLM struct {
+	response string
+	err      error
+
+	calls       int64 // atomic
+	inFlight    int64 // atomic
+	maxInFlight int64 // atomic — high-water mark of concurrent calls
+}
+
+func (m *callCountingLLM) Enabled() bool { return true }
+
+func (m *callCountingLLM) CompleteWithMessages(_ context.Context, _ string, _ []llm.Message) (string, error) {
+	atomic.AddInt64(&m.calls, 1)
+	cur := atomic.AddInt64(&m.inFlight, 1)
+	defer atomic.AddInt64(&m.inFlight, -1)
+	for {
+		max := atomic.LoadInt64(&m.maxInFlight)
+		if cur <= max || atomic.CompareAndSwapInt64(&m.maxInFlight, max, cur) {
+			break
+		}
+	}
+	// Simulate remote-API latency so concurrent goroutines actually overlap.
+	time.Sleep(20 * time.Millisecond)
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.response, nil
+}
+
+// TestSummarizerWorker_tick_boundsConcurrency verifies that at most
+// Concurrency documents are ever in flight simultaneously within one tick,
+// and that all documents are still eventually processed via the bounded
+// worker pool (#170).
+func TestSummarizerWorker_tick_boundsConcurrency(t *testing.T) {
+	const docCount = 10
+	const concurrency = 3
+
+	docs := make([]*model.Document, docCount)
+	for i := range docs {
+		docs[i] = makeDoc("content")
+	}
+	st := &mockSummaryStore{unsummarized: docs}
+	lm := &callCountingLLM{response: validSummaryJSON("T", "• B")}
+
+	w := NewSummarizerWorker(SummarizerConfig{
+		Store:       st,
+		LLM:         lm,
+		BatchSize:   docCount,
+		Concurrency: concurrency,
+	})
+	w.tick(context.Background())
+
+	if len(st.updateCalls) != docCount {
+		t.Errorf("expected %d UpdateSummary calls, got %d", docCount, len(st.updateCalls))
+	}
+	if got := atomic.LoadInt64(&lm.maxInFlight); got > concurrency {
+		t.Errorf("max concurrent LLM calls = %d, want <= %d", got, concurrency)
+	}
+	if got := atomic.LoadInt64(&lm.maxInFlight); got < 2 {
+		t.Errorf("max concurrent LLM calls = %d, want >= 2 (pool should actually run in parallel)", got)
 	}
 }
 


### PR DESCRIPTION
## 요약

- **PII 정책 전환**: `PII_REDACTION_ENABLED`, `PII_NUMBER_HASHING_ENABLED` 플래그 도입(기본 false). #163/#164/#165/#167에서 구축한 redaction/hashing 기능은 그대로 유지하되 플래그 뒤로 감춤. 해싱 비활성 시 `metadata.number`에 원본 번호 기록. SourceID 해싱은 의도적으로 변경하지 않음(재키잉 시 기존 문서 고아화 위험). 데이터 소유자 본인의 개인 코퍼스에 대한 의도적인 정책 전환.
- **ollama 제거**: `docker-compose.local.yml`에서 ollama를 `local-inference` profile 뒤로 이동. Go 코드 어디에도 ollama 참조 없음(`grep -rln ollama --include=*.go` 결과 없음). 하루에 두 번 원치 않는 ollama 컨테이너가 되살아나는 원인이었던 stale `depends_on` 제거. 프로젝트 방침: local/internal LLM 미사용, 전 추론은 API key 기반 원격 API로.
- **summarizer 처리량 개선**: 로컬 ollama 기준으로 설정됐던 tick 전체 8초 상한이 원격 API 전환 후 40-60% `context deadline exceeded` 실패를 유발. per-document timeout + bounded worker pool로 교체. `cmd/collector`의 drain timeout은 `SUMMARIZER_DOC_TIMEOUT + 10s`로 파생시켜 다시 stale해지지 않도록 함. 신규 knob: `SUMMARIZER_BATCH_SIZE`(50), `SUMMARIZER_INTERVAL`(30s), `SUMMARIZER_DOC_TIMEOUT`(30s), `SUMMARIZER_CONCURRENCY`(5). 측정 처리량 0.46 docs/min → 예상 100-300 docs/min.
- **설계 문서**: `docs/superpowers/specs/2026-08-17-ask-capture-design.md` — Ask & Capture(RAG Q&A + 노트 캡처, tacit-knowledge 추출) 설계 문서. raw note / LLM 정리 메타데이터 / 별도 추적되는 추론(inference) 3계층 데이터 분리 모델. 구현 없는 설계 문서.

## 커밋

1. `feat(privacy): make PII redaction and number hashing opt-in (default off)`
2. `chore(compose): move ollama behind local-inference profile`
3. `fix(worker): per-document timeout and concurrency for remote LLM backend`
4. `docs(spec): Ask & Capture design — RAG Q&A and note capture with tacit-knowledge extraction`

## CI 참고사항

`Go vulnerability check` 잡이 이 PR과 무관하게 `origin/main`에서도 동일하게 실패합니다. `origin/main`을 독립된 worktree로 체크아웃해 `govulncheck`을 직접 실행해 확인함 — chi/net-http/x/text 등 12건의 기존 advisory drift로, 이 PR이 유발한 것이 아닙니다.

## Test plan

- [x] `go build ./...` 통과
- [x] `go test -count=1 ./...` 전체 통과
- [x] `docker compose -f docker-compose.local.yml config --services`에 ollama 미노출 확인
- [x] `origin/main` 클린 worktree에서 govulncheck 사전 실패 확인(이 PR과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)