### PR TITLE
feat: 멀티턴 채팅 지원 - Ask 대화 이력 저장 및 채팅 UI

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,6 +66,7 @@ func run() error {
 	metricsStore := store.NewEvalMetricsStore(pg)       // issue #19: eval metrics history
 	reindexStateStore := store.NewReindexStateStore(pg) // issue #20: reindex state tracking
 	entityStore := store.NewEntityStore(pg)             // issue #77: knowledge-graph entities
+	askSessionStore := store.NewAskSessionStore(pg)     // multi-turn /ask conversation history
 
 	// --- Embedding engine ---
 	embedClient, err := search.NewEmbeddingEngine(cfg)
@@ -122,7 +123,8 @@ func run() error {
 		WithIngestMessages(docStore, chunkStore, embedClient, cfg.IngestMaxBatchMessages, cfg.CollectorCutover).
 		WithIngestRecording(docStore, cfg.IngestRecordingDir, cfg.IngestMaxFileBytes, cfg.CollectorCutover).
 		WithNotes(docStore, chunkStore, embedClient).
-		WithAskConfig(time.Duration(cfg.AskTimeoutSeconds)*time.Second, cfg.AskContextTopK, cfg.AskContextInsightM)
+		WithAskConfig(time.Duration(cfg.AskTimeoutSeconds)*time.Second, cfg.AskContextTopK, cfg.AskContextInsightM).
+		WithAskSessions(askSessionStore)
 	httpServer := &http.Server{
 		Addr:         ":" + cfg.Port,
 		Handler:      srv.Handler(),

--- a/internal/api/ask.go
+++ b/internal/api/ask.go
@@ -15,9 +15,12 @@ import (
 	"github.com/baekenough/second-brain/internal/model"
 )
 
-// AskRequest is the JSON body accepted by POST /api/v1/ask.
+// AskRequest is the JSON body accepted by POST /api/v1/ask. ConversationID
+// is optional: omitted (or an unparsable value) starts a brand-new
+// conversation with a server-generated id — see resolveConversation.
 type AskRequest struct {
-	Question string `json:"question"`
+	Question       string `json:"question"`
+	ConversationID string `json:"conversation_id,omitempty"`
 }
 
 // AskSourceItem mirrors web/src/lib/types.ts:122-127 EXACTLY — field names
@@ -30,6 +33,20 @@ type AskSourceItem struct {
 	Title      string  `json:"title"`
 	SourceType string  `json:"source_type"`
 	Score      float64 `json:"score"`
+}
+
+// askConversationPayload is the "conversation" SSE event body. It is sent
+// once, before "sources", so the client can learn the conversation_id for
+// a brand-new conversation (or have the requested one echoed back) and the
+// 0-based turn_index of the turn currently being answered — both needed to
+// pass conversation_id back on the client's next follow-up request. This
+// event was added after the frontend shipped; parseAskEvent
+// (web/src/lib/sseEvents.ts) returns null for unrecognized event names and
+// the caller ignores nulls, so adding it here does not break the deployed
+// frontend (frontend wiring to actually use it is separate work).
+type askConversationPayload struct {
+	ConversationID string `json:"conversation_id"`
+	TurnIndex      int    `json:"turn_index"`
 }
 
 // askSourcesPayload is the "sources" SSE event body (spec §5.1).
@@ -181,13 +198,37 @@ func (s *Server) askHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), s.askTimeout)
 	defer cancel()
 
+	// Multi-turn setup: resolve/mint the conversation id + this turn's
+	// index, and load capped recent history (question/answer text only —
+	// see askHistoryTurn). Emitted BEFORE "sources" so the client can learn
+	// conversation_id even if retrieval subsequently fails.
+	conversationID, turnIndex, history := s.resolveConversation(ctx, req.ConversationID)
+	if err := writeSSEEvent(w, flusher, "conversation", askConversationPayload{
+		ConversationID: conversationID.String(),
+		TurnIndex:      turnIndex,
+	}); err != nil {
+		slog.Error("ask: failed to write conversation event", "error", err)
+		return
+	}
+
+	// Query rewrite: a follow-up like "그거 더 자세히" carries no searchable
+	// content on its own, so Stage 1/2 must see a standalone question
+	// instead of the user's raw wording. No-op (returns req.Question
+	// unchanged) when this is the first turn of the conversation — see
+	// rewriteStandaloneQuestion's doc comment for the full fallback
+	// contract. The user's ORIGINAL question (req.Question), not this
+	// rewritten one, is what Stage 3 shows the model as the current turn
+	// (buildAskMessages) and what gets persisted (saveAskTurn) — the
+	// rewrite is a search-only artifact.
+	searchQuestion, _ := s.rewriteStandaloneQuestion(ctx, history, req.Question)
+
 	// Stage 1: intent classification. Classify's contract never returns a
 	// non-nil error in the shipped implementation, but the defensive
 	// fallback keeps this handler correct even against a future
 	// Classifier implementation that does fail (spec §4.4).
-	params, err := s.intentClassifier.Classify(ctx, req.Question)
+	params, err := s.intentClassifier.Classify(ctx, searchQuestion)
 	if err != nil {
-		params = intent.Params{RawQuery: req.Question, Kind: intent.KindGeneral}
+		params = intent.Params{RawQuery: searchQuestion, Kind: intent.KindGeneral}
 	}
 
 	// Stage 2: retrieval assembly (원문/정리 vs 추론 layers, spec §5.3).
@@ -196,6 +237,10 @@ func (s *Server) askHandler(w http.ResponseWriter, r *http.Request) {
 		slog.Error("ask: retrieval failed", "error", err)
 		_ = writeSSEEvent(w, flusher, "error", askErrorPayload{Message: "retrieval failed"})
 		_ = writeSSEEvent(w, flusher, "done", askDonePayload{FinishReason: "error"})
+		// No turn is persisted here: this is a total-pipeline failure with
+		// no sources and no answer text — there is nothing worth replaying
+		// into a future turn's history, and persisting an empty/error stub
+		// would just consume a turn_index for no benefit.
 		return
 	}
 
@@ -214,20 +259,39 @@ func (s *Server) askHandler(w http.ResponseWriter, r *http.Request) {
 	// (spec §6.3). insight-only results never satisfy this check.
 	if len(result.Observed) == 0 {
 		_ = writeSSEEvent(w, flusher, "done", askDonePayload{FinishReason: "no_evidence"})
+		s.saveAskTurn(ctx, conversationID, turnIndex, req.Question, "", "no_evidence", sources)
 		return
 	}
 
-	// Stage 3: synthesis + streaming.
-	finishReason := s.synthesize(ctx, w, flusher, req.Question, result)
+	// Stage 3: synthesis + streaming. question passed here is the user's
+	// ORIGINAL wording (not searchQuestion) — see the rewrite comment above.
+	finishReason, answer := s.synthesize(ctx, w, flusher, req.Question, result, history)
 	if finishReason == "" {
 		// Sentinel for "client disconnected mid-stream" (context.Canceled):
 		// the connection is already gone, so attempting a final "done"
 		// write would be a doomed w.Write call. A server-side timeout
 		// (context.DeadlineExceeded) is NOT this case — synthesize already
 		// wrote an "error" event and returned "error" for that path.
+		//
+		// Still persist a partial turn when synthesize managed to stream at
+		// least one token before the disconnect: it is more useful to a
+		// same-conversation retry than nothing (the rewrite/synthesis
+		// stages for the NEXT turn can see how far the previous answer
+		// got), and no client is waiting on this write so it costs nothing
+		// to attempt. finish_reason "error" (not a new enum value) because
+		// the answer never legitimately completed. An empty partial answer
+		// (cancelled before the first token) is not worth a turn_index.
+		if answer != "" {
+			s.saveAskTurn(ctx, conversationID, turnIndex, req.Question, answer, "error", sources)
+		}
 		return
 	}
 	_ = writeSSEEvent(w, flusher, "done", askDonePayload{FinishReason: finishReason})
+	// Saved AFTER the client-visible "done" write so a slow/failing DB
+	// write never delays or breaks the response the client already has —
+	// saveAskTurn itself also swallows its own errors (see its doc
+	// comment), this ordering is the second half of that guarantee.
+	s.saveAskTurn(ctx, conversationID, turnIndex, req.Question, answer, finishReason, sources)
 }
 
 // mapAskSources converts search results into the wire-contract AskSourceItem
@@ -249,64 +313,92 @@ func mapAskSources(results []*model.SearchResult) []AskSourceItem {
 
 // synthesize is Stage 3. It writes "token" SSE events directly (streaming
 // side effect) as the LLM produces them, rather than returning the full
-// answer.
+// answer to the client — but it also accumulates that same text into the
+// answer return value so askHandler can persist it (saveAskTurn) without
+// synthesize needing to know anything about ask_sessions/persistence.
 //
-// Return value is the finish_reason to use for the "done" event, with one
+// finishReason is the value to use for the "done" event, with one
 // exception: an empty string is a sentinel meaning "the client disconnected
 // mid-stream (context.Canceled) — do not write a done event at all", since
 // askHandler cannot distinguish "stop" from "the caller already handled it"
-// any other way without an extra return value.
-func (s *Server) synthesize(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, question string, result RetrievalResult) string {
+// any other way without an extra return value. answer holds whatever text
+// was produced before that happened, which may be empty (disconnected
+// before the first token) or partial (disconnected mid-stream) — it is
+// never the empty string for finishReason "stop".
+func (s *Server) synthesize(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, question string, result RetrievalResult, history []askHistoryTurn) (finishReason, answer string) {
 	if !s.llmClient.Enabled() {
 		_ = writeSSEEvent(w, flusher, "error", askErrorPayload{Message: "LLM is not configured"})
-		return "error"
+		return "error", ""
 	}
 
-	messages := buildAskMessages(question, result)
+	messages := buildAskMessages(question, result, history)
 	systemPrompt := buildAskSystemPrompt(s.nowFunc())
 
 	if sc, ok := s.llmClient.(llm.StreamCompleter); ok {
+		var answerBuilder strings.Builder
 		err := sc.StreamWithMessages(ctx, systemPrompt, messages, func(delta string) {
+			answerBuilder.WriteString(delta)
 			_ = writeSSEEvent(w, flusher, "token", askTokenPayload{Text: delta})
 		})
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				slog.Info("ask: client disconnected during synthesis", "error", err)
-				return ""
+				return "", answerBuilder.String()
 			}
 			slog.Error("ask: streaming synthesis failed", "error", err)
 			_ = writeSSEEvent(w, flusher, "error", askErrorPayload{Message: "synthesis failed"})
-			return "error"
+			return "error", answerBuilder.String()
 		}
-		return "stop"
+		return "stop", answerBuilder.String()
 	}
 
 	// Fallback for a Completer that does not implement StreamCompleter
 	// (e.g. a test fake, or a future non-streaming-only backend): emit the
 	// full answer as a single "token" event.
-	answer, err := s.llmClient.CompleteWithMessages(ctx, systemPrompt, messages)
+	full, err := s.llmClient.CompleteWithMessages(ctx, systemPrompt, messages)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			slog.Info("ask: client disconnected during synthesis", "error", err)
-			return ""
+			return "", ""
 		}
 		slog.Error("ask: synthesis failed", "error", err)
 		_ = writeSSEEvent(w, flusher, "error", askErrorPayload{Message: "synthesis failed"})
-		return "error"
+		return "error", ""
 	}
-	_ = writeSSEEvent(w, flusher, "token", askTokenPayload{Text: answer})
-	return "stop"
+	_ = writeSSEEvent(w, flusher, "token", askTokenPayload{Text: full})
+	return "stop", full
 }
 
-// buildAskMessages assembles the multi-turn prompt for Stage 3: a
-// [관측된 사실] section built from result.Observed, an optional
+// buildAskMessages assembles the multi-turn prompt for Stage 3.
+//
+// history (askHistoryTurn: question/answer TEXT only, capped at
+// askMaxHistoryTurns) is replayed FIRST as genuine alternating
+// user/assistant turns, exactly as the LLM originally produced/received
+// them. It deliberately carries no source-document content — evidence for
+// a previous turn already shaped that turn's answer text, and re-attaching
+// its full document bodies here would both (a) duplicate information the
+// model already has via the answer text and (b) make prompt size grow with
+// total conversation evidence rather than just conversation length. This
+// is the single reviewer-visible guarantee behind requirement (c) of the
+// multi-turn ask feature: no prior turn's document body is ever replayed.
+//
+// After history, the CURRENT turn is appended as: a [관측된 사실] section
+// built from result.Observed, an optional
 // [추론 — 가설이며 사실로 인용 불가] section built from result.Inferred, and the
 // user's raw question as the final turn. Each document line includes its
 // occurred_at (formatOccurredAt, KST, "시각 정보 없음" when nil) so the model
 // can reason about when the document's content happened, not just what it
 // says — the second half of the date-context fix (see buildAskSystemPrompt
 // for the first half, "what day is today").
