### PR TITLE
fix(api): /ask 프롬프트에 현재 날짜·문서 발생 시각 컨텍스트 주입

### DIFF
--- a/internal/api/ask.go
+++ b/internal/api/ask.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/baekenough/second-brain/internal/intent"
 	"github.com/baekenough/second-brain/internal/llm"
@@ -52,18 +53,81 @@ type askErrorPayload struct {
 	Message string `json:"message"`
 }
 
-// askSystemPrompt instructs the model to answer strictly from the supplied
-// context, degrade to "모른다" when the context is insufficient, and never
-// present [추론] (insight) content as established fact — the echo-chamber
-// guard from spec §3.2/§6.5 extends into the synthesized answer itself, not
-// just the retrieval layer (search.applyInsightExclusionDefault).
-const askSystemPrompt = `당신은 사용자의 개인 지식 베이스에서 검색된 문서를 근거로 질문에 답하는 어시스턴트입니다.
+// kstLocation is the timezone used to render every date/time shown to the
+// model in the Stage 3 prompt: the current-date line in
+// buildAskSystemPrompt and each document's occurred_at in buildAskMessages.
+// Second Brain's users and ingested data are Korea-based, so dates are
+// always rendered in Asia/Seoul rather than the server process's local
+// timezone (which may be UTC in a container) — otherwise a request served
+// near local midnight could show the model the wrong calendar date and
+// reintroduce the exact bug this file fixes.
+//
+// time.LoadLocation reads the OS tzdata database; the production image
+// (Dockerfile's runtime-base stage) installs the tzdata package for exactly
+// this reason. The time.FixedZone fallback below only matters for an
+// environment without a tzdata database (e.g. a minimal test sandbox) —
+// Korea observes no DST, so a fixed UTC+9 offset is equivalent to the IANA
+// zone at every point in time, not just an approximation.
+var kstLocation = loadKSTLocation()
+
+func loadKSTLocation() *time.Location {
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		return time.FixedZone("KST", 9*60*60)
+	}
+	return loc
+}
+
+// koreanWeekdayNames is indexed by time.Weekday (Sunday=0 ... Saturday=6).
+var koreanWeekdayNames = [...]string{"일", "월", "화", "수", "목", "금", "토"}
+
+// formatKoreanDateTime renders t (already converted to the desired
+// location by the caller) as "YYYY-MM-DD(요일) HH:MM".
+func formatKoreanDateTime(t time.Time) string {
+	return fmt.Sprintf("%04d-%02d-%02d(%s) %02d:%02d",
+		t.Year(), int(t.Month()), t.Day(), koreanWeekdayNames[t.Weekday()], t.Hour(), t.Minute())
+}
+
+// formatOccurredAt renders a document's OccurredAt in KST, or an explicit
+// "no timestamp" label when nil. nil is common and expected: every
+// llm-memory-source document has OccurredAt == nil (see
+// internal/model/document.go's field comment), so this must not panic and
+// must not silently omit the field — an omitted field could read to the
+// model as "same day as now" rather than "unknown".
+func formatOccurredAt(t *time.Time) string {
+	if t == nil {
+		return "시각 정보 없음"
+	}
+	return formatKoreanDateTime(t.In(kstLocation))
+}
+
+// askSystemPromptTemplate is buildAskSystemPrompt's format string. It
+// instructs the model to answer strictly from the supplied context,
+// degrade to "모른다" when the context is insufficient, and never present
+// [추론] (insight) content as established fact — the echo-chamber guard
+// from spec §3.2/§6.5 extends into the synthesized answer itself, not just
+// the retrieval layer (search.applyInsightExclusionDefault). %s is the
+// current date/time rendered by buildAskSystemPrompt.
+const askSystemPromptTemplate = `당신은 사용자의 개인 지식 베이스에서 검색된 문서를 근거로 질문에 답하는 어시스턴트입니다.
+
+현재 시각: %s (KST, 한국 표준시) 기준입니다.
 
 규칙:
 1. 반드시 아래 제공된 [관측된 사실] 및 [추론] 섹션의 내용에만 근거해 답변하세요. 컨텍스트 밖의 지식을 사용하지 마세요.
 2. 컨텍스트만으로 답할 수 없으면 솔직하게 "제공된 정보로는 답변할 수 없습니다"라고 답하세요. 추측해서 답하지 마세요.
 3. [추론] 섹션은 AI가 문서에서 도출한 가설이며 확정된 사실이 아닙니다. 이 섹션의 내용을 인용할 때는 반드시 "~로 추정됩니다" 등 가설임을 밝히세요. 사실인 것처럼 단정하지 마세요.
