### PR TITLE
fix(web): Ask 링크 제거 + Capture 파일 업로드 추가

### DIFF
--- a/web/src/app/api/upload/route.ts
+++ b/web/src/app/api/upload/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Upload proxy — POST /api/upload
+ *
+ * Session-protected route (NOT under /api/v1/*) that lets the Capture
+ * screen upload a file to the backend's file-ingest endpoint. Unlike
+ * src/app/api/v1/ingest/file/route.ts — which forwards the mobile app's
+ * own Bearer token as-is — the browser has no API_KEY of its own, so this
+ * route attaches the server-held API_KEY, mirroring
+ * src/app/api/notes/route.ts's pattern.
+ *
+ * Request body (multipart/form-data, forwarded verbatim):
+ *   file    — file to ingest (required)
+ *   title   — document title (optional)
+ *   source  — source type string (optional)
+ *   tags    — comma-separated tag list (optional)
+ *
+ * Response:
+ *   201 { document_id: string, accepted: boolean }
+ */
+import { type NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // Content-Type must be forwarded verbatim for multipart (includes boundary)
+  const contentType = request.headers.get("content-type") ?? "";
+  const body = await request.arrayBuffer();
+
+  try {
+    const upstream = await fetch(`${BACKEND_URL}/api/v1/ingest/file`, {
+      method: "POST",
+      headers: {
+        ...(contentType ? { "Content-Type": contentType } : {}),
+        ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }),
+      },
+      body,
+    });
+    const data: unknown = await upstream.json().catch(() => ({}));
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Upstream request failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/web/src/app/capture/page.tsx
+++ b/web/src/app/capture/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { listDocuments, createNote, retryNoteEnrichment, deleteNote } from "@/lib/api";
+import {
+  listDocuments,
+  createNote,
+  retryNoteEnrichment,
+  deleteNote,
+  uploadFile,
+  MAX_UPLOAD_FILE_BYTES,
+} from "@/lib/api";
 import { getNoteMetadata } from "@/lib/types";
 import type { DocumentDetail } from "@/lib/types";
 import { describeEnrichmentStatus } from "@/lib/enrichmentStatus";
@@ -77,6 +84,8 @@ export default function CapturePage() {
   const [notes, setNotes] = useState<DocumentDetail[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
@@ -145,6 +154,32 @@ export default function CapturePage() {
     }
   }
 
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    // Always clear the input value so selecting the same file twice in a
+    // row (e.g. retry after an error) still fires a change event.
+    e.target.value = "";
+    if (!file || uploading) return;
+
+    if (file.size > MAX_UPLOAD_FILE_BYTES) {
+      setError(
+        `파일이 너무 큽니다 (최대 ${Math.floor(MAX_UPLOAD_FILE_BYTES / (1024 * 1024))}MB).`,
+      );
+      return;
+    }
+
+    setUploading(true);
+    setError(null);
+    try {
+      await uploadFile(file);
+      await refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "파일 업로드 중 오류가 발생했습니다.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
   async function handleRetry(id: string) {
     try {
       await retryNoteEnrichment(id);
@@ -192,6 +227,34 @@ export default function CapturePage() {
           저장
         </Button>
         {error && <p className="text-sm text-danger">{error}</p>}
+      </div>
+
+      {/* File upload — separate from the text compose field above; the
+          backend ingests the file as its own document (source: upload). */}
+      <div className="space-y-2 rounded-lg border border-border bg-surface p-4">
+        <h2 className="text-sm font-medium text-foreground">파일로 저장</h2>
+        <p className="text-xs text-foreground-muted">
+          PDF, DOCX, XLSX, PPTX, HWPX, HTML, TXT, MD 파일을 업로드할 수 있습니다.
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".pdf,.docx,.xlsx,.pptx,.hwpx,.html,.htm,.txt,.md,.text"
+            onChange={(e) => void handleFileSelected(e)}
+            disabled={uploading}
+            className="hidden"
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => fileInputRef.current?.click()}
+            loading={uploading}
+            disabled={uploading}
+          >
+            파일 선택 및 업로드
+          </Button>
+        </div>
       </div>
 
       {/* Recent notes */}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -48,12 +48,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
               Second Brain
             </Link>
             <nav className="flex items-center gap-1 text-sm">
-              <Link
-                href="/ask"
-                className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"
-              >
-                Ask
-              </Link>
+              {/* Ask nav link removed: /api/v1/ask backend does not exist yet
+                  and was causing 404s in production. Restore once the Ask
+                  backend is implemented. */}
               <Link
                 href="/capture"
                 className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,12 +3,18 @@ import type {
   CreateNoteResponse,
   DocumentDetail,
   DocumentsResponse,
+  IngestFileResponse,
   RecentItemsResponse,
   SearchParams,
   SearchResponse,
   SourcesResponse,
   StatsResponse,
 } from "./types";
+
+/** Per-upload size cap enforced by the backend (internal/api/ingest_file.go
+ * defaultIngestMaxFileBytes) — mirrored here so the Capture screen can
+ * reject oversized files before spending an upload round-trip. */
+export const MAX_UPLOAD_FILE_BYTES = 100 * 1024 * 1024;
 
 /**
  * Resolve the API base URL depending on execution environment.
@@ -156,5 +162,19 @@ export async function retryNoteEnrichment(id: string): Promise<void> {
 export async function deleteNote(id: string): Promise<void> {
   await fetchJson<unknown>(`${getApiBase()}/notes/${encodeURIComponent(id)}`, {
     method: "DELETE",
+  });
+}
+
+// ── File upload (Capture) ────────────────────────────────────────────────
+
+/** Uploads a file to POST /api/upload (browser-only). No Content-Type is
+ * set explicitly — the browser derives the multipart boundary from the
+ * FormData body automatically; setting it manually would drop the boundary. */
+export async function uploadFile(file: File): Promise<IngestFileResponse> {
+  const formData = new FormData();
+  formData.append("file", file);
+  return fetchJson<IngestFileResponse>(`${getApiBase()}/upload`, {
+    method: "POST",
+    body: formData,
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -112,6 +112,12 @@ export interface CreateNoteResponse {
   status: "pending";
 }
 
+/** Response shape of POST /api/v1/ingest/file (internal/api/ingest_file.go). */
+export interface IngestFileResponse {
+  document_id: string;
+  accepted: boolean;
+}
+
 /** One entry of the `sources` SSE event (spec §5.1). */
 export interface AskSourceItem {
   id: string;


### PR DESCRIPTION
## 요약
- `/ask` 백엔드(`POST /api/v1/ask`)가 아직 없어 운영 환경에서 Ask 링크 클릭 시 404가 발생하고 있었습니다. 백엔드가 구현될 때까지 네비게이션에서 Ask 링크를 내렸습니다.
- Capture 화면에 파일 업로드 기능을 추가했습니다. 기존 백엔드 엔드포인트 `POST /api/v1/ingest/file`(multipart `file` 필드, 최대 100MiB, 지원 확장자 10종)에 세션 보호 프록시 `/api/upload`를 새로 붙여 연결했습니다.
- `sseEvents.ts`는 삭제하지 않고 남겨두었습니다. Ask 백엔드가 구현되면 그대로 재사용할 예정입니다.

## Test plan
- [ ] CI 전체 잡 통과 확인
- [ ] Capture 화면에서 파일 업로드 동작 확인 (배포 후)