-func buildAskMessages(question string, result RetrievalResult) []llm.Message {
+func buildAskMessages(question string, result RetrievalResult, history []askHistoryTurn) []llm.Message {
+	messages := make([]llm.Message, 0, len(history)*2+2)
+	for _, h := range history {
+		messages = append(messages,
+			llm.Message{Role: "user", Content: h.Question},
+			llm.Message{Role: "assistant", Content: h.Answer},
+		)
+	}
+
 	var b strings.Builder
 	b.WriteString("[관측된 사실]\n")
 	if len(result.Observed) == 0 {
@@ -322,8 +414,9 @@ func buildAskMessages(question string, result RetrievalResult) []llm.Message {
 		}
 	}
 
-	return []llm.Message{
-		{Role: "user", Content: b.String()},
-		{Role: "user", Content: question},
-	}
+	messages = append(messages,
+		llm.Message{Role: "user", Content: b.String()},
+		llm.Message{Role: "user", Content: question},
+	)
+	return messages
 }

--- a/internal/api/ask_conversations.go
+++ b/internal/api/ask_conversations.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// AskConversationStore is the subset of *store.AskSessionStore used by the
+// multi-turn ask pipeline: persisting each turn (askHandler via
+// saveAskTurn, ask_history.go) and serving the two read-only
+// conversation-browsing routes below. Kept narrow — mirroring
+// DocumentStore/FeedbackRecorder's existing interface-per-need convention
+// in this package — so tests can inject an in-memory fake instead of a
+// real Postgres-backed *store.AskSessionStore.
+type AskConversationStore interface {
+	Insert(ctx context.Context, session store.AskSession) (store.AskSession, error)
+	ListConversationTurns(ctx context.Context, conversationID uuid.UUID) ([]store.AskSession, error)
+	ListRecentConversations(ctx context.Context, limit int) ([]store.AskSession, error)
+}
+
+// defaultAskConversationsLimit mirrors AskSessionStore.ListRecentConversations'
+// own internal default (store/ask_sessions.go) — kept in sync here so an
+// omitted/invalid ?limit query param on GET /api/v1/ask/conversations
+// behaves identically to calling the store method with limit<=0 directly.
+const defaultAskConversationsLimit = 50
+
+// WithAskSessions enables conversation persistence for POST /api/v1/ask
+// (turn history + query rewrite, ask_history.go) and registers
+// GET /api/v1/ask/conversations and GET /api/v1/ask/conversations/{id}.
+// Optional — a Server that never calls this still serves /api/v1/ask, just
+// without cross-request memory: every request behaves like the first turn
+// of a brand-new conversation (see resolveConversation), and the two GET
+// routes are not registered at all (mirrors how WithNotes/WithIngestFile
+// gate their own optional routes in router.go).
+func (s *Server) WithAskSessions(sessions AskConversationStore) *Server {
+	s.askSessions = sessions
+	return s
+}
+
+// askConversationSummary is one element of the GET /api/v1/ask/conversations
+// response body: the latest turn of a conversation, letting the client
+// render a title (question) and preview without a second round-trip per
+// conversation.
+type askConversationSummary struct {
+	ConversationID string    `json:"conversation_id"`
+	TurnIndex      int       `json:"turn_index"`
+	Question       string    `json:"question"`
+	Answer         string    `json:"answer"`
+	FinishReason   string    `json:"finish_reason"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+// askConversationTurn is one element of the
+// GET /api/v1/ask/conversations/{id} response body: a full turn, including
+// its sources (unlike askConversationSummary, which omits them — the list
+// view does not need per-conversation evidence, only the detail view does).
+type askConversationTurn struct {
+	ID           string          `json:"id"`
+	TurnIndex    int             `json:"turn_index"`
+	Question     string          `json:"question"`
+	Answer       string          `json:"answer"`
+	FinishReason string          `json:"finish_reason"`
+	Sources      []AskSourceItem `json:"sources"`
+	CreatedAt    time.Time       `json:"created_at"`
+}
+
+func toAskConversationSummary(session store.AskSession) askConversationSummary {
+	return askConversationSummary{
+		ConversationID: session.ConversationID.String(),
+		TurnIndex:      session.TurnIndex,
+		Question:       session.Question,
+		Answer:         session.Answer,
+		FinishReason:   session.FinishReason,
+		CreatedAt:      session.CreatedAt,
+	}
+}
+
+func toAskConversationTurn(session store.AskSession) askConversationTurn {
+	return askConversationTurn{
+		ID:           session.ID.String(),
+		TurnIndex:    session.TurnIndex,
+		Question:     session.Question,
+		Answer:       session.Answer,
+		FinishReason: session.FinishReason,
+		Sources:      toAskSourceItems(session.Sources),
+		CreatedAt:    session.CreatedAt,
+	}
+}
+
+// toAskSourceItems converts store.AskSource (persistence shape) to
+// AskSourceItem (wire shape) — the two are duplicated by design, see
+// store.AskSource's doc comment for why store cannot import internal/api.
+func toAskSourceItems(sources []store.AskSource) []AskSourceItem {
+	items := make([]AskSourceItem, 0, len(sources))
+	for _, src := range sources {
+		items = append(items, AskSourceItem{
+			ID: src.ID, Title: src.Title, SourceType: src.SourceType, Score: src.Score,
+		})
+	}
+	return items
+}
+
+// askConversationsHandler handles GET /api/v1/ask/conversations?limit=N:
+// the latest turn of each conversation, most recently active first. Only
+// registered when s.askSessions != nil (see WithAskSessions), so
+// s.askSessions is guaranteed non-nil inside this handler.
+func (s *Server) askConversationsHandler(w http.ResponseWriter, r *http.Request) {
+	limit := defaultAskConversationsLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			limit = n
+		}
+		// A non-numeric or <=0 limit is treated as "not provided" (falls
+		// back to the default) rather than a 400 — mirrors
+		// resolveConversation's "malformed input degrades gracefully"
+		// philosophy for this same handler family.
+	}
+
+	conversations, err := s.askSessions.ListRecentConversations(r.Context(), limit)
+	if err != nil {
+		slog.Error("ask: list recent conversations failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to list conversations")
+		return
+	}
+
+	out := make([]askConversationSummary, 0, len(conversations))
+	for _, c := range conversations {
+		out = append(out, toAskConversationSummary(c))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// askConversationDetailHandler handles GET /api/v1/ask/conversations/{id}:
+// every turn of one conversation, ordered turn_index ASC. Only registered
+// when s.askSessions != nil (see WithAskSessions).
+func (s *Server) askConversationDetailHandler(w http.ResponseWriter, r *http.Request) {
+	conversationID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid conversation id")
+		return
+	}
+
+	turns, err := s.askSessions.ListConversationTurns(r.Context(), conversationID)
+	if err != nil {
+		slog.Error("ask: list conversation turns failed", "error", err, "conversation_id", conversationID)
+		writeError(w, http.StatusInternalServerError, "failed to load conversation")
+		return
+	}
+	if len(turns) == 0 {
+		writeError(w, http.StatusNotFound, "conversation not found")
+		return
+	}
+
+	out := make([]askConversationTurn, 0, len(turns))
+	for _, t := range turns {
+		out = append(out, toAskConversationTurn(t))
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/ask_history.go
+++ b/internal/api/ask_history.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// askHistoryTurn is the trimmed-down shape of a previous conversation turn
+// replayed into the rewrite prompt (ask_rewrite.go) and the Stage 3
+// synthesis prompt (buildAskMessages). It deliberately carries only
+// question/answer TEXT — never Sources, FinishReason, or any other field
+// from store.AskSession — because those are the only two fields either
+// prompt is allowed to see (see buildAskMessages' doc comment for why
+// source-document bodies must never be replayed).
+type askHistoryTurn struct {
+	Question string
+	Answer   string
+}
+
+// askMaxHistoryTurns caps how many previous turns are replayed into both
+// the query-rewrite prompt and the Stage 3 synthesis prompt.
+//
+// Only question/answer TEXT is replayed (never source-document bodies —
+// see buildAskMessages), so even at this cap the added context grows with
+// conversation LENGTH, not with how much evidence backed each answer.
+// Still, an unbounded conversation would eventually dominate the prompt
+// budget and drown out the current turn's actual retrieved evidence, so a
+// cap is required regardless. 6 is a deliberately conservative starting
+// point: it keeps a realistic multi-topic follow-up chain fully coherent
+// (this spec's own follow-up examples — "그거 더 자세히", "그럼 그 사람은?" — are
+// 1-2 turns deep) while bounding worst-case prompt growth to a small,
+// predictable number of turns even for a long-running chat session. Raise
+// this only alongside an actual token-budget accounting pass, not casually
+// — see buildAskRewritePrompt/buildAskMessages for where this cap is spent.
+const askMaxHistoryTurns = 6
+
+// recentAskHistory trims turns (already ordered turn_index ASC, per
+// AskSessionStore.ListConversationTurns) down to the most recent max
+// entries and projects them to askHistoryTurn.
+func recentAskHistory(turns []store.AskSession, max int) []askHistoryTurn {
+	if max > 0 && len(turns) > max {
+		turns = turns[len(turns)-max:]
+	}
+	history := make([]askHistoryTurn, 0, len(turns))
+	for _, t := range turns {
+		history = append(history, askHistoryTurn{Question: t.Question, Answer: t.Answer})
+	}
+	return history
+}
+
+// resolveConversation determines the conversation_id/turn_index for this
+// /ask request and loads capped recent history for the rewrite/synthesis
+// stages.
+//
+//   - No conversation_id in the request, or one that fails to parse as a
+//     UUID: starts a brand-new conversation (fresh server-generated uuid,
+//     turn 0, no history). An unparsable id is treated identically to "none
+//     supplied" rather than rejected with a 400 — a stale/mistyped
+//     client-supplied id must not block the user from asking a question.
+//   - s.askSessions == nil (server not wired with conversation persistence):
+//     behaves like a fresh conversation on every call — turn_index is
+//     always 0 and history is always empty, since there is nowhere to read
+//     prior turns from. /ask still answers correctly in this configuration,
+//     just single-turn (no cross-request memory).
+//   - History fetch failure (DB error): logged and treated as "no history"
+//     rather than failing the whole request — this one request degrades to
+//     a single-turn answer instead of erroring out, matching the "재작성
+//     실패 시 원문으로 폴백" fail-open philosophy applied one layer up.
+func (s *Server) resolveConversation(ctx context.Context, requestedID string) (conversationID uuid.UUID, turnIndex int, history []askHistoryTurn) {
+	if requestedID != "" {
+		if parsed, err := uuid.Parse(requestedID); err == nil {
+			conversationID = parsed
+		}
+	}
+	if conversationID == uuid.Nil {
+		conversationID = uuid.New()
+	}
+	if s.askSessions == nil {
+		return conversationID, 0, nil
+	}
+
+	turns, err := s.askSessions.ListConversationTurns(ctx, conversationID)
+	if err != nil {
+		slog.Error("ask: failed to load conversation history, continuing single-turn",
+			"error", err, "conversation_id", conversationID)
+		return conversationID, 0, nil
+	}
+	return conversationID, len(turns), recentAskHistory(turns, askMaxHistoryTurns)
+}
+
+// saveAskTurn persists one conversation turn best-effort: a storage failure
+// is logged and swallowed, never surfaced to the client, because by the
+// time askHandler calls this the SSE stream has already delivered its
+// "done"/final event (or the connection is already gone) — there is no
+// remaining channel to report a save failure back to the caller through,
+// and failing the whole request over it would be strictly worse than an
+// answer the user already has but that simply isn't saved for next time.
+//
+// When ctx is already canceled/expired (client disconnected mid-stream,
+// server-side askTimeout hit), Insert is retried against a short-lived
+// detached context instead of the dead one — otherwise every disconnect
+// would also silently skip persistence, defeating the point of saving a
+// partial answer at all (see askHandler's finishReason=="" branch).
+func (s *Server) saveAskTurn(ctx context.Context, conversationID uuid.UUID, turnIndex int, question, answer, finishReason string, sources []AskSourceItem) {
+	if s.askSessions == nil {
+		return
+	}
+
+	saveCtx := ctx
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		saveCtx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+	}
+
+	storeSources := make([]store.AskSource, 0, len(sources))
+	for _, src := range sources {
+		storeSources = append(storeSources, store.AskSource{
+			ID: src.ID, Title: src.Title, SourceType: src.SourceType, Score: src.Score,
+		})
+	}
+
+	if _, err := s.askSessions.Insert(saveCtx, store.AskSession{
+		ConversationID: conversationID,
+		TurnIndex:      turnIndex,
+		Question:       question,
+		Answer:         answer,
+		FinishReason:   finishReason,
+		Sources:        storeSources,
+	}); err != nil {
+		slog.Error("ask: failed to save conversation turn",
+			"error", err, "conversation_id", conversationID, "turn_index", turnIndex)
+	}
+}

--- a/internal/api/ask_multiturn_test.go
+++ b/internal/api/ask_multiturn_test.go
@@ -1,0 +1,622 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// --- (a) first question skips rewrite ---
+
+// TestAskHandler_FirstTurn_SkipsRewrite covers requirement (a): a brand-new
+// conversation (no conversation_id, empty history) must not invoke the
+// rewrite LLM call at all — only the streaming synthesis call.
+func TestAskHandler_FirstTurn_SkipsRewrite(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{"question": "첫 질문입니다"}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if fakeLLM.completeCalls != 0 {
+		t.Errorf("CompleteWithMessages (rewrite) called %d times on the first turn, want 0", fakeLLM.completeCalls)
+	}
+	if len(searcher.gotQueries) == 0 || searcher.gotQueries[0] != "첫 질문입니다" {
+		t.Errorf("search query = %v, want the raw question unchanged (no history to rewrite from)", searcher.gotQueries)
+	}
+}
+
+// --- (b) follow-up searches the rewritten query ---
+
+// TestAskHandler_FollowUp_SearchesRewrittenQuery covers requirement (b): a
+// second turn in an existing conversation must classify/search using the
+// LLM's rewritten standalone question, not the user's raw follow-up
+// wording — and the rewrite call itself must be given the prior turn's
+// question/answer text.
+func TestAskHandler_FollowUp_SearchesRewrittenQuery(t *testing.T) {
+	t.Parallel()
+	conversationID := uuid.New()
+	sessions := newFakeAskSessionStore()
+	sessions.seed(conversationID, store.AskSession{
+		ID: uuid.New(), ConversationID: conversationID, TurnIndex: 0,
+		Question: "second-brain 프로젝트가 뭐야", Answer: "개인 지식 관리 백엔드 서비스입니다",
+		FinishReason: "stop",
+	})
+
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{
+		enabled:      true,
+		chunks:       []string{"답"},
+		completeResp: "second-brain 프로젝트의 아키텍처는 어떻게 되나요",
+	}
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{
+		"question":        "그거 더 자세히 알려줘",
+		"conversation_id": conversationID.String(),
+	}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if fakeLLM.completeCalls != 1 {
+		t.Fatalf("CompleteWithMessages (rewrite) called %d times, want exactly 1", fakeLLM.completeCalls)
+	}
+	if len(searcher.gotQueries) == 0 {
+		t.Fatal("searcher was never called")
+	}
+	for _, q := range searcher.gotQueries {
+		if q != fakeLLM.completeResp {
+			t.Errorf("search query = %q, want the rewritten question %q (not the raw follow-up)", q, fakeLLM.completeResp)
+		}
+	}
+
+	rewritePrompt := fakeLLM.completeMessagesLog[0]
+	if len(rewritePrompt) == 0 {
+		t.Fatal("rewrite call received no messages")
+	}
+	rewriteContent := rewritePrompt[0].Content
+	if !strings.Contains(rewriteContent, "second-brain 프로젝트가 뭐야") || !strings.Contains(rewriteContent, "개인 지식 관리 백엔드 서비스입니다") {
+		t.Errorf("rewrite prompt = %q, want it to include the previous turn's question and answer", rewriteContent)
+	}
+	if !strings.Contains(rewriteContent, "그거 더 자세히 알려줘") {
+		t.Errorf("rewrite prompt = %q, want it to include the current raw question", rewriteContent)
+	}
+}
+
+// TestAskHandler_FollowUp_SynthesisSeesOriginalQuestion asserts Stage 3
+// still shows the model the user's ORIGINAL wording as the current turn,
+// not the rewritten standalone question — only search/classification use
+// the rewrite (spec: "종합 단계에는 사용자의 원래 질문을 보여주세요").
+func TestAskHandler_FollowUp_SynthesisSeesOriginalQuestion(t *testing.T) {
+	t.Parallel()
+	conversationID := uuid.New()
+	sessions := newFakeAskSessionStore()
+	sessions.seed(conversationID, store.AskSession{
+		ID: uuid.New(), ConversationID: conversationID, TurnIndex: 0,
+		Question: "이전 질문", Answer: "이전 답변", FinishReason: "stop",
+	})
+
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}, completeResp: "재작성된 질문"}
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{
+		"question":        "원래 질문 그대로",
+		"conversation_id": conversationID.String(),
+	}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	// fakeLLM.gotMessages is overwritten last by the streaming synthesis
+	// call (rewrite uses CompleteWithMessages, synthesis uses
+	// StreamWithMessages), so at this point it reflects Stage 3 only.
+	lastMsg := fakeLLM.gotMessages[len(fakeLLM.gotMessages)-1]
+	if lastMsg.Content != "원래 질문 그대로" {
+		t.Errorf("synthesis final turn = %q, want the user's original wording %q (not the rewritten %q)",
+			lastMsg.Content, "원래 질문 그대로", fakeLLM.completeResp)
+	}
+}
+
+// --- (c) synthesis prompt excludes prior source-document bodies ---
+
+// TestAskHandler_SynthesisPrompt_ExcludesPriorSourceDocumentBodies covers
+// requirement (c): the previous turn's Sources (evidence documents) must
+// never be replayed into the Stage 3 prompt — only its question/answer
+// TEXT. A distinctive marker is planted only in the previous turn's stored
+// Sources (never in its Question/Answer), so its presence in the prompt
+// sent to the LLM would prove a leak.
+func TestAskHandler_SynthesisPrompt_ExcludesPriorSourceDocumentBodies(t *testing.T) {
+	t.Parallel()
+	const leakMarker = "이전턴근거문서제목마커12345"
+
+	conversationID := uuid.New()
+	sessions := newFakeAskSessionStore()
+	sessions.seed(conversationID, store.AskSession{
+		ID: uuid.New(), ConversationID: conversationID, TurnIndex: 0,
+		Question: "이전 질문 텍스트", Answer: "이전 답변 텍스트", FinishReason: "stop",
+		Sources: []store.AskSource{{ID: uuid.New().String(), Title: leakMarker, SourceType: "sms", Score: 0.9}},
+	})
+
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "새 문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}, completeResp: "재작성됨"}
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{
+		"question":        "후속 질문",
+		"conversation_id": conversationID.String(),
+	}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	var allContent strings.Builder
+	for _, m := range fakeLLM.gotMessages {
+		allContent.WriteString(m.Content)
+		allContent.WriteString("\n")
+	}
+	if strings.Contains(allContent.String(), leakMarker) {
+		t.Errorf("synthesis prompt leaked a prior turn's source-document title: %q\nfull prompt messages: %#v", leakMarker, fakeLLM.gotMessages)
+	}
+	if !strings.Contains(allContent.String(), "이전 질문 텍스트") || !strings.Contains(allContent.String(), "이전 답변 텍스트") {
+		t.Errorf("synthesis prompt is missing the previous turn's question/answer text entirely: %#v", fakeLLM.gotMessages)
+	}
+}
+
+// --- (d) save failure must not break the response ---
+
+// TestAskHandler_SaveFailure_DoesNotBreakResponse covers requirement (d):
+// an AskSessionStore.Insert failure must be logged and swallowed, never
+// surfaced to the client — the SSE event sequence must be identical to the
+// happy path.
+func TestAskHandler_SaveFailure_DoesNotBreakResponse(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"안녕", "하세요"}}
+	sessions := newFakeAskSessionStore()
+	sessions.insertErr = errors.New("db: connection reset")
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{"question": "질문"}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	frames := parseSSEFrames(t, rr.Body.String())
+	got := frameEvents(frames)
+	want := []string{"conversation", "sources", "token", "token", "done"}
+	if len(got) != len(want) {
+		t.Fatalf("events = %v, want %v (a store failure must not change the SSE sequence)", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("events[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	var doneP askDonePayload
+	if err := json.Unmarshal([]byte(frames[len(frames)-1].data), &doneP); err != nil {
+		t.Fatalf("unmarshal done payload: %v", err)
+	}
+	if doneP.FinishReason != "stop" {
+		t.Errorf("finish_reason = %q, want %q despite the store failure", doneP.FinishReason, "stop")
+	}
+	if len(sessions.insertCalls) != 1 {
+		t.Errorf("Insert was attempted %d times, want exactly 1 (it should still be attempted, just tolerated on failure)", len(sessions.insertCalls))
+	}
+}
+
+// --- (e) "conversation" event precedes "sources" ---
+
+// TestAskHandler_ConversationEventPrecedesSources covers requirement (e)
+// end-to-end (TestAskHandler_SSEFieldNames also checks this incidentally;
+// this test is the dedicated, explicitly-named assertion for it) and
+// additionally asserts the payload's conversation_id/turn_index values for
+// a brand-new conversation.
+func TestAskHandler_ConversationEventPrecedesSources(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{"question": "질문"}, "Bearer test-key")
+
+	frames := parseSSEFrames(t, rr.Body.String())
+	if len(frames) < 2 {
+		t.Fatalf("too few frames: %v", frameEvents(frames))
+	}
+	if frames[0].event != "conversation" {
+		t.Fatalf("frames[0].event = %q, want %q", frames[0].event, "conversation")
+	}
+	if frames[1].event != "sources" {
+		t.Fatalf("frames[1].event = %q, want %q", frames[1].event, "sources")
+	}
+
+	var payload askConversationPayload
+	if err := json.Unmarshal([]byte(frames[0].data), &payload); err != nil {
+		t.Fatalf("unmarshal conversation payload: %v", err)
+	}
+	if _, err := uuid.Parse(payload.ConversationID); err != nil {
+		t.Errorf("conversation_id = %q, not a valid uuid: %v", payload.ConversationID, err)
+	}
+	if payload.TurnIndex != 0 {
+		t.Errorf("turn_index = %d, want 0 for a brand-new conversation", payload.TurnIndex)
+	}
+}
+
+// --- conversation_id round-trip across two real requests ---
+
+// TestAskHandler_ConversationRoundTrip_TurnIndexIncrements drives two
+// sequential requests through the same in-memory session store: the first
+// creates a conversation, the second supplies its conversation_id back and
+// must be assigned turn_index 1 (not another turn_index 0).
+func TestAskHandler_ConversationRoundTrip_TurnIndexIncrements(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답1"}}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr1 := doAskRequest(t, srv, nil, map[string]any{"question": "첫 질문"}, "Bearer test-key")
+	frames1 := parseSSEFrames(t, rr1.Body.String())
+	var conv1 askConversationPayload
+	if err := json.Unmarshal([]byte(frames1[0].data), &conv1); err != nil {
+		t.Fatalf("unmarshal first conversation payload: %v", err)
+	}
+	if conv1.TurnIndex != 0 {
+		t.Fatalf("first turn_index = %d, want 0", conv1.TurnIndex)
+	}
+
+	fakeLLM.chunks = []string{"답2"}
+	rr2 := doAskRequest(t, srv, nil, map[string]any{
+		"question":        "두번째 질문",
+		"conversation_id": conv1.ConversationID,
+	}, "Bearer test-key")
+	frames2 := parseSSEFrames(t, rr2.Body.String())
+	var conv2 askConversationPayload
+	if err := json.Unmarshal([]byte(frames2[0].data), &conv2); err != nil {
+		t.Fatalf("unmarshal second conversation payload: %v", err)
+	}
+	if conv2.ConversationID != conv1.ConversationID {
+		t.Errorf("second conversation_id = %q, want it to match the first %q", conv2.ConversationID, conv1.ConversationID)
+	}
+	if conv2.TurnIndex != 1 {
+		t.Errorf("second turn_index = %d, want 1", conv2.TurnIndex)
+	}
+}
+
+// TestAskHandler_UnparsableConversationID_StartsFreshConversation asserts
+// an unparsable conversation_id degrades to "start a new conversation"
+// rather than a 400 — a stale/mistyped client-supplied id must not block
+// the user from asking a question.
+func TestAskHandler_UnparsableConversationID_StartsFreshConversation(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{
+		"question":        "질문",
+		"conversation_id": "not-a-uuid",
+	}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	frames := parseSSEFrames(t, rr.Body.String())
+	var payload askConversationPayload
+	if err := json.Unmarshal([]byte(frames[0].data), &payload); err != nil {
+		t.Fatalf("unmarshal conversation payload: %v", err)
+	}
+	if payload.ConversationID == "not-a-uuid" {
+		t.Errorf("conversation_id echoed back the unparsable client value instead of minting a new one")
+	}
+	if _, err := uuid.Parse(payload.ConversationID); err != nil {
+		t.Errorf("conversation_id = %q, not a valid uuid: %v", payload.ConversationID, err)
+	}
+	if payload.TurnIndex != 0 {
+		t.Errorf("turn_index = %d, want 0", payload.TurnIndex)
+	}
+}
+
+// --- no persistence wired: single-turn behaviour preserved ---
+
+// TestAskHandler_NoSessionsWired_StillAnswersSingleTurn asserts a Server
+// that never calls WithAskSessions still fully answers /ask (the
+// "conversation" event is still emitted with a fresh id every time,
+// turn_index is always 0, and no rewrite/save ever happens since there is
+// no history to read).
+func TestAskHandler_NoSessionsWired_StillAnswersSingleTurn(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}}
+	srv := newAskTestServer(searcher, &fakeIntentClassifier{}, fakeLLM) // no WithAskSessions
+
+	rr := doAskRequest(t, srv, nil, map[string]any{
+		"question":        "질문",
+		"conversation_id": uuid.New().String(),
+	}, "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	frames := parseSSEFrames(t, rr.Body.String())
+	var payload askConversationPayload
+	if err := json.Unmarshal([]byte(frames[0].data), &payload); err != nil {
+		t.Fatalf("unmarshal conversation payload: %v", err)
+	}
+	if payload.TurnIndex != 0 {
+		t.Errorf("turn_index = %d, want 0 (no persistence wired, so history can never be read back)", payload.TurnIndex)
+	}
+	if fakeLLM.completeCalls != 0 {
+		t.Errorf("rewrite (CompleteWithMessages) called %d times with no persistence wired, want 0", fakeLLM.completeCalls)
+	}
+}
+
+// --- cancel-mid-stream save decision ---
+
+// TestAskHandler_CanceledMidStream_SavesPartialAnswer covers the "decide
+// whether to persist a partial answer on client disconnect" requirement:
+// this project's chosen answer is YES when at least one token was streamed
+// before the disconnect, with finish_reason "error" (it never legitimately
+// completed).
+func TestAskHandler_CanceledMidStream_SavesPartialAnswer(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	ctx, cancel := context.WithCancel(context.Background())
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"부분", "답변"}, cancelAfter: 1, cancelFn: cancel}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	doAskRequest(t, srv, ctx, map[string]any{"question": "질문"}, "Bearer test-key")
+
+	if len(sessions.insertCalls) != 1 {
+		t.Fatalf("Insert called %d times, want exactly 1 (partial answer must still be saved)", len(sessions.insertCalls))
+	}
+	saved := sessions.insertCalls[0]
+	if saved.Answer != "부분" {
+		t.Errorf("saved answer = %q, want the partial text streamed before cancellation %q", saved.Answer, "부분")
+	}
+	if saved.FinishReason != "error" {
+		t.Errorf("saved finish_reason = %q, want %q (never legitimately completed)", saved.FinishReason, "error")
+	}
+}
+
+// TestAskHandler_CanceledBeforeFirstToken_DoesNotSave: when the connection
+// drops before any token was produced, there is no meaningful answer text
+// to persist — no Insert call should happen at all.
+func TestAskHandler_CanceledBeforeFirstToken_DoesNotSave(t *testing.T) {
+	t.Parallel()
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{docResult(model.SourceSMS, "문서")}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled before the handler even starts streaming
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"안 씀"}}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	doAskRequest(t, srv, ctx, map[string]any{"question": "질문"}, "Bearer test-key")
+
+	if len(sessions.insertCalls) != 0 {
+		t.Errorf("Insert called %d times, want 0 (no token was ever produced)", len(sessions.insertCalls))
+	}
+}
+
+// --- history cap ---
+
+// TestRecentAskHistory_CapsAtMax asserts recentAskHistory keeps only the
+// MOST RECENT askMaxHistoryTurns entries (oldest turns dropped first).
+func TestRecentAskHistory_CapsAtMax(t *testing.T) {
+	t.Parallel()
+	var turns []store.AskSession
+	for i := 0; i < askMaxHistoryTurns+3; i++ {
+		turns = append(turns, store.AskSession{
+			TurnIndex: i,
+			Question:  fmtTurnLabel("Q", i),
+			Answer:    fmtTurnLabel("A", i),
+		})
+	}
+
+	history := recentAskHistory(turns, askMaxHistoryTurns)
+
+	if len(history) != askMaxHistoryTurns {
+		t.Fatalf("len(history) = %d, want %d", len(history), askMaxHistoryTurns)
+	}
+	// The oldest 3 turns (index 0,1,2) must have been dropped; the kept
+	// window must start at turn index 3.
+	if history[0].Question != fmtTurnLabel("Q", 3) {
+		t.Errorf("history[0].Question = %q, want %q (oldest turns should be dropped first)", history[0].Question, fmtTurnLabel("Q", 3))
+	}
+	last := askMaxHistoryTurns + 2
+	if history[len(history)-1].Question != fmtTurnLabel("Q", last) {
+		t.Errorf("history[last].Question = %q, want %q", history[len(history)-1].Question, fmtTurnLabel("Q", last))
+	}
+}
+
+func fmtTurnLabel(prefix string, i int) string {
+	return prefix + "-" + strconv.Itoa(i)
+}
+
+// --- rewrite unit tests ---
+
+// TestRewriteStandaloneQuestion_NoHistory_SkipsRewrite is the unit-level
+// counterpart to TestAskHandler_FirstTurn_SkipsRewrite.
+func TestRewriteStandaloneQuestion_NoHistory_SkipsRewrite(t *testing.T) {
+	t.Parallel()
+	fakeLLM := &fakeAskLLM{enabled: true, completeResp: "무시되어야 함"}
+	srv := newAskTestServer(&fixedDocSearcher{}, &fakeIntentClassifier{}, fakeLLM)
+
+	got, ok := srv.rewriteStandaloneQuestion(context.Background(), nil, "원래 질문")
+
+	if ok {
+		t.Error("ok = true, want false (no history to rewrite from)")
+	}
+	if got != "원래 질문" {
+		t.Errorf("got = %q, want the original question unchanged", got)
+	}
+	if fakeLLM.completeCalls != 0 {
+		t.Errorf("CompleteWithMessages called %d times, want 0", fakeLLM.completeCalls)
+	}
+}
+
+// TestRewriteStandaloneQuestion_LLMError_FallsBackToOriginal asserts a
+// rewrite-call error degrades to the original question rather than failing.
+func TestRewriteStandaloneQuestion_LLMError_FallsBackToOriginal(t *testing.T) {
+	t.Parallel()
+	fakeLLM := &fakeAskLLM{enabled: true, completeErr: errors.New("llm: timeout")}
+	srv := newAskTestServer(&fixedDocSearcher{}, &fakeIntentClassifier{}, fakeLLM)
+	history := []askHistoryTurn{{Question: "이전 질문", Answer: "이전 답변"}}
+
+	got, ok := srv.rewriteStandaloneQuestion(context.Background(), history, "원래 질문")
+
+	if ok {
+		t.Error("ok = true, want false on rewrite error")
+	}
+	if got != "원래 질문" {
+		t.Errorf("got = %q, want the original question as fallback", got)
+	}
+}
+
+// TestRewriteStandaloneQuestion_EmptyResponse_FallsBackToOriginal asserts
+// an empty/whitespace-only rewrite response is treated as a failure, not a
+// literal empty search query.
+func TestRewriteStandaloneQuestion_EmptyResponse_FallsBackToOriginal(t *testing.T) {
+	t.Parallel()
+	fakeLLM := &fakeAskLLM{enabled: true, completeResp: "   "}
+	srv := newAskTestServer(&fixedDocSearcher{}, &fakeIntentClassifier{}, fakeLLM)
+	history := []askHistoryTurn{{Question: "이전 질문", Answer: "이전 답변"}}
+
+	got, ok := srv.rewriteStandaloneQuestion(context.Background(), history, "원래 질문")
+
+	if ok {
+		t.Error("ok = true, want false on empty rewrite response")
+	}
+	if got != "원래 질문" {
+		t.Errorf("got = %q, want the original question as fallback", got)
+	}
+}
+
+// --- GET /api/v1/ask/conversations ---
+
+func doAskGet(t *testing.T, srv *Server, path, authHeader string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+func TestAskConversationsHandler_ListsRecentConversations(t *testing.T) {
+	t.Parallel()
+	sessions := newFakeAskSessionStore()
+	conv1, conv2 := uuid.New(), uuid.New()
+	sessions.seed(conv1, store.AskSession{ID: uuid.New(), ConversationID: conv1, TurnIndex: 0, Question: "대화1", Answer: "답1", FinishReason: "stop"})
+	sessions.seed(conv2, store.AskSession{ID: uuid.New(), ConversationID: conv2, TurnIndex: 0, Question: "대화2", Answer: "답2", FinishReason: "stop"})
+	srv := newAskTestServerWithSessions(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}, sessions)
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations", "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var out []askConversationSummary
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2", len(out))
+	}
+}
+
+func TestAskConversationsHandler_RequiresAuth(t *testing.T) {
+	t.Parallel()
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}, sessions)
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations", "")
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestAskConversationsRoutes_NotRegisteredWithoutSessions(t *testing.T) {
+	t.Parallel()
+	srv := newAskTestServer(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}) // no WithAskSessions
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations", "Bearer test-key")
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (route must not be registered without WithAskSessions)", rr.Code)
+	}
+}
+
+func TestAskConversationDetailHandler_ReturnsTurnsInOrder(t *testing.T) {
+	t.Parallel()
+	sessions := newFakeAskSessionStore()
+	conv := uuid.New()
+	sessions.seed(conv,
+		store.AskSession{ID: uuid.New(), ConversationID: conv, TurnIndex: 0, Question: "Q0", Answer: "A0", FinishReason: "stop"},
+		store.AskSession{ID: uuid.New(), ConversationID: conv, TurnIndex: 1, Question: "Q1", Answer: "A1", FinishReason: "stop"},
+	)
+	srv := newAskTestServerWithSessions(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}, sessions)
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations/"+conv.String(), "Bearer test-key")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var out []askConversationTurn
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2", len(out))
+	}
+	if out[0].Question != "Q0" || out[1].Question != "Q1" {
+		t.Errorf("turns = %+v, want turn_index ASC order", out)
+	}
+}
+
+func TestAskConversationDetailHandler_UnknownID_Returns404(t *testing.T) {
+	t.Parallel()
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}, sessions)
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations/"+uuid.New().String(), "Bearer test-key")
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAskConversationDetailHandler_InvalidID_Returns400(t *testing.T) {
+	t.Parallel()
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}, sessions)
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations/not-a-uuid", "Bearer test-key")
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/api/ask_rewrite.go
+++ b/internal/api/ask_rewrite.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/baekenough/second-brain/internal/llm"
+)
+
+// askRewriteSystemPrompt instructs the model to compress a capped
+// conversation history plus the user's latest (possibly context-dependent)
+// question into ONE standalone question a document search can run against
+// without seeing any prior turn.
+//
+// This exists because retrieval (assembleRetrieval) and intent
+// classification (intent.Classify) only ever see a single question string
+// — a follow-up like "그거 더 자세히" or "그럼 그 사람은?" carries no
+// searchable content on its own, so it must be rewritten BEFORE it reaches
+// Stage 1/2. The rewritten text is used ONLY for search/classification;
+// Stage 3 synthesis still shows the model the user's original wording
+// (buildAskMessages' question param, sourced from req.Question in
+// askHandler) so the visible answer reads naturally, not as a restatement
+// of an artificially-expanded question.
+const askRewriteSystemPrompt = `당신은 대화형 검색 시스템의 질의 재작성기입니다. 아래 [이전 대화]와 사용자의 [현재 질문]을 보고, 이전 대화 없이도 독립적으로 이해되는 검색용 질문 하나를 작성하세요.
+
+규칙:
+1. 현재 질문이 가리키는 대상(대명사, 생략된 주어/목적어, "그거"/"그 사람"/"거기" 등)을 이전 대화에서 찾아 명시적으로 채워 넣으세요.
+2. 이전 대화에 없는 새로운 정보를 추가하거나 질문의 의도를 바꾸지 마세요. 압축·명확화만 하세요.
+3. 결과는 재작성된 질문 한 문장만 출력하세요. 설명, 따옴표, 접두사를 붙이지 마세요.`
+
+// buildAskRewritePrompt renders the user-turn content for the rewrite call:
+// the capped history (question/answer pairs, oldest first, matching
+// askMaxHistoryTurns) followed by the current question.
+func buildAskRewritePrompt(history []askHistoryTurn, question string) string {
+	var b strings.Builder
+	b.WriteString("[이전 대화]\n")
+	for i, h := range history {
+		fmt.Fprintf(&b, "Q%d: %s\nA%d: %s\n", i+1, h.Question, i+1, h.Answer)
+	}
+	fmt.Fprintf(&b, "\n[현재 질문]\n%s", question)
+	return b.String()
+}
+
+// rewriteStandaloneQuestion asks the LLM to compress history+question into
+// one standalone search query.
+//
+// Returns (question, false) unchanged — i.e. skips rewriting entirely —
+// whenever a rewrite cannot be trusted to be an improvement:
+//   - no history (nothing to resolve — this is the conversation's first
+//     turn; requirement (a) of the multi-turn ask feature)
+//   - the LLM is not configured (Enabled() == false)
+//   - the rewrite call errors
+//   - the model returns an empty/whitespace-only response
+//
+// This "fail open" contract means a rewrite failure can never make search
+// WORSE than not rewriting at all — the caller (askHandler) always has a
+// usable search query, and a rewrite error is logged but never surfaces to
+// the client (spec: "재작성 실패 시 원문으로 폴백. 에러로 전체를 죽이지 마세요").
+func (s *Server) rewriteStandaloneQuestion(ctx context.Context, history []askHistoryTurn, question string) (rewritten string, ok bool) {
+	if len(history) == 0 || !s.llmClient.Enabled() {
+		return question, false
+	}
+
+	prompt := buildAskRewritePrompt(history, question)
+	result, err := s.llmClient.CompleteWithMessages(ctx, askRewriteSystemPrompt, []llm.Message{
+		{Role: "user", Content: prompt},
+	})
+	if err != nil {
+		slog.Warn("ask: query rewrite failed, falling back to raw question", "error", err)
+		return question, false
+	}
+
+	result = strings.TrimSpace(result)
+	if result == "" {
+		slog.Warn("ask: query rewrite returned empty response, falling back to raw question")
+		return question, false
+	}
+	return result, true
+}

--- a/internal/api/ask_test.go
+++ b/internal/api/ask_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/model"
 	"github.com/baekenough/second-brain/internal/search"
+	"github.com/baekenough/second-brain/internal/store"
 	"github.com/google/uuid"
 )
 
@@ -28,9 +31,16 @@ type fixedDocSearcher struct {
 	observed []*model.SearchResult
 	inferred []*model.SearchResult
 	err      error
+
+	// gotQueries records every SearchQuery.Query this fake received, in
+	// call order — used by the query-rewrite tests to assert Stage 2 saw
+	// the rewritten (standalone) question, not the user's raw follow-up
+	// wording.
+	gotQueries []string
 }
 
 func (f *fixedDocSearcher) Search(_ context.Context, q model.SearchQuery) ([]*model.SearchResult, error) {
+	f.gotQueries = append(f.gotQueries, q.Query)
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -95,6 +105,13 @@ type fakeAskLLM struct {
 	// synthesize's plumbing (date-context fix, ask.go askSystemPrompt).
 	gotSystemPrompt string
 	gotMessages     []llm.Message
+
+	// completeMessagesLog records every CompleteWithMessages call's
+	// messages argument, in call order — unlike gotSystemPrompt/gotMessages
+	// (which the streaming synthesis call for the SAME request overwrites
+	// right after rewriteStandaloneQuestion runs), this lets rewrite tests
+	// inspect exactly what was sent to the rewrite call specifically.
+	completeMessagesLog [][]llm.Message
 }
 
 func (f *fakeAskLLM) Enabled() bool { return f.enabled }
@@ -103,6 +120,7 @@ func (f *fakeAskLLM) CompleteWithMessages(_ context.Context, systemPrompt string
 	f.completeCalls++
 	f.gotSystemPrompt = systemPrompt
 	f.gotMessages = messages
+	f.completeMessagesLog = append(f.completeMessagesLog, messages)
 	return f.completeResp, f.completeErr
 }
 
@@ -131,6 +149,76 @@ func (f *fakeAskLLM) StreamWithMessages(ctx context.Context, systemPrompt string
 }
 
 var _ llm.StreamCompleter = (*fakeAskLLM)(nil)
+
+// fakeAskSessionStore is an in-memory AskConversationStore fake — no real
+// DB needed to test askHandler's persistence/history behaviour. insertErr /
+// listErr, when non-nil, make every Insert / List* call fail respectively,
+// exercising askHandler's "a storage failure must never affect the client
+// response" contract.
+type fakeAskSessionStore struct {
+	mu        sync.Mutex
+	turnsByID map[uuid.UUID][]store.AskSession
+	insertErr error
+	listErr   error
+
+	insertCalls []store.AskSession
+}
+
+func newFakeAskSessionStore() *fakeAskSessionStore {
+	return &fakeAskSessionStore{turnsByID: map[uuid.UUID][]store.AskSession{}}
+}
+
+// seed pre-populates one conversation's turn history, as if earlier
+// requests had already been answered and saved.
+func (f *fakeAskSessionStore) seed(conversationID uuid.UUID, turns ...store.AskSession) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.turnsByID[conversationID] = append([]store.AskSession{}, turns...)
+}
+
+func (f *fakeAskSessionStore) Insert(_ context.Context, session store.AskSession) (store.AskSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.insertCalls = append(f.insertCalls, session)
+	if f.insertErr != nil {
+		return store.AskSession{}, f.insertErr
+	}
+	if session.ID == uuid.Nil {
+		session.ID = uuid.New()
+	}
+	session.CreatedAt = time.Now()
+	f.turnsByID[session.ConversationID] = append(f.turnsByID[session.ConversationID], session)
+	return session, nil
+}
+
+func (f *fakeAskSessionStore) ListConversationTurns(_ context.Context, conversationID uuid.UUID) ([]store.AskSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return append([]store.AskSession{}, f.turnsByID[conversationID]...), nil
+}
+
+func (f *fakeAskSessionStore) ListRecentConversations(_ context.Context, limit int) ([]store.AskSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var latest []store.AskSession
+	for _, turns := range f.turnsByID {
+		if len(turns) == 0 {
+			continue
+		}
+		latest = append(latest, turns[len(turns)-1])
+	}
+	sort.Slice(latest, func(i, j int) bool { return latest[i].CreatedAt.After(latest[j].CreatedAt) })
+	if limit > 0 && len(latest) > limit {
+		latest = latest[:limit]
+	}
+	return latest, nil
+}
 
 // --- helpers ---
 
@@ -161,6 +249,16 @@ func newAskTestServerWithNow(searcher documentSearcher, classifier intent.Classi
 	srv := newAskTestServer(searcher, classifier, llmClient)
 	srv.now = now
 	return srv
+}
+
+// newAskTestServerWithSessions is newAskTestServer plus conversation
+// persistence wired via WithAskSessions — the multi-turn (query rewrite +
+// turn history + save) tests use this instead of newAskTestServer, which
+// deliberately leaves askSessions nil (single-turn only, matching every
+// pre-existing ask_test.go test's behaviour unchanged).
+func newAskTestServerWithSessions(searcher documentSearcher, classifier intent.Classifier, llmClient llm.Completer, sessions AskConversationStore) *Server {
+	srv := newAskTestServer(searcher, classifier, llmClient)
+	return srv.WithAskSessions(sessions)
 }
 
 func doAskRequest(t *testing.T, srv *Server, ctx context.Context, body any, authHeader string) *httptest.ResponseRecorder {
@@ -259,7 +357,7 @@ func TestAskHandler_NoObservedResults_NoEvidenceNoLLMCall(t *testing.T) {
 	}
 	frames := parseSSEFrames(t, rr.Body.String())
 	got := frameEvents(frames)
-	want := []string{"sources", "done"}
+	want := []string{"conversation", "sources", "done"}
 	if len(got) != len(want) {
 		t.Fatalf("events = %v, want %v", got, want)
 	}
@@ -270,7 +368,7 @@ func TestAskHandler_NoObservedResults_NoEvidenceNoLLMCall(t *testing.T) {
 	}
 
 	var done askDonePayload
-	if err := json.Unmarshal([]byte(frames[1].data), &done); err != nil {
+	if err := json.Unmarshal([]byte(frames[2].data), &done); err != nil {
 		t.Fatalf("unmarshal done payload: %v", err)
 	}
 	if done.FinishReason != "no_evidence" {
@@ -309,7 +407,7 @@ func TestAskHandler_HappyPath_EventOrderAndSourceIDs(t *testing.T) {
 
 	frames := parseSSEFrames(t, rr.Body.String())
 	got := frameEvents(frames)
-	want := []string{"sources", "token", "token", "token", "done"}
+	want := []string{"conversation", "sources", "token", "token", "token", "done"}
 	if len(got) != len(want) {
 		t.Fatalf("events = %v, want %v; body=%s", got, want, rr.Body.String())
 	}
@@ -320,8 +418,8 @@ func TestAskHandler_HappyPath_EventOrderAndSourceIDs(t *testing.T) {
 	}
 
 	var sources askSourcesPayload
-	if err := json.Unmarshal([]byte(frames[0].data), &sources); err != nil {
-		t.Fatalf("unmarshal sources payload: %v; raw=%s", err, frames[0].data)
+	if err := json.Unmarshal([]byte(frames[1].data), &sources); err != nil {
+		t.Fatalf("unmarshal sources payload: %v; raw=%s", err, frames[1].data)
 	}
 	if len(sources.Sources) != 2 {
 		t.Fatalf("sources = %v, want 2 items (1 observed + 1 inferred)", sources.Sources)
@@ -334,7 +432,7 @@ func TestAskHandler_HappyPath_EventOrderAndSourceIDs(t *testing.T) {
 	}
 
 	var doneP askDonePayload
-	if err := json.Unmarshal([]byte(frames[4].data), &doneP); err != nil {
+	if err := json.Unmarshal([]byte(frames[5].data), &doneP); err != nil {
 		t.Fatalf("unmarshal done payload: %v", err)
 	}
 	if doneP.FinishReason != "stop" {
@@ -352,7 +450,7 @@ func TestAskHandler_LLMNotConfigured_EmitsErrorThenDoneError(t *testing.T) {
 
 	frames := parseSSEFrames(t, rr.Body.String())
 	got := frameEvents(frames)
-	want := []string{"sources", "error", "done"}
+	want := []string{"conversation", "sources", "error", "done"}
 	if len(got) != len(want) {
 		t.Fatalf("events = %v, want %v", got, want)
 	}
@@ -362,7 +460,7 @@ func TestAskHandler_LLMNotConfigured_EmitsErrorThenDoneError(t *testing.T) {
 		}
 	}
 	var doneP askDonePayload
-	_ = json.Unmarshal([]byte(frames[2].data), &doneP)
+	_ = json.Unmarshal([]byte(frames[3].data), &doneP)
 	if doneP.FinishReason != "error" {
 		t.Errorf("finish_reason = %q, want %q", doneP.FinishReason, "error")
 	}
@@ -381,12 +479,12 @@ func TestAskHandler_RetrievalError_EmitsErrorDoneNoSources(t *testing.T) {
 
 	frames := parseSSEFrames(t, rr.Body.String())
 	got := frameEvents(frames)
-	want := []string{"error", "done"}
+	want := []string{"conversation", "error", "done"}
 	if len(got) != len(want) {
 		t.Fatalf("events = %v, want %v (no sources event — search failed before sources could be computed)", got, want)
 	}
 	var doneP askDonePayload
-	_ = json.Unmarshal([]byte(frames[1].data), &doneP)
+	_ = json.Unmarshal([]byte(frames[2].data), &doneP)
 	if doneP.FinishReason != "error" {
 		t.Errorf("finish_reason = %q, want %q", doneP.FinishReason, "error")
 	}
@@ -403,9 +501,10 @@ func TestAskHandler_ClientDisconnectMidStream_NoFurtherWrites(t *testing.T) {
 
 	frames := parseSSEFrames(t, rr.Body.String())
 	got := frameEvents(frames)
-	// Exactly "sources" + the single token delivered before cancellation was
-	// observed; no "done" (connection is gone) and no further "token" frames.
-	want := []string{"sources", "token"}
+	// Exactly "conversation" + "sources" + the single token delivered
+	// before cancellation was observed; no "done" (connection is gone) and
+	// no further "token" frames.
+	want := []string{"conversation", "sources", "token"}
 	if len(got) != len(want) {
 		t.Fatalf("events = %v, want %v (no writes after client disconnect)", got, want)
 	}
@@ -428,10 +527,19 @@ func TestAskHandler_SSEFieldNames(t *testing.T) {
 
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(frames[0].data), &raw); err != nil {
+		t.Fatalf("conversation payload not valid JSON: %v", err)
+	}
+	for _, want := range []string{"conversation_id", "turn_index"} {
+		if _, ok := raw[want]; !ok {
+			t.Errorf("conversation payload missing key %q; raw=%s", want, frames[0].data)
+		}
+	}
+
+	if err := json.Unmarshal([]byte(frames[1].data), &raw); err != nil {
 		t.Fatalf("sources payload not valid JSON: %v", err)
 	}
 	if _, ok := raw["sources"]; !ok {
-		t.Fatalf("sources payload missing top-level %q key; raw=%s", "sources", frames[0].data)
+		t.Fatalf("sources payload missing top-level %q key; raw=%s", "sources", frames[1].data)
 	}
 	var items []map[string]json.RawMessage
 	if err := json.Unmarshal(raw["sources"], &items); err != nil {
@@ -443,14 +551,14 @@ func TestAskHandler_SSEFieldNames(t *testing.T) {
 		}
 	}
 
-	if err := json.Unmarshal([]byte(frames[1].data), &raw); err != nil {
+	if err := json.Unmarshal([]byte(frames[2].data), &raw); err != nil {
 		t.Fatalf("token payload not valid JSON: %v", err)
 	}
 	if _, ok := raw["text"]; !ok {
 		t.Errorf("token payload missing key %q", "text")
 	}
 
-	if err := json.Unmarshal([]byte(frames[2].data), &raw); err != nil {
+	if err := json.Unmarshal([]byte(frames[3].data), &raw); err != nil {
 		t.Fatalf("done payload not valid JSON: %v", err)
 	}
 	if _, ok := raw["finish_reason"]; !ok {
@@ -541,7 +649,7 @@ func TestBuildAskMessages_IncludesOccurredAt(t *testing.T) {
 	doc := model.Document{ID: uuid.New(), SourceType: model.SourceSMS, Title: "문자", Content: "내용", OccurredAt: &occurred}
 	result := RetrievalResult{Observed: []*model.SearchResult{{Document: doc, Score: 0.9}}}
 
-	messages := buildAskMessages("질문", result)
+	messages := buildAskMessages("질문", result, nil)
 
 	if len(messages) == 0 {
 		t.Fatal("buildAskMessages returned no messages")
@@ -569,7 +677,7 @@ func TestBuildAskMessages_NilOccurredAt_NoPanicAndLabelled(t *testing.T) {
 				t.Fatalf("buildAskMessages panicked on nil OccurredAt: %v", r)
 			}
 		}()
-		messages = buildAskMessages("질문", result)
+		messages = buildAskMessages("질문", result, nil)
 	}()
 
 	if len(messages) == 0 {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -117,6 +117,15 @@ type Server struct {
 	askTopK          int
 	askInsightM      int
 
+	// askSessions is optional. When non-nil, POST /api/v1/ask persists each
+	// turn and rewrites follow-up questions using prior turns (multi-turn
+	// conversations, ask_history.go), and GET /api/v1/ask/conversations +
+	// GET /api/v1/ask/conversations/{id} are registered. Set via
+	// WithAskSessions before calling Handler(). nil (the default) keeps
+	// /api/v1/ask fully functional but single-turn only — see
+	// resolveConversation.
+	askSessions AskConversationStore
+
 	// now is the clock buildAskSystemPrompt uses to render "current date" in
 	// the Stage 3 system prompt (date-context fix: askSystemPrompt used to
 	// be a compile-time const with no way to know "today", so the model
@@ -272,6 +281,10 @@ func (s *Server) buildHandler() http.Handler {
 		r.Post("/api/v1/feedback", s.feedbackHandler)
 
 		r.Post("/api/v1/ask", s.askHandler)
+		if s.askSessions != nil {
+			r.Get("/api/v1/ask/conversations", s.askConversationsHandler)
+			r.Get("/api/v1/ask/conversations/{id}", s.askConversationDetailHandler)
+		}
 
 		r.Handle("/api/v1/graphql", s.graphqlHandler())
 

--- a/internal/store/ask_sessions.go
+++ b/internal/store/ask_sessions.go
@@ -1,0 +1,222 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// AskSource mirrors internal/api.AskSourceItem's wire shape (id, title,
+// source_type, score) — that struct lives in internal/api, which this
+// package must not depend on (store is a lower layer than api), so the
+// shape is duplicated here rather than imported. Keep field names/JSON tags
+// in sync with internal/api/ask.go's AskSourceItem if either changes.
+type AskSource struct {
+	ID         string  `json:"id"`
+	Title      string  `json:"title"`
+	SourceType string  `json:"source_type"`
+	Score      float64 `json:"score"`
+}
+
+// AskSession represents one row in ask_sessions (migration 024): a single
+// turn (one question/answer exchange) within a multi-turn conversation,
+// persisted so a page refresh does not lose the answer. TurnIndex is 0-based
+// and unique within ConversationID (see migration 024's UNIQUE constraint).
+// There is deliberately no separate "conversations" table — the first turn's
+// Question doubles as the conversation's title (YAGNI; add one later if
+// conversation-level metadata becomes necessary).
+type AskSession struct {
+	ID             uuid.UUID
+	ConversationID uuid.UUID
+	TurnIndex      int
+	Question       string
+	Answer         string
+	FinishReason   string // "stop" | "error" | "no_evidence"
+	Sources        []AskSource
+	CreatedAt      time.Time
+}
+
+// AskSessionStore provides persistence for ask_sessions (migration 024).
+type AskSessionStore struct {
+	pg *Postgres
+}
+
+// NewAskSessionStore returns an AskSessionStore backed by the given Postgres instance.
+func NewAskSessionStore(pg *Postgres) *AskSessionStore {
+	return &AskSessionStore{pg: pg}
+}
+
+// Insert records one conversation turn and returns the persisted row with
+// id/created_at filled in from the database (id is DB-generated via
+// gen_random_uuid() when session.ID is uuid.Nil; a caller-supplied ID is
+// honored otherwise). The caller is responsible for supplying
+// ConversationID and TurnIndex — Insert does not compute the next turn
+// index itself, since the caller (the /ask handler) already knows the
+// conversation's current length from the request context.
+//
+// The UNIQUE(conversation_id, turn_index) constraint (migration 024)
+// surfaces as a plain error here if the caller races two writers for the
+// same turn; it is not treated as a special "ok, already inserted" case
+// because, unlike UpsertAction/UpsertEntityRelations, a turn collision
+// means a real logic error upstream (two answers claiming the same turn),
+// not a harmless re-observation.
+//
+// Sources defaults to an empty slice (never nil) before marshaling so the
+// stored JSONB is always a valid array, matching the column's
+// NOT NULL DEFAULT '[]'::jsonb.
+func (s *AskSessionStore) Insert(ctx context.Context, session AskSession) (AskSession, error) {
+	if session.Sources == nil {
+		session.Sources = []AskSource{}
+	}
+	sourcesJSON, err := json.Marshal(session.Sources)
+	if err != nil {
+		return AskSession{}, fmt.Errorf("ask session insert: marshal sources: %w", err)
+	}
+
+	const q = `
+		INSERT INTO ask_sessions (id, conversation_id, turn_index, question, answer, finish_reason, sources)
+		VALUES (COALESCE(NULLIF($1, '00000000-0000-0000-0000-000000000000'::uuid), gen_random_uuid()), $2, $3, $4, $5, $6, $7::jsonb)
+		RETURNING id, created_at`
+
+	row := s.pg.pool.QueryRow(ctx, q,
+		session.ID, session.ConversationID, session.TurnIndex,
+		session.Question, session.Answer, session.FinishReason, string(sourcesJSON),
+	)
+	if err := row.Scan(&session.ID, &session.CreatedAt); err != nil {
+		return AskSession{}, fmt.Errorf("ask session insert: %w", err)
+	}
+	return session, nil
+}
+
+// ListConversationTurns returns every turn of one conversation ordered by
+// turn_index ASC — used both to rebuild multi-turn LLM context (question 1,
+// answer 1, question 2, answer 2, ...) and to restore the /ask screen after
+// a page refresh.
+func (s *AskSessionStore) ListConversationTurns(ctx context.Context, conversationID uuid.UUID) ([]AskSession, error) {
+	const q = `
+		SELECT id, conversation_id, turn_index, question, answer, finish_reason, sources, created_at
+		FROM ask_sessions
+		WHERE conversation_id = $1
+		ORDER BY turn_index ASC`
+
+	rows, err := s.pg.pool.Query(ctx, q, conversationID)
+	if err != nil {
+		return nil, fmt.Errorf("ask session list conversation turns %s: %w", conversationID, err)
+	}
+	defer rows.Close()
+
+	var results []AskSession
+	for rows.Next() {
+		session, err := scanAskSession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("ask session list conversation turns scan: %w", err)
+		}
+		results = append(results, session)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ask session list conversation turns iter: %w", err)
+	}
+	return results, nil
+}
+
+// ListRecentConversations returns the latest turn of each conversation,
+// ordered by that turn's created_at DESC — the /ask screen's conversation
+// list view (one row per conversation, most recently active first).
+//
+// Implemented with DISTINCT ON (conversation_id) rather than a
+// ROW_NUMBER() window function: verified via EXPLAIN ANALYZE on real
+// Postgres (Mac mini prod, rolled back afterward) against migration 024's
+// indexes, with synthetic data (500 conversations x 10 turns = 5,003 rows).
+// Both plans do the same Seq Scan + Sort on (conversation_id, created_at
+// DESC) underneath; DISTINCT ON's planner cost was lower (475.12..475.24
+// vs 596.61..596.67) because Unique is a single pass over the sorted rows
+// with no per-row window-function bookkeeping, while WindowAgg materializes
+// a rn column before the outer filter discards all but rn=1. At this data
+// size actual execution time was statistically indistinguishable (1.96ms
+// DISTINCT ON vs 1.87ms window — within noise); DISTINCT ON was chosen for
+// its lower, more predictable cost estimate as conversation volume grows,
+// not for a measured speed win at this scale.
+func (s *AskSessionStore) ListRecentConversations(ctx context.Context, limit int) ([]AskSession, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+
+	const q = `
+		SELECT id, conversation_id, turn_index, question, answer, finish_reason, sources, created_at
+		FROM (
+			SELECT DISTINCT ON (conversation_id)
+				id, conversation_id, turn_index, question, answer, finish_reason, sources, created_at
+			FROM ask_sessions
+			ORDER BY conversation_id, created_at DESC
+		) latest_turn
+		ORDER BY created_at DESC
+		LIMIT $1`
+
+	rows, err := s.pg.pool.Query(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("ask session list recent conversations: %w", err)
+	}
+	defer rows.Close()
+
+	var results []AskSession
+	for rows.Next() {
+		session, err := scanAskSession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("ask session list recent conversations scan: %w", err)
+		}
+		results = append(results, session)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ask session list recent conversations iter: %w", err)
+	}
+	return results, nil
+}
+
+// Get retrieves a single ask session turn by id. Returns nil, nil when no
+// row matches — this is not an error condition (mirrors
+// EvalMetricsStore.Latest), leaving 404-vs-500 handling to the caller.
+func (s *AskSessionStore) Get(ctx context.Context, id uuid.UUID) (*AskSession, error) {
+	const q = `
+		SELECT id, conversation_id, turn_index, question, answer, finish_reason, sources, created_at
+		FROM ask_sessions
+		WHERE id = $1`
+
+	row := s.pg.pool.QueryRow(ctx, q, id)
+	session, err := scanAskSession(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("ask session get %s: %w", id, err)
+	}
+	return &session, nil
+}
+
+// --- scan helpers ---
+
+type askSessionScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAskSession(row askSessionScanner) (AskSession, error) {
+	var (
+		session     AskSession
+		sourcesJSON []byte
+	)
+	if err := row.Scan(
+		&session.ID, &session.ConversationID, &session.TurnIndex,
+		&session.Question, &session.Answer, &session.FinishReason,
+		&sourcesJSON, &session.CreatedAt,
+	); err != nil {
+		return AskSession{}, err
+	}
+	if err := json.Unmarshal(sourcesJSON, &session.Sources); err != nil {
+		return AskSession{}, fmt.Errorf("unmarshal sources: %w", err)
+	}
+	return session, nil
+}

--- a/migrations/024_ask_sessions.sql
+++ b/migrations/024_ask_sessions.sql
@@ -1,0 +1,59 @@
+-- Migration 024: ask_sessions (Ask 화면 멀티턴 대화 보존, Part D 피드백
+-- 루프의 토대).
+--
+-- Background: /ask 화면은 답변을 React state에만 보관했다 — 새로고침하면
+-- 사라진다(운영에서 발견된 리스크). 기존 feedback 테이블(migration 005)은
+-- 이미 session_id/query/document_id/chunk_id/thumbs 컬럼을 갖고 있어
+-- "대화 세션이 저장된다"를 전제하고 있었지만, 그 세션을 실제로 만드는
+-- 쪽이 없었다. 이 마이그레이션이 그 빈자리를 채운다.
+--
+-- Design: 한 행 = 한 대화(conversation_id)의 한 turn(turn_index, 0부터
+-- 시작). 여러 turn이 conversation_id로 묶여 멀티턴 대화를 이룬다.
+-- conversations라는 별도 테이블은 만들지 않는다 — 대화 제목/메타데이터가
+-- 아직 필요 없고, 첫 turn(turn_index = 0)의 question이 사실상 제목
+-- 역할을 한다(YAGNI). 필요해지면 그때 conversations 테이블을 추가하고
+-- ask_sessions.conversation_id에 FK를 건다.
+--
+-- UNIQUE(conversation_id, turn_index): 같은 대화 안에서 turn 순서가
+-- 중복/충돌하지 않도록 보장한다(동시 저장 레이스가 나도 DB가 막는다).
+--
+-- sources는 JSONB로 저장하고 documents/chunks에 FK를 걸지 않는다: 근거
+-- 문서가 나중에 삭제(mass-delete guard, hard delete 등)돼도 "그때 무엇을
+-- 근거로 답했는지"라는 이력은 보존되어야 한다. FK를 걸면 문서 삭제 시
+-- 이력이 깨지거나(RESTRICT) 조용히 유실된다(SET NULL/CASCADE 모두
+-- 부적절). 각 원소 형태: {"id": "<uuid>", "title": "...", "source_type":
+-- "...", "score": 0.0}.
+--
+-- feedback.session_id는 TEXT 타입이며(migration 005), 이제 ask_sessions
+-- .conversation_id(UUID)를 문자열로 담는 것이 자연스럽다 — 한 대화 = 한
+-- feedback 세션. ask_sessions.id(개별 turn의 PK)가 아니라
+-- conversation_id를 담아야 같은 대화의 여러 turn에서 나온 피드백이 하나의
+-- session_id로 묶인다. 여기서 FK를 걸지 않는 이유: 배포된 eval 시드
+-- feedback 행(50건)의 session_id 값이 UUID 형식이 아닐 수 있어 FK 제약을
+-- 추가하면 마이그레이션 자체가 실패할 위험이 있다(사전 확인 결과는
+-- store/ask_sessions.go 검증 로그 및 배포 노트를 참고). 애플리케이션
+-- 레벨에서 conversation_id를 session_id로 채우는 것으로 연결을 유지한다.
+--
+-- Additive only.
+
+CREATE TABLE IF NOT EXISTS ask_sessions (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id UUID        NOT NULL,
+    turn_index      INT         NOT NULL,
+    question        TEXT        NOT NULL,
+    answer          TEXT        NOT NULL,
+    finish_reason   TEXT        NOT NULL,             -- stop | error | no_evidence
+    sources         JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (conversation_id, turn_index)
+);
+
+-- Conversation restore (ListConversationTurns: turn_index ASC within one
+-- conversation_id) and the UNIQUE constraint above share this same column
+-- order, so this index also backs constraint enforcement.
+CREATE INDEX IF NOT EXISTS idx_ask_sessions_conversation_turn
+    ON ask_sessions (conversation_id, turn_index);
+
+-- Recent-conversations-list read pattern (ListRecentConversations: latest
+-- turn per conversation, DESC).
+CREATE INDEX IF NOT EXISTS idx_ask_sessions_created_at ON ask_sessions (created_at DESC);

--- a/web/src/app/api/ask/conversations/[id]/route.ts
+++ b/web/src/app/api/ask/conversations/[id]/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Ask conversation detail proxy — GET /api/ask/conversations/{id}
+ *
+ * Session-protected (web/src/proxy.ts catch-all). Forwards to the Go
+ * backend's GET /api/v1/ask/conversations/{id} using the server-held
+ * API_KEY, mirroring web/src/app/api/documents/[id]/route.ts's pattern.
+ * Returns every turn of one conversation ordered turn_index ASC, used to
+ * restore the /ask screen after a page refresh.
+ */
+import { type NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const { id } = await params;
+
+  const upstreamUrl = `${BACKEND_URL}/api/v1/ask/conversations/${encodeURIComponent(id)}`;
+
+  try {
+    const upstream = await fetch(upstreamUrl, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }),
+      },
+      cache: "no-store",
+    });
+    const data: unknown = await upstream.json().catch(() => ({}));
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Upstream request failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/web/src/app/api/ask/conversations/route.ts
+++ b/web/src/app/api/ask/conversations/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Ask conversations proxy — GET /api/ask/conversations?limit=N
+ *
+ * Session-protected (web/src/proxy.ts catch-all — this path is NOT under
+ * /api/v1/*, mirroring web/src/app/api/documents/route.ts's GET pattern).
+ * Forwards to the Go backend's GET /api/v1/ask/conversations using the
+ * server-held API_KEY, returning the latest turn of each conversation
+ * (most recently active first) for the /ask screen's recent-conversations
+ * list.
+ */
+import { type NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const limit = request.nextUrl.searchParams.get("limit");
+
+  const url = new URL(`${BACKEND_URL}/api/v1/ask/conversations`);
+  if (limit) url.searchParams.set("limit", limit);
+
+  try {
+    const upstream = await fetch(url.toString(), {
+      headers: {
+        "Content-Type": "application/json",
+        ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }),
+      },
+      cache: "no-store",
+    });
+    const data: unknown = await upstream.json().catch(() => ({}));
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Upstream request failed";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/web/src/app/ask/page.tsx
+++ b/web/src/app/ask/page.tsx
@@ -1,10 +1,35 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, Suspense } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { splitSSEBuffer, parseAskEvent } from "@/lib/sseEvents";
-import type { AskSourceItem } from "@/lib/types";
+import { listConversations, getConversation } from "@/lib/api";
+import type { AskSourceItem, AskConversationSummary } from "@/lib/types";
 import { getAskLayer, ASK_LAYER_LABELS } from "@/lib/constants";
 import { Button } from "@/components/ui";
+import { MarkdownContent } from "@/app/documents/[id]/MarkdownContent";
+
+type FinishReason = "stop" | "error" | "no_evidence";
+
+/** One rendered exchange: the user's question + the assistant's (possibly
+ * still-streaming) answer. Mirrors one row of ask_sessions (internal/store/
+ * ask_sessions.go's AskSession), plus local-only streaming/error state. */
+interface Turn {
+  turnIndex: number;
+  question: string;
+  answer: string;
+  sources: AskSourceItem[];
+  finishReason: FinishReason | null;
+  streaming: boolean;
+  error: string | null;
+}
+
+// How often accumulated "token" events are flushed into React state while a
+// turn is streaming. Re-parsing the full markdown answer on every single
+// token (which can arrive many times per second) would make the page
+// stutter; batching flushes to roughly this interval keeps the UI smooth
+// without a noticeably laggy typing effect.
+const STREAM_FLUSH_INTERVAL_MS = 80;
 
 function SourceCard({ source }: { source: AskSourceItem }) {
   const layer = getAskLayer(source.source_type);
@@ -25,24 +50,221 @@ function SourceCard({ source }: { source: AskSourceItem }) {
   );
 }
 
-export default function AskPage() {
+function UserBubble({ question }: { question: string }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[85%] rounded-2xl rounded-br-sm bg-accent px-4 py-2.5 text-sm text-white whitespace-pre-wrap">
+        {question}
+      </div>
+    </div>
+  );
+}
+
+function AssistantBubble({ turn }: { turn: Turn }) {
+  const showTyping = turn.streaming && !turn.answer;
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[90%] space-y-2">
+        <div className="rounded-2xl rounded-bl-sm border border-border bg-surface px-4 py-2.5">
+          {turn.answer && <MarkdownContent source={turn.answer} />}
+          {showTyping && (
+            <div className="flex items-center gap-1 py-1" aria-label="답변 생성 중">
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-foreground-subtle [animation-delay:-0.3s]" />
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-foreground-subtle [animation-delay:-0.15s]" />
+              <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-foreground-subtle" />
+            </div>
+          )}
+          {turn.finishReason === "no_evidence" && (
+            <p className="text-sm text-foreground-subtle">관련된 근거를 찾지 못했습니다.</p>
+          )}
+          {turn.error && <p className="text-sm text-danger">{turn.error}</p>}
+        </div>
+        {turn.sources.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {turn.sources.map((s) => (
+              <SourceCard key={s.id} source={s} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConversationSidebar({
+  conversations,
+  activeId,
+  onSelect,
+  onNew,
+}: {
+  conversations: AskConversationSummary[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+}) {
+  return (
+    <aside className="hidden w-64 shrink-0 flex-col gap-2 border-r border-border pr-3 lg:flex">
+      <Button type="button" variant="secondary" size="sm" onClick={onNew} className="justify-center">
+        + 새 대화
+      </Button>
+      <div className="flex-1 space-y-1 overflow-y-auto">
+        {conversations.length === 0 && (
+          <p className="px-2 py-4 text-center text-xs text-foreground-subtle">대화 기록이 없습니다</p>
+        )}
+        {conversations.map((c) => (
+          <button
+            key={c.conversation_id}
+            type="button"
+            onClick={() => onSelect(c.conversation_id)}
+            className={`block w-full truncate rounded-md px-2 py-2 text-left text-xs transition-colors ${
+              c.conversation_id === activeId
+                ? "bg-accent-subtle text-accent"
+                : "text-foreground-muted hover:bg-surface-subtle hover:text-foreground"
+            }`}
+          >
+            {c.question || "(제목 없음)"}
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function AskPageInner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const conversationParam = searchParams.get("c");
+
   const [question, setQuestion] = useState("");
-  const [answer, setAnswer] = useState("");
-  const [sources, setSources] = useState<AskSourceItem[]>([]);
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [conversations, setConversations] = useState<AskConversationSummary[]>([]);
   const [streaming, setStreaming] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState(false);
+
   const bufferRef = useRef("");
+  const pendingTextRef = useRef("");
+  const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Tracks the in-flight request so a new question (or unmount) can cancel
   // whatever stream is currently being read — without this, asking a
   // second question while the first is still streaming would leave both
-  // readers appending tokens into the same answer state concurrently.
+  // readers appending tokens into the same turn state concurrently.
   const abortControllerRef = useRef<AbortController | null>(null);
+  const scrollEndRef = useRef<HTMLDivElement | null>(null);
+
+  const loadConversations = useCallback(() => {
+    listConversations(20)
+      .then(setConversations)
+      .catch(() => setConversations([]));
+  }, []);
+
+  useEffect(() => {
+    loadConversations();
+  }, [loadConversations]);
+
+  // Restore a conversation from the URL (?c=<uuid>) on load or when the
+  // param changes externally (sidebar click updates it too, but that path
+  // sets local state directly — see selectConversation — so this effect
+  // mainly covers page load / back-forward navigation / a shared link).
+  useEffect(() => {
+    if (!conversationParam) {
+      setTurns([]);
+      setConversationId(null);
+      return;
+    }
+    if (conversationParam === conversationId) return;
+
+    let cancelled = false;
+    setRestoring(true);
+    getConversation(conversationParam)
+      .then((rows) => {
+        if (cancelled) return;
+        setConversationId(conversationParam);
+        setTurns(
+          rows.map((t) => ({
+            turnIndex: t.turn_index,
+            question: t.question,
+            answer: t.answer,
+            sources: t.sources ?? [],
+            finishReason: t.finish_reason,
+            streaming: false,
+            error: null,
+          })),
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Conversation no longer exists / failed to load — fall back to a
+        // fresh conversation rather than leaving the screen stuck.
+        setConversationId(null);
+        setTurns([]);
+      })
+      .finally(() => {
+        if (!cancelled) setRestoring(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationParam]);
+
+  useEffect(() => {
+    scrollEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [turns]);
 
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
+      if (flushTimerRef.current) clearInterval(flushTimerRef.current);
     };
   }, []);
+
+  function updateLastTurn(updater: (turn: Turn) => Turn) {
+    setTurns((prev) => {
+      if (prev.length === 0) return prev;
+      const next = [...prev];
+      const last = next[next.length - 1];
+      if (!last) return prev;
+      next[next.length - 1] = updater(last);
+      return next;
+    });
+  }
+
+  function startFlushTimer() {
+    if (flushTimerRef.current) return;
+    flushTimerRef.current = setInterval(() => {
+      if (!pendingTextRef.current) return;
+      const chunk = pendingTextRef.current;
+      pendingTextRef.current = "";
+      updateLastTurn((t) => ({ ...t, answer: t.answer + chunk }));
+    }, STREAM_FLUSH_INTERVAL_MS);
+  }
+
+  function stopFlushTimer() {
+    if (flushTimerRef.current) {
+      clearInterval(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    // Flush whatever is left so the final characters are not dropped.
+    if (pendingTextRef.current) {
+      const chunk = pendingTextRef.current;
+      pendingTextRef.current = "";
+      updateLastTurn((t) => ({ ...t, answer: t.answer + chunk }));
+    }
+  }
+
+  function selectConversation(id: string) {
+    if (streaming) abortControllerRef.current?.abort();
+    router.push(`${pathname}?c=${id}`, { scroll: false });
+  }
+
+  function startNewConversation() {
+    if (streaming) abortControllerRef.current?.abort();
+    setConversationId(null);
+    setTurns([]);
+    router.push(pathname, { scroll: false });
+  }
 
   async function handleAsk() {
     const trimmed = question.trim();
@@ -53,17 +275,33 @@ export default function AskPage() {
     const controller = new AbortController();
     abortControllerRef.current = controller;
 
-    setAnswer("");
-    setSources([]);
-    setError(null);
+    setQuestion("");
     setStreaming(true);
     bufferRef.current = "";
+    pendingTextRef.current = "";
+    startFlushTimer();
+
+    setTurns((prev) => [
+      ...prev,
+      {
+        turnIndex: prev.length,
+        question: trimmed,
+        answer: "",
+        sources: [],
+        finishReason: null,
+        streaming: true,
+        error: null,
+      },
+    ]);
 
     try {
       const res = await fetch("/api/ask", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: trimmed }),
+        body: JSON.stringify({
+          question: trimmed,
+          ...(conversationId && { conversation_id: conversationId }),
+        }),
         signal: controller.signal,
       });
 
@@ -86,11 +324,22 @@ export default function AskPage() {
         for (const raw of events) {
           const evt = parseAskEvent(raw);
           if (!evt) continue;
-          if (evt.type === "sources") setSources(evt.sources);
-          else if (evt.type === "token") setAnswer((prev) => prev + evt.text);
-          else if (evt.type === "error") setError(evt.message);
-          else if (evt.type === "done" && evt.finish_reason === "no_evidence") {
-            setError((prev) => prev ?? "관련된 근거를 찾지 못했습니다.");
+          if (evt.type === "conversation") {
+            setConversationId((prev) => {
+              if (prev === evt.conversation_id) return prev;
+              // First turn of a brand-new conversation: reflect its id in
+              // the URL so a refresh restores it (spec requirement).
+              router.replace(`${pathname}?c=${evt.conversation_id}`, { scroll: false });
+              return evt.conversation_id;
+            });
+          } else if (evt.type === "sources") {
+            updateLastTurn((t) => ({ ...t, sources: evt.sources }));
+          } else if (evt.type === "token") {
+            pendingTextRef.current += evt.text;
+          } else if (evt.type === "error") {
+            updateLastTurn((t) => ({ ...t, error: evt.message }));
+          } else if (evt.type === "done") {
+            updateLastTurn((t) => ({ ...t, finishReason: evt.finish_reason }));
           }
         }
       }
@@ -99,71 +348,97 @@ export default function AskPage() {
       // facing error — surfacing it would flash a confusing message every
       // time the user asks a follow-up before the previous answer finishes.
       if (e instanceof DOMException && e.name === "AbortError") return;
-      setError(e instanceof Error ? e.message : "답변 생성 중 오류가 발생했습니다.");
+      updateLastTurn((t) => ({
+        ...t,
+        error: e instanceof Error ? e.message : "답변 생성 중 오류가 발생했습니다.",
+      }));
     } finally {
+      stopFlushTimer();
       if (abortControllerRef.current === controller) {
         setStreaming(false);
+        updateLastTurn((t) => ({ ...t, streaming: false }));
         abortControllerRef.current = null;
+        loadConversations();
       }
     }
   }
 
-  return (
-    <div className="flex min-h-[calc(100vh-8rem)] flex-col">
-      {/* Answer + sources */}
-      <div className="flex-1 space-y-4 overflow-y-auto pb-24 sm:pb-4">
-        {sources.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {sources.map((s) => (
-              <SourceCard key={s.id} source={s} />
-            ))}
-          </div>
-        )}
-        {answer && (
-          <p className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">{answer}</p>
-        )}
-        {error && <p className="text-sm text-danger">{error}</p>}
-        {!answer && !error && !streaming && (
-          <p className="py-12 text-center text-sm text-foreground-subtle">
-            내 데이터에 질문해보세요
-          </p>
-        )}
-      </div>
+  const isEmpty = turns.length === 0 && !restoring;
 
-      {/* Input — mobile: fixed to the viewport bottom (spec §7.2's required
-          deviation). This app has a real prior incident with an element
-          fixed to the bottom edge overlapping content underneath it (a
-          save button hidden behind the tab bar on a past mobile release) —
-          the pb-24 on the scroll container above exists specifically to
-          reserve room for this bar so the same class of bug does not repeat
-          here. Desktop: inline, no fixed positioning needed. */}
-      <div className="fixed inset-x-0 bottom-0 border-t border-border bg-background px-4 py-3 sm:static sm:border-0 sm:bg-transparent sm:px-0 sm:py-0">
-        <div className="mx-auto flex max-w-4xl gap-2">
-          <input
-            type="text"
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                void handleAsk();
-              }
-            }}
-            placeholder="질문을 입력하세요…"
-            disabled={streaming}
-            className="flex-1 rounded-lg border border-border bg-surface px-3 py-2.5 text-sm text-foreground placeholder:text-foreground-subtle focus:ring-2 focus:ring-accent/40 focus:outline-none disabled:opacity-50"
-          />
-          <Button
-            type="button"
-            variant="primary"
-            onClick={() => void handleAsk()}
-            loading={streaming}
-            disabled={streaming || !question.trim()}
-          >
-            질문
-          </Button>
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] gap-4">
+      <ConversationSidebar
+        conversations={conversations}
+        activeId={conversationId}
+        onSelect={selectConversation}
+        onNew={startNewConversation}
+      />
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* Conversation */}
+        <div className="flex-1 space-y-4 overflow-y-auto pb-24 sm:pb-4">
+          {restoring && (
+            <p className="py-12 text-center text-sm text-foreground-subtle">
+              대화를 불러오는 중…
+            </p>
+          )}
+          {isEmpty && (
+            <p className="py-12 text-center text-sm text-foreground-subtle">
+              내 데이터에 질문해보세요
+            </p>
+          )}
+          {turns.map((turn) => (
+            <div key={turn.turnIndex} className="space-y-3">
+              <UserBubble question={turn.question} />
+              <AssistantBubble turn={turn} />
+            </div>
+          ))}
+          <div ref={scrollEndRef} />
+        </div>
+
+        {/* Input — mobile: fixed to the viewport bottom (spec §7.2's required
+            deviation). This app has a real prior incident with an element
+            fixed to the bottom edge overlapping content underneath it (a
+            save button hidden behind the tab bar on a past mobile release) —
+            the pb-24 on the scroll container above exists specifically to
+            reserve room for this bar so the same class of bug does not repeat
+            here. Desktop: inline, no fixed positioning needed. */}
+        <div className="fixed inset-x-0 bottom-0 border-t border-border bg-background px-4 py-3 sm:static sm:border-0 sm:bg-transparent sm:px-0 sm:py-0">
+          <div className="mx-auto flex max-w-4xl gap-2">
+            <input
+              type="text"
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  void handleAsk();
+                }
+              }}
+              placeholder="질문을 입력하세요…"
+              disabled={streaming}
+              className="min-h-[44px] flex-1 rounded-lg border border-border bg-surface px-3 py-2.5 text-sm text-foreground placeholder:text-foreground-subtle focus:ring-2 focus:ring-accent/40 focus:outline-none disabled:opacity-50"
+            />
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => void handleAsk()}
+              loading={streaming}
+              disabled={streaming || !question.trim()}
+            >
+              질문
+            </Button>
+          </div>
         </div>
       </div>
     </div>
+  );
+}
+
+export default function AskPage() {
+  return (
+    <Suspense>
+      <AskPageInner />
+    </Suspense>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,6 @@
 import type {
+  AskConversationSummary,
+  AskConversationTurn,
   BaselineStats,
   CreateNoteResponse,
   DocumentDetail,
@@ -163,6 +165,27 @@ export async function deleteNote(id: string): Promise<void> {
   await fetchJson<unknown>(`${getApiBase()}/notes/${encodeURIComponent(id)}`, {
     method: "DELETE",
   });
+}
+
+// ── Ask (conversations) ──────────────────────────────────────────────────
+//
+// Both helpers are client-only: they hit /api/ask/conversations[/:id], the
+// session-protected proxy pair (web/src/app/api/ask/conversations/*), not
+// the backend's /api/v1/ask/conversations directly. getApiBase()'s server
+// branch would prepend /api/v1, which does not exist under this proxy —
+// these are only ever called from "use client" components (the /ask page).
+
+export async function listConversations(limit = 20): Promise<AskConversationSummary[]> {
+  const res = await fetchJson<AskConversationSummary[]>(
+    `${getApiBase()}/ask/conversations?limit=${limit}`,
+  );
+  return res ?? [];
+}
+
+export async function getConversation(id: string): Promise<AskConversationTurn[]> {
+  return fetchJson<AskConversationTurn[]>(
+    `${getApiBase()}/ask/conversations/${encodeURIComponent(id)}`,
+  );
 }
 
 // ── File upload (Capture) ────────────────────────────────────────────────

--- a/web/src/lib/sseEvents.test.ts
+++ b/web/src/lib/sseEvents.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { splitSSEBuffer, parseAskEvent } from "./sseEvents";
 
+const CONVERSATION_EVENT =
+  'event: conversation\ndata: {"conversation_id":"c1","turn_index":0}\n\n';
 const SOURCES_EVENT =
   'event: sources\ndata: {"sources":[{"id":"a","title":"t","source_type":"sms","score":0.8}]}\n\n';
 const TOKEN_EVENT = 'event: token\ndata: {"text":"hello "}\n\n';
@@ -20,6 +22,11 @@ describe("splitSSEBuffer", () => {
     expect(events.map((e) => e.event)).toEqual(["sources", "token", "done"]);
   });
 
+  it("parses a conversation event ahead of the others", () => {
+    const { events } = splitSSEBuffer(CONVERSATION_EVENT + SOURCES_EVENT);
+    expect(events.map((e) => e.event)).toEqual(["conversation", "sources"]);
+  });
+
   it("holds back an incomplete trailing event across chunk boundaries", () => {
     // Simulates fetch's ReadableStream splitting mid-event — a byte
     // boundary that lands inside the DONE_EVENT, not at its edge.
@@ -37,6 +44,15 @@ describe("splitSSEBuffer", () => {
 });
 
 describe("parseAskEvent", () => {
+  it("parses a conversation event", () => {
+    const [raw] = splitSSEBuffer(CONVERSATION_EVENT).events;
+    expect(parseAskEvent(raw!)).toEqual({
+      type: "conversation",
+      conversation_id: "c1",
+      turn_index: 0,
+    });
+  });
+
   it("parses a sources event", () => {
     // Non-null assertion is safe: the "parses a single complete event" test
     // above already establishes that a well-formed event produces exactly

--- a/web/src/lib/sseEvents.ts
+++ b/web/src/lib/sseEvents.ts
@@ -42,6 +42,14 @@ export function splitSSEBuffer(buffer: string): { events: RawSSEEvent[]; remaind
 export function parseAskEvent(raw: RawSSEEvent): AskStreamEvent | null {
   try {
     switch (raw.event) {
+      case "conversation": {
+        const payload = JSON.parse(raw.data) as { conversation_id: string; turn_index: number };
+        return {
+          type: "conversation",
+          conversation_id: payload.conversation_id,
+          turn_index: payload.turn_index,
+        };
+      }
       case "sources": {
         const payload = JSON.parse(raw.data) as { sources: AskSourceItem[] };
         return { type: "sources", sources: payload.sources ?? [] };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -126,12 +126,40 @@ export interface AskSourceItem {
   score: number;
 }
 
-/** Parsed, typed form of the four /api/v1/ask SSE event types (spec §5.1). */
+/** Parsed, typed form of the five /api/v1/ask SSE event types (spec §5.1).
+ * "conversation" is always the first event of a stream — see
+ * internal/api/ask_conversations.go's askConversationPayload doc comment. */
 export type AskStreamEvent =
+  | { type: "conversation"; conversation_id: string; turn_index: number }
   | { type: "sources"; sources: AskSourceItem[] }
   | { type: "token"; text: string }
   | { type: "done"; finish_reason: "stop" | "error" | "no_evidence" }
   | { type: "error"; message: string };
+
+/** One element of GET /api/ask/conversations (backend:
+ * askConversationSummary, internal/api/ask_conversations.go) — the latest
+ * turn of a conversation, used to render the recent-conversations list. */
+export interface AskConversationSummary {
+  conversation_id: string;
+  turn_index: number;
+  question: string;
+  answer: string;
+  finish_reason: "stop" | "error" | "no_evidence";
+  created_at: string;
+}
+
+/** One element of GET /api/ask/conversations/{id} (backend:
+ * askConversationTurn, internal/api/ask_conversations.go) — a full turn
+ * including its sources, used to restore a conversation after a refresh. */
+export interface AskConversationTurn {
+  id: string;
+  turn_index: number;
+  question: string;
+  answer: string;
+  finish_reason: "stop" | "error" | "no_evidence";
+  sources: AskSourceItem[];
+  created_at: string;
+}
 
 /** Which of the three Ask-answer lanes (spec §5.2, §7.2) a source belongs to. */
 export type AskLayer = "note" | "observed" | "insight";


### PR DESCRIPTION
## 요약

새로고침 시 대화가 사라지는 문제(사용자가 "큰 리스크"로 지목), 채팅 인터페이스 부재, 마크다운/코드 미렌더링 3가지 문제를 해결합니다.

### DB / 저장 계층
- `ask_sessions(conversation_id, turn_index, ...)` 테이블 추가 — 한 행 = 한 turn, `UNIQUE(conversation_id, turn_index)`
- `sources`는 jsonb 스냅샷이며 **FK를 걸지 않음** — 근거 문서가 나중에 삭제되어도 "그때 무엇을 근거로 답했는지" 이력이 보존되어야 하기 때문
- 마이그레이션은 실제 DB `BEGIN`/`ROLLBACK`으로 검증 완료

### 질의 재작성 (query rewriting)
- 후속 질문("그거 더 자세히")을 그대로 검색하면 결과가 없으므로, 검색 전에 이전 대화를 참고해 독립형 질문으로 재작성
- 종합(synthesis) 단계에는 사용자의 원문 질문을 그대로 전달
- 첫 질문은 재작성 LLM 호출을 건너뜀

### 이력 관리
- 대화 이력은 최근 6턴까지만 참고
- 이전 turn의 **근거 문서 본문은 재전송하지 않음** (질문·답변 텍스트만 전달) — 토큰 폭증 방지

### 중단(cancel) 처리
- 스트리밍 중 토큰이 하나라도 생성된 상태에서 취소되면 `context.WithoutCancel` + 5초 타임아웃으로 부분 답변을 저장
  (취소된 컨텍스트로는 DB Insert가 실패하므로)

### SSE 이벤트
- `conversation` 이벤트를 신규 추가 (스트림에서 가장 먼저 전송)
- 기존 4종 이벤트 스키마는 무변경 — 프론트가 미지 이벤트를 무시하므로 하위 호환 유지

### 프론트엔드
- 기존 `MarkdownContent`(remark-gfm + rehype-highlight, rehype-raw 미사용)를 재사용 — 새 의존성 없음
- 스트리밍 중 토큰을 ref에 누적하고 80ms 주기로 flush하여 마크다운 재파싱 부하 제한
- 새로고침 복원: URL `?c=<conversation_id>` 반영 + 페이지 진입 시 대화 자동 복원

## 커밋 구성
1. `feat(db)` — migration + store 계층
2. `feat(api)` — 멀티턴 API, 질의 재작성, 대화 엔드포인트
3. `feat(web)` — 채팅 UI 재구성

## 테스트 계획
- [ ] CI 6개 잡 전부 통과 확인
- [ ] 새로고침 후 대화 복원 동작 확인 (배포 후)
- [ ] 후속 질문 재작성 동작 확인 (배포 후)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>