-4. 한국어로, 간결하고 명확하게 답변하세요.`
+4. "내일", "어제", "지난주", "이번 달" 등 상대적인 시간 표현이 질문이나 문서 내용에 등장하면, 반드시 위의 현재 시각을 기준으로 날짜를 계산해 해석하세요. 각 문서 하단의 [발생] 시각도 이 기준으로 판단하세요. 현재 시각을 알 수 없다는 이유로 답변을 회피하지 마세요.
+5. 한국어로, 간결하고 명확하게 답변하세요.`
+
+// buildAskSystemPrompt renders askSystemPromptTemplate with now converted
+// to KST. now is normally s.nowFunc() (real time.Now, or an injected clock
+// in tests) — see Server.now's doc comment for why this exists: the prior
+// compile-time askSystemPrompt const gave the model no way to know "today",
+// so it could not resolve "내일"/"어제" and answered that it didn't know
+// what day it was.
+func buildAskSystemPrompt(now time.Time) string {
+	return fmt.Sprintf(askSystemPromptTemplate, formatKoreanDateTime(now.In(kstLocation)))
+}
 
 // writeSSEEvent writes one "event: <name>\ndata: <json>\n\n" frame and
 // flushes immediately so the client sees it without buffering. Returns an
@@ -199,9 +263,10 @@ func (s *Server) synthesize(ctx context.Context, w http.ResponseWriter, flusher 
 	}
 
 	messages := buildAskMessages(question, result)
