### PR TITLE
feat(web): Ask 화면 SSE 스트리밍 + 네비 링크 복원

### DIFF
--- a/web/src/app/api/ask/route.ts
+++ b/web/src/app/api/ask/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Ask proxy — POST /api/ask
+ *
+ * Session-protected (web/src/proxy.ts catch-all). Unlike every other proxy
+ * in this app, this handler does NOT buffer the upstream response with
+ * .json()/.text() — it passes upstream.body straight through as the
+ * Response body, preserving the SSE stream (spec §5.1). Buffering here
+ * would silently turn a streaming answer into a "wait for everything, then
+ * show it all at once" answer, with no error and no obvious symptom other
+ * than a much longer time-to-first-token.
+ */
+import { type NextRequest } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const body = await request.text();
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${BACKEND_URL}/api/v1/ask`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }),
+      },
+      body,
+      // Forward client aborts (new question / navigation away) upstream so
+      // the backend stops generating instead of continuing to burn tokens
+      // for a client that has already stopped listening.
+      signal: request.signal,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "upstream unreachable";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // A non-SSE error response (e.g. 401/400/503 per spec §5.1's error table)
+  // is still JSON, not a stream — forward it as-is rather than trying to
+  // stream a body that was never a stream.
+  if (
+    !upstream.body ||
+    !(upstream.headers.get("content-type") ?? "").includes("text/event-stream")
+  ) {
+    const text = await upstream.text();
+    return new Response(text, {
+      status: upstream.status,
+      headers: { "Content-Type": upstream.headers.get("content-type") ?? "application/json" },
+    });
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      // Disables response buffering in any reverse proxy sitting between
+      // this handler and the browser (cloudflared, per spec §8) — without
+      // this, an intermediate proxy can still batch the stream even though
+      // this handler itself does not.
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+// Never cache an SSE response — each call is a unique, stateful generation.
+export const dynamic = "force-dynamic";

--- a/web/src/app/ask/page.tsx
+++ b/web/src/app/ask/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { splitSSEBuffer, parseAskEvent } from "@/lib/sseEvents";
+import type { AskSourceItem } from "@/lib/types";
+import { getAskLayer, ASK_LAYER_LABELS } from "@/lib/constants";
+import { Button } from "@/components/ui";
+
+function SourceCard({ source }: { source: AskSourceItem }) {
+  const layer = getAskLayer(source.source_type);
+  const isInsight = layer === "insight";
+  return (
+    <div
+      className={`rounded-md border px-3 py-2 text-xs ${
+        isInsight ? "border-accent/30 bg-accent-subtle" : "border-border bg-surface-subtle"
+      }`}
+    >
+      <div className="flex items-center gap-1.5">
+        <span className={`font-medium ${isInsight ? "text-accent" : "text-foreground-subtle"}`}>
+          {ASK_LAYER_LABELS[layer]}
+        </span>
+        <span className="line-clamp-1 text-foreground-muted">{source.title}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function AskPage() {
+  const [question, setQuestion] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [sources, setSources] = useState<AskSourceItem[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bufferRef = useRef("");
+  // Tracks the in-flight request so a new question (or unmount) can cancel
+  // whatever stream is currently being read — without this, asking a
+  // second question while the first is still streaming would leave both
+  // readers appending tokens into the same answer state concurrently.
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  async function handleAsk() {
+    const trimmed = question.trim();
+    if (!trimmed || streaming) return;
+
+    // Cancel any previous in-flight stream before starting a new one.
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setAnswer("");
+    setSources([]);
+    setError(null);
+    setStreaming(true);
+    bufferRef.current = "";
+
+    try {
+      const res = await fetch("/api/ask", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ question: trimmed }),
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `요청이 실패했습니다 (${res.status})`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        bufferRef.current += decoder.decode(value, { stream: true });
+        const { events, remainder } = splitSSEBuffer(bufferRef.current);
+        bufferRef.current = remainder;
+
+        for (const raw of events) {
+          const evt = parseAskEvent(raw);
+          if (!evt) continue;
+          if (evt.type === "sources") setSources(evt.sources);
+          else if (evt.type === "token") setAnswer((prev) => prev + evt.text);
+          else if (evt.type === "error") setError(evt.message);
+          else if (evt.type === "done" && evt.finish_reason === "no_evidence") {
+            setError((prev) => prev ?? "관련된 근거를 찾지 못했습니다.");
+          }
+        }
+      }
+    } catch (e: unknown) {
+      // A deliberate abort (new question / navigating away) is not a user
+      // facing error — surfacing it would flash a confusing message every
+      // time the user asks a follow-up before the previous answer finishes.
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      setError(e instanceof Error ? e.message : "답변 생성 중 오류가 발생했습니다.");
+    } finally {
+      if (abortControllerRef.current === controller) {
+        setStreaming(false);
+        abortControllerRef.current = null;
+      }
+    }
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] flex-col">
+      {/* Answer + sources */}
+      <div className="flex-1 space-y-4 overflow-y-auto pb-24 sm:pb-4">
+        {sources.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {sources.map((s) => (
+              <SourceCard key={s.id} source={s} />
+            ))}
+          </div>
+        )}
+        {answer && (
+          <p className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">{answer}</p>
+        )}
+        {error && <p className="text-sm text-danger">{error}</p>}
+        {!answer && !error && !streaming && (
+          <p className="py-12 text-center text-sm text-foreground-subtle">
+            내 데이터에 질문해보세요
+          </p>
+        )}
+      </div>
+
+      {/* Input — mobile: fixed to the viewport bottom (spec §7.2's required
+          deviation). This app has a real prior incident with an element
+          fixed to the bottom edge overlapping content underneath it (a
+          save button hidden behind the tab bar on a past mobile release) —
+          the pb-24 on the scroll container above exists specifically to
+          reserve room for this bar so the same class of bug does not repeat
+          here. Desktop: inline, no fixed positioning needed. */}
+      <div className="fixed inset-x-0 bottom-0 border-t border-border bg-background px-4 py-3 sm:static sm:border-0 sm:bg-transparent sm:px-0 sm:py-0">
+        <div className="mx-auto flex max-w-4xl gap-2">
+          <input
+            type="text"
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void handleAsk();
+              }
+            }}
+            placeholder="질문을 입력하세요…"
+            disabled={streaming}
+            className="flex-1 rounded-lg border border-border bg-surface px-3 py-2.5 text-sm text-foreground placeholder:text-foreground-subtle focus:ring-2 focus:ring-accent/40 focus:outline-none disabled:opacity-50"
+          />
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => void handleAsk()}
+            loading={streaming}
+            disabled={streaming || !question.trim()}
+          >
+            질문
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -48,9 +48,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
               Second Brain
             </Link>
             <nav className="flex items-center gap-1 text-sm">
-              {/* Ask nav link removed: /api/v1/ask backend does not exist yet
-                  and was causing 404s in production. Restore once the Ask
-                  backend is implemented. */}
+              <Link
+                href="/ask"
+                className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"
+              >
+                질문
+              </Link>
               <Link
                 href="/capture"
                 className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"


### PR DESCRIPTION
## 요약
- 백엔드 `POST /api/v1/ask`가 배포되어(PR #180) 차단이 풀린 프론트엔드 태스크 2건을 구현했습니다.
- **SSE 패스스루 프록시** (`web/src/app/api/ask/route.ts`) — `upstream.body`를 그대로 클라이언트에 전달하고 `.json()`/`.text()`로 소비하지 않습니다. 소비하면 스트림이 끝날 때까지 버퍼링되어 토큰 단위 스트리밍이 무의미해지기 때문입니다. `X-Accel-Buffering: no` 헤더로 중간 프록시의 버퍼링도 차단했습니다.
- 클라이언트 취소가 백엔드 LLM 생성까지 전파되도록 `signal: request.signal`을 전달하고, 새 질문 제출 또는 컴포넌트 언마운트 시 `AbortController`로 이전 요청을 취소합니다.
- `finish_reason: no_evidence`일 때 빈 화면 대신 안내 메시지를 표시합니다.
- 답변은 plain text로 렌더링합니다 (마크다운 파싱 안 함 — XSS 표면 축소).
- PR #179에서 404로 인해 내렸던 Ask 네비 링크를 복원했습니다.

## 변경 파일
- `web/src/app/api/ask/route.ts` (신규)
- `web/src/app/ask/page.tsx` (신규)
- `web/src/app/layout.tsx` (수정)

## Test plan
- [ ] CI 전체 통과 확인 (6개 잡)
- [ ] `/ask` 페이지에서 질문 제출 시 토큰 단위 스트리밍 확인
- [ ] 새 질문 제출/페이지 이탈 시 이전 요청 취소 확인
- [ ] `no_evidence` 응답 시 안내 메시지 표시 확인

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>