+	systemPrompt := buildAskSystemPrompt(s.nowFunc())
 
 	if sc, ok := s.llmClient.(llm.StreamCompleter); ok {
-		err := sc.StreamWithMessages(ctx, askSystemPrompt, messages, func(delta string) {
+		err := sc.StreamWithMessages(ctx, systemPrompt, messages, func(delta string) {
 			_ = writeSSEEvent(w, flusher, "token", askTokenPayload{Text: delta})
 		})
 		if err != nil {
@@ -219,7 +284,7 @@ func (s *Server) synthesize(ctx context.Context, w http.ResponseWriter, flusher 
 	// Fallback for a Completer that does not implement StreamCompleter
 	// (e.g. a test fake, or a future non-streaming-only backend): emit the
 	// full answer as a single "token" event.
-	answer, err := s.llmClient.CompleteWithMessages(ctx, askSystemPrompt, messages)
+	answer, err := s.llmClient.CompleteWithMessages(ctx, systemPrompt, messages)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			slog.Info("ask: client disconnected during synthesis", "error", err)
@@ -236,7 +301,11 @@ func (s *Server) synthesize(ctx context.Context, w http.ResponseWriter, flusher 
 // buildAskMessages assembles the multi-turn prompt for Stage 3: a
 // [관측된 사실] section built from result.Observed, an optional
 // [추론 — 가설이며 사실로 인용 불가] section built from result.Inferred, and the
-// user's raw question as the final turn.
+// user's raw question as the final turn. Each document line includes its
+// occurred_at (formatOccurredAt, KST, "시각 정보 없음" when nil) so the model
+// can reason about when the document's content happened, not just what it
+// says — the second half of the date-context fix (see buildAskSystemPrompt
+// for the first half, "what day is today").
 func buildAskMessages(question string, result RetrievalResult) []llm.Message {
 	var b strings.Builder
 	b.WriteString("[관측된 사실]\n")
@@ -244,12 +313,12 @@ func buildAskMessages(question string, result RetrievalResult) []llm.Message {
 		b.WriteString("(없음)\n")
 	}
 	for _, r := range result.Observed {
-		fmt.Fprintf(&b, "- (%s) %s: %s\n", r.Document.SourceType, r.Document.Title, r.Document.Content)
+		fmt.Fprintf(&b, "- (%s) %s [발생: %s]: %s\n", r.Document.SourceType, r.Document.Title, formatOccurredAt(r.Document.OccurredAt), r.Document.Content)
 	}
 	if len(result.Inferred) > 0 {
 		b.WriteString("\n[추론 — 가설이며 사실로 인용 불가]\n")
 		for _, r := range result.Inferred {
-			fmt.Fprintf(&b, "- (%s) %s: %s\n", r.Document.SourceType, r.Document.Title, r.Document.Content)
+			fmt.Fprintf(&b, "- (%s) %s [발생: %s]: %s\n", r.Document.SourceType, r.Document.Title, formatOccurredAt(r.Document.OccurredAt), r.Document.Content)
 		}
 	}
 

--- a/internal/api/ask_test.go
+++ b/internal/api/ask_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/baekenough/second-brain/internal/intent"
 	"github.com/baekenough/second-brain/internal/llm"
@@ -87,17 +88,28 @@ type fakeAskLLM struct {
 
 	streamCalls   int
 	completeCalls int
+
+	// gotSystemPrompt / gotMessages record the last synthesis call's
+	// arguments so tests can assert on buildAskSystemPrompt's injected-now
+	// output and buildAskMessages' occurred_at rendering without duplicating
+	// synthesize's plumbing (date-context fix, ask.go askSystemPrompt).
+	gotSystemPrompt string
+	gotMessages     []llm.Message
 }
 
 func (f *fakeAskLLM) Enabled() bool { return f.enabled }
 
-func (f *fakeAskLLM) CompleteWithMessages(_ context.Context, _ string, _ []llm.Message) (string, error) {
+func (f *fakeAskLLM) CompleteWithMessages(_ context.Context, systemPrompt string, messages []llm.Message) (string, error) {
 	f.completeCalls++
+	f.gotSystemPrompt = systemPrompt
+	f.gotMessages = messages
 	return f.completeResp, f.completeErr
 }
 
-func (f *fakeAskLLM) StreamWithMessages(ctx context.Context, _ string, _ []llm.Message, onDelta func(string)) error {
+func (f *fakeAskLLM) StreamWithMessages(ctx context.Context, systemPrompt string, messages []llm.Message, onDelta func(string)) error {
 	f.streamCalls++
+	f.gotSystemPrompt = systemPrompt
+	f.gotMessages = messages
 	if f.streamErr != nil {
 		return f.streamErr
 	}
@@ -137,6 +149,17 @@ func newAskTestServer(searcher documentSearcher, classifier intent.Classifier, l
 	svc := search.NewService(searcher, askDisabledEmbedder{})
 	srv := NewServer(nil, svc, nil, nil, llmClient, "", "test-key")
 	srv.intentClassifier = classifier
+	return srv
+}
+
+// newAskTestServerWithNow is newAskTestServer plus an injected clock,
+// mirroring intent.SetNow's role for LLMClassifier: it lets tests pin
+// buildAskSystemPrompt's "current time" instead of depending on the real
+// clock (date-context fix — see ask.go's askSystemPrompt doc comment for
+// the production bug this covers).
+func newAskTestServerWithNow(searcher documentSearcher, classifier intent.Classifier, llmClient llm.Completer, now func() time.Time) *Server {
+	srv := newAskTestServer(searcher, classifier, llmClient)
+	srv.now = now
 	return srv
 }
 
@@ -441,4 +464,118 @@ func mapKeys(m map[string]json.RawMessage) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// --- date-context fix tests (issue: "내일 일정" produced "현재 시점을 알 수 없다") ---
+
+// TestBuildAskSystemPrompt_IncludesInjectedNowDateAndWeekday asserts the
+// system prompt is no longer a compile-time constant blind to "now" — it
+// must render the injected current date, its Korean weekday, and an
+// explicit instruction to resolve relative expressions ("내일" etc.)
+// against that date.
+func TestBuildAskSystemPrompt_IncludesInjectedNowDateAndWeekday(t *testing.T) {
+	t.Parallel()
+	// 2026-08-18 03:00 UTC == 2026-08-18 12:00 KST (Tuesday/화).
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+
+	prompt := buildAskSystemPrompt(now)
+
+	if !strings.Contains(prompt, "2026-08-18") {
+		t.Errorf("prompt = %q, want it to contain the injected current date 2026-08-18", prompt)
+	}
+	if !strings.Contains(prompt, "화") {
+		t.Errorf("prompt = %q, want it to contain the Korean weekday 화 for 2026-08-18", prompt)
+	}
+	if !strings.Contains(prompt, "내일") {
+		t.Errorf("prompt = %q, want an instruction referencing relative date terms like 내일", prompt)
+	}
+}
+
+// TestBuildAskSystemPrompt_ConvertsToKST_NotServerLocal pins a UTC instant
+// whose calendar date differs from its KST calendar date (2026-08-17 20:00
+// UTC == 2026-08-18 05:00 KST) — the prompt must show the KST date, proving
+// the conversion is explicit and not dependent on the server's local
+// timezone (which may be UTC in a container).
+func TestBuildAskSystemPrompt_ConvertsToKST_NotServerLocal(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC)
+
+	prompt := buildAskSystemPrompt(now)
+
+	if !strings.Contains(prompt, "2026-08-18") {
+		t.Errorf("prompt = %q, want the KST date 2026-08-18 (not the UTC date 2026-08-17)", prompt)
+	}
+	if strings.Contains(prompt, "2026-08-17") {
+		t.Errorf("prompt = %q, must not contain the UTC calendar date 2026-08-17", prompt)
+	}
+}
+
+// TestAskHandler_SystemPromptReflectsInjectedNow is the end-to-end version:
+// it drives the full askHandler and asserts the system prompt actually
+// passed to the LLM client (not just buildAskSystemPrompt in isolation)
+// reflects the Server's injected clock.
+func TestAskHandler_SystemPromptReflectsInjectedNow(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}}
+	fixedNow := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC) // 2026-08-18 12:00 KST
+	srv := newAskTestServerWithNow(searcher, &fakeIntentClassifier{}, fakeLLM, func() time.Time { return fixedNow })
+
+	rr := doAskRequest(t, srv, nil, map[string]any{"question": "내일 일정 알려줘"}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(fakeLLM.gotSystemPrompt, "2026-08-18") {
+		t.Errorf("system prompt = %q, want it to contain the injected current date 2026-08-18", fakeLLM.gotSystemPrompt)
+	}
+}
+
+// TestBuildAskMessages_IncludesOccurredAt asserts each document context
+// line carries its occurred_at timestamp (converted to KST) so the model
+// can reason about when the document's content actually happened, not just
+// what it says.
+func TestBuildAskMessages_IncludesOccurredAt(t *testing.T) {
+	t.Parallel()
+	occurred := time.Date(2026, 6, 21, 5, 30, 0, 0, time.UTC) // 2026-06-21 14:30 KST
+	doc := model.Document{ID: uuid.New(), SourceType: model.SourceSMS, Title: "문자", Content: "내용", OccurredAt: &occurred}
+	result := RetrievalResult{Observed: []*model.SearchResult{{Document: doc, Score: 0.9}}}
+
+	messages := buildAskMessages("질문", result)
+
+	if len(messages) == 0 {
+		t.Fatal("buildAskMessages returned no messages")
+	}
+	contextMsg := messages[0].Content
+	if !strings.Contains(contextMsg, "2026-06-21") || !strings.Contains(contextMsg, "14:30") {
+		t.Errorf("context message = %q, want it to contain occurred_at converted to KST (2026-06-21 14:30)", contextMsg)
+	}
+}
+
+// TestBuildAskMessages_NilOccurredAt_NoPanicAndLabelled covers the
+// llm-memory-source case where OccurredAt is always null: buildAskMessages
+// must not panic on a nil *time.Time, and should render an explicit
+// "no timestamp" label rather than silently omitting the field (so the
+// model doesn't misinterpret absence as "same day as now").
+func TestBuildAskMessages_NilOccurredAt_NoPanicAndLabelled(t *testing.T) {
+	t.Parallel()
+	doc := model.Document{ID: uuid.New(), SourceType: model.SourceInsight, Title: "메모", Content: "내용", OccurredAt: nil}
+	result := RetrievalResult{Observed: []*model.SearchResult{{Document: doc, Score: 0.9}}}
+
+	var messages []llm.Message
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("buildAskMessages panicked on nil OccurredAt: %v", r)
+			}
+		}()
+		messages = buildAskMessages("질문", result)
+	}()
+
+	if len(messages) == 0 {
+		t.Fatal("buildAskMessages returned no messages")
+	}
+	if !strings.Contains(messages[0].Content, "시각 정보 없음") {
+		t.Errorf("context message = %q, want a null-occurred_at placeholder (\"시각 정보 없음\")", messages[0].Content)
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -117,6 +117,14 @@ type Server struct {
 	askTopK          int
 	askInsightM      int
 
+	// now is the clock buildAskSystemPrompt uses to render "current date" in
+	// the Stage 3 system prompt (date-context fix: askSystemPrompt used to
+	// be a compile-time const with no way to know "today", so the model
+	// could not resolve "내일"/"어제" and answered that it didn't know what
+	// day it was). nil means time.Now — mirrors intent.LLMClassifier.now's
+	// injected-clock convention for deterministic tests.
+	now func() time.Time
+
 	// piiNumberHashingEnabled mirrors cfg.PIINumberHashingEnabled (issue #164
 	// policy reversal). Zero value (false) is the new default and is used by
 	// both ingestMessagesHandler (smsmap.MapSMS/MapCall) and
@@ -180,6 +188,16 @@ func (s *Server) WithAskConfig(timeout time.Duration, topK, insightM int) *Serve
 		s.askInsightM = insightM
 	}
 	return s
+}
+
+// nowFunc returns s.now() if a clock was injected (tests), otherwise the
+// real time.Now. Used by askHandler to render buildAskSystemPrompt's
+// "current date" line.
+func (s *Server) nowFunc() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
 }
 
 // WithPIINumberHashing sets the phone-number hashing policy (issue #164;


### PR DESCRIPTION
## 재현된 버그
사용자가 "내일 일정"을 물었더니 "현재 시점의 '내일'이 언제인지 특정할 수 없다"는 답변이 나옴.

## 원인 두 겹
1. `askSystemPrompt`가 컴파일 타임 상수라 현재 날짜가 들어갈 자리가 없었음
2. `buildAskMessages`가 문서의 `occurred_at`을 프롬프트에 싣지 않았음

즉 모델은 오늘이 며칠인지도, 각 문서가 언제 일어난 일인지도 몰랐음.

## 수정 내용
- 시스템 프롬프트를 `buildAskSystemPrompt(now)` 함수로 전환하고 **KST 기준 현재 시각·요일**을 명시
- 각 문서 줄에 `[발생: ...]` 추가. `occurred_at`이 null이면 생략하지 않고 "시각 정보 없음"으로 표기 (생략 시 모델이 최근 문서로 오해할 위험 방지 — llm-memory 19,885건이 전량 null)
- 시간대는 `Asia/Seoul`을 명시 로드(운영 이미지에 tzdata 포함 확인), 서버 로컬(UTC) 미사용. **자정 경계 회귀 테스트** 포함(UTC 08-17 20:00 → KST 08-18 표시 검증)
- `now` 주입 패턴은 기존 `internal/intent.LLMClassifier`와 동일하게 맞춤
- 신규 테스트 5개, 전체 회귀 없음

## 변경 파일
- `internal/api/ask.go`
- `internal/api/ask_test.go`
- `internal/api/router.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)