### PR TITLE
feat(telemetry): OpenTelemetry 계측 추가 (LLM, 임베딩, 전사)

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -22,9 +22,15 @@ import (
 	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/setup"
 	"github.com/baekenough/second-brain/internal/store"
+	"github.com/baekenough/second-brain/internal/telemetry"
 	"github.com/baekenough/second-brain/internal/worker"
 	"github.com/joho/godotenv"
 )
+
+// otelShutdownTimeout bounds how long the deferred telemetry shutdown may
+// block process exit. A dead/unreachable Langfuse collector must never
+// delay shutdown — see internal/telemetry's non-blocking guarantee.
+const otelShutdownTimeout = 5 * time.Second
 
 // extractionMaxDetachedWriteDuration bounds how long ExtractionWorker's
 // detached persist+bookkeeping write phases can keep running after the
@@ -79,6 +85,22 @@ func run() error {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	// --- Telemetry (OpenTelemetry → Langfuse, OTLP/HTTP) ---
+	// A no-op TracerProvider is configured when cfg.LangfuseOTLPEndpoint is
+	// empty (the default) — zero behavior change until an operator sets
+	// LANGFUSE_OTLP_ENDPOINT/LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY.
+	otelShutdown, err := telemetry.InitOTel(ctx, cfg.LangfuseOTLPEndpoint, cfg.LangfusePublicKey, cfg.LangfuseSecretKey)
+	if err != nil {
+		return fmt.Errorf("telemetry: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
+		defer shutdownCancel()
+		if err := otelShutdown(shutdownCtx); err != nil {
+			slog.Warn("telemetry: shutdown error (spans may have been dropped)", "error", err)
+		}
+	}()
 
 	// --- Database ---
 	pg, err := store.NewPostgres(ctx, cfg.DatabaseURL)

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -36,7 +36,13 @@ import (
 	"github.com/baekenough/second-brain/internal/model"
 	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/store"
+	"github.com/baekenough/second-brain/internal/telemetry"
 )
+
+// otelShutdownTimeout bounds how long the deferred telemetry shutdown may
+// block process exit. A dead/unreachable Langfuse collector must never
+// delay shutdown — see internal/telemetry's non-blocking guarantee.
+const otelShutdownTimeout = 5 * time.Second
 
 // errRegression is returned by run() when a metric regression is detected.
 // main() maps this to os.Exit(1) so that deferred cleanup runs normally.
@@ -118,6 +124,25 @@ func run() error {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	// --- Telemetry (OpenTelemetry → Langfuse, OTLP/HTTP) ---
+	// A no-op TracerProvider is configured when cfg.LangfuseOTLPEndpoint is
+	// empty (the default) — zero behavior change until an operator sets
+	// LANGFUSE_OTLP_ENDPOINT/LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY. eval
+	// only calls the embedding engine (via search.NewEmbeddingEngine below)
+	// — the NDCG/MRR Score-API push described in the plan's Task 4 is
+	// explicitly out of scope for this change.
+	otelShutdown, err := telemetry.InitOTel(ctx, cfg.LangfuseOTLPEndpoint, cfg.LangfusePublicKey, cfg.LangfuseSecretKey)
+	if err != nil {
+		return fmt.Errorf("telemetry: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
+		defer shutdownCancel()
+		if err := otelShutdown(shutdownCtx); err != nil {
+			slog.Warn("telemetry: shutdown error (spans may have been dropped)", "error", err)
+		}
+	}()
 
 	// --- Database ---
 	pg, err := store.NewPostgres(ctx, cfg.DatabaseURL)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,7 +19,13 @@ import (
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/store"
+	"github.com/baekenough/second-brain/internal/telemetry"
 )
+
+// otelShutdownTimeout bounds how long the deferred telemetry shutdown may
+// block process exit. A dead/unreachable Langfuse collector must never
+// delay shutdown — see internal/telemetry's non-blocking guarantee.
+const otelShutdownTimeout = 5 * time.Second
 
 func main() {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
@@ -45,6 +51,22 @@ func run() error {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	// --- Telemetry (OpenTelemetry → Langfuse, OTLP/HTTP) ---
+	// A no-op TracerProvider is configured when cfg.LangfuseOTLPEndpoint is
+	// empty (the default) — zero behavior change until an operator sets
+	// LANGFUSE_OTLP_ENDPOINT/LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY.
+	otelShutdown, err := telemetry.InitOTel(ctx, cfg.LangfuseOTLPEndpoint, cfg.LangfusePublicKey, cfg.LangfuseSecretKey)
+	if err != nil {
+		return fmt.Errorf("telemetry: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), otelShutdownTimeout)
+		defer shutdownCancel()
+		if err := otelShutdown(shutdownCtx); err != nil {
+			slog.Warn("telemetry: shutdown error (spans may have been dropped)", "error", err)
+		}
+	}()
 
 	// --- Database ---
 	pg, err := store.NewPostgres(ctx, cfg.DatabaseURL)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,10 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/xuri/excelize/v2 v2.10.1
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
@@ -35,6 +39,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
@@ -56,6 +61,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -78,13 +84,14 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+Eg
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
 github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.4.2 h1:BdSNuMjRbotnxHSfxy+PCSa4xAmz7szw70ktAtWRYrY=
@@ -100,6 +102,8 @@ github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuM
 github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/graphql-go/handler v0.2.4 h1:gz9q11TUHPNUpqzV8LMa+rkqM5NUuH/nkE3oF2LS3rI=
 github.com/graphql-go/handler v0.2.4/go.mod h1:gsQlb4gDvURR0bgN8vWQEh+s5vJALM2lYL3n3cf6OxQ=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -203,6 +207,10 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:Oyrsyzu
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=
 go.opentelemetry.io/otel v1.43.0/go.mod h1:JuG+u74mvjvcm8vj8pI5XiHy1zDeoCS2LB1spIq7Ay0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bTWkw0ICGcOLCAI5l6zsD1j20k=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0 h1:3iZJKlCZufyRzPzlQhUIWVmfltrXuGyfjREgGP3UUjc=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0/go.mod h1:/G+nUPfhq2e+qiXMGxMwumDrP5jtzU+mWN7/sjT2rak=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=
@@ -211,6 +219,10 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
+go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=

--- a/internal/collector/whisper.go
+++ b/internal/collector/whisper.go
@@ -19,12 +19,42 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/baekenough/second-brain/internal/audiovalidate"
 	"github.com/baekenough/second-brain/internal/collector/smsmap"
 	"github.com/baekenough/second-brain/internal/config"
 	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/telemetry"
 	"github.com/google/uuid"
 )
+
+// whisperTracerName is the OTel instrumentation scope name for every span
+// created in this file. Looked up fresh via otel.Tracer() on each call
+// rather than cached in a package-level var — see the identical rationale
+// in internal/llm/client.go's tracer() helper.
+const whisperTracerName = "github.com/baekenough/second-brain/internal/collector/whisper"
+
+func whisperTracer() oteltrace.Tracer { return otel.Tracer(whisperTracerName) }
+
+// whisperGenAISystem returns the gen_ai.system span attribute value for a
+// transcription call. Unlike internal/llm and internal/search (which always
+// speak to OpenAI directly), WhisperCollector's endpoint is operator-chosen
+// and commonly a self-hosted whisper.cpp server (see isLocalWhisperEndpoint
+// and the WHISPER_CLOUD_ALLOWED cloud-endpoint guard) — so this distinguishes
+// the two rather than uniformly reporting "openai", letting a Langfuse
+// provider-failure-rate dashboard actually separate "our local whisper.cpp
+// is down" from "OpenAI's endpoint is failing" (see the observability plan's
+// Task 4(a) failure-mode analysis).
+func whisperGenAISystem(isLocal bool) string {
+	if isLocal {
+		return "whisper-self-hosted"
+	}
+	return "openai"
+}
 
 // whisperDefaultHTTPTimeout is the fallback per-request timeout used when the
 // config value is zero (misconfigured). 2 hours covers long audio recordings
@@ -1054,7 +1084,12 @@ func (c *WhisperCollector) CollectStream(ctx context.Context, since time.Time, o
 	//
 	// transcribeFile / diarizeAudio internals are unchanged; only the dispatch is
 	// parallelised and the emit is incremental.
-	emitted, streamErr := c.streamPending(ctx, pending, now, onBatch)
+	//
+	// isLocal (computed once above) is threaded through to buildDocument /
+	// transcribeFile so each transcription span's gen_ai.system attribute
+	// reflects locality without re-running isLocalWhisperEndpoint's DNS
+	// lookup per file.
+	emitted, streamErr := c.streamPending(ctx, pending, now, isLocal, onBatch)
 
 	slog.Info("whisper: collected transcripts", "count", emitted, "audio_dir", c.cfg.WhisperAudioDir)
 	return streamErr
@@ -1100,7 +1135,7 @@ type pendingTranscription struct {
 //
 // When concurrency == 1 a single worker processes the channel, reproducing the
 // original sequential transcription order.
-func (c *WhisperCollector) streamPending(ctx context.Context, pending []pendingTranscription, now time.Time, onBatch func([]model.Document) error) (int, error) {
+func (c *WhisperCollector) streamPending(ctx context.Context, pending []pendingTranscription, now time.Time, isLocal bool, onBatch func([]model.Document) error) (int, error) {
 	if len(pending) == 0 {
 		return 0, nil
 	}
@@ -1131,7 +1166,7 @@ func (c *WhisperCollector) streamPending(ctx context.Context, pending []pendingT
 			if streamCtx.Err() != nil {
 				return
 			}
-			doc, ok := c.buildDocument(streamCtx, item, now)
+			doc, ok := c.buildDocument(streamCtx, item, now, isLocal)
 			if !ok {
 				continue // failure already logged; partial success
 			}
@@ -1225,8 +1260,8 @@ func (c *WhisperCollector) streamPending(ctx context.Context, pending []pendingT
 // inline in the walk; it is unchanged except for being extracted so the worker
 // pool can call it concurrently. transcribeFile / diarizeAudio internals are
 // untouched.
-func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTranscription, now time.Time) (model.Document, bool) {
-	txResult, err := c.transcribeFile(ctx, item.path)
+func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTranscription, now time.Time, isLocal bool) (model.Document, bool) {
+	txResult, err := c.transcribeFile(ctx, item.path, isLocal)
 	if err != nil {
 		slog.Warn("whisper: transcription failed", "path", item.path, "error", err)
 		return model.Document{}, false // partial success — skip
@@ -1536,11 +1571,31 @@ type transcribeFileResult struct {
 //
 // The Authorization header is set only when cfg.WhisperAPIKey is non-empty,
 // enabling use with local whisper.cpp servers that do not require authentication.
-func (c *WhisperCollector) transcribeFile(ctx context.Context, path string) (transcribeFileResult, error) {
+//
+// Tracing: each call (one per worker-pool item — see buildDocument) is
+// wrapped in a single "transcription" span, tagged with gen_ai.system
+// (whisperGenAISystem(isLocal) — distinguishes self-hosted whisper.cpp from
+// OpenAI's cloud endpoint), gen_ai.request.model, and audio.size_bytes. err
+// is a named return so the deferred finalizer can record whichever error
+// this function's several return points ultimately produce.
+func (c *WhisperCollector) transcribeFile(ctx context.Context, path string, isLocal bool) (_ transcribeFileResult, err error) {
 	audioBytes, err := os.ReadFile(path)
 	if err != nil {
 		return transcribeFileResult{}, fmt.Errorf("read audio file: %w", err)
 	}
+
+	ctx, span := whisperTracer().Start(ctx, "transcription", oteltrace.WithAttributes(
+		attribute.String(telemetry.AttrGenAISystem, whisperGenAISystem(isLocal)),
+		attribute.String(telemetry.AttrGenAIRequestModel, c.cfg.WhisperModel),
+		attribute.Int(telemetry.AttrAudioSizeBytes, len(audioBytes)),
+	))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	// See doc comment above: native diarization is requested unconditionally
 	// of cfg.DiarizationEnabled, which retains its original meaning only for

--- a/internal/collector/whisper_otel_test.go
+++ b/internal/collector/whisper_otel_test.go
@@ -1,0 +1,175 @@
+package collector
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/baekenough/second-brain/internal/config"
+	"github.com/baekenough/second-brain/internal/telemetry"
+)
+
+// These tests exercise the OTel span structure of WhisperCollector's
+// transcription calls and are intentionally NOT run in parallel (no
+// t.Parallel()): they mutate the process-global OTel TracerProvider via
+// otel.SetTracerProvider, which the rest of this package's tests never
+// touch. Go's test runner completes all non-parallel tests — including
+// these — before resuming any test that called t.Parallel(), so there is no
+// overlap with this package's other (parallel) tests despite the shared
+// global state. See the identical pattern in
+// internal/llm/client_otel_test.go and internal/search/embed_otel_test.go.
+func withInMemoryTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+	})
+	return exp
+}
+
+func attrMap(s tracetest.SpanStub) map[string]string {
+	out := make(map[string]string, len(s.Attributes))
+	for _, kv := range s.Attributes {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+// TestWhisperGenAISystem_LocalVsCloud verifies the pure gen_ai.system value
+// selection in isolation (no network involved): local whisper.cpp-style
+// endpoints and OpenAI's cloud API are tagged differently so a Langfuse
+// dashboard can distinguish them, per Task 4(a) of the observability plan
+// ("which provider is failing").
+func TestWhisperGenAISystem_LocalVsCloud(t *testing.T) {
+	if got, want := whisperGenAISystem(true), "whisper-self-hosted"; got != want {
+		t.Errorf("whisperGenAISystem(true) = %q, want %q", got, want)
+	}
+	if got, want := whisperGenAISystem(false), "openai"; got != want {
+		t.Errorf("whisperGenAISystem(false) = %q, want %q", got, want)
+	}
+}
+
+// TestWhisperCollector_Collect_TranscriptionSpanCreated verifies that each
+// transcribeFile call (invoked per-worker inside the CollectStream worker
+// pool — see buildDocument) produces exactly one "transcription" span
+// carrying the GenAI attributes plus audio.size_bytes. httptest.Server binds
+// to 127.0.0.1, so isLocalWhisperEndpoint classifies it as local — the
+// "whisper-self-hosted" branch of whisperGenAISystem is what this
+// integration path naturally exercises (the "openai"/cloud branch is
+// covered directly by TestWhisperGenAISystem_LocalVsCloud above, since
+// reaching a genuinely non-local host from a test would require real
+// network access, which these tests must not do).
+func TestWhisperCollector_Collect_TranscriptionSpanCreated(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	dir := t.TempDir()
+	srv, _ := newWhisperTestServer(t, "안녕하세요")
+
+	mtime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	audioPath := writeDummyAudio(t, dir, "call.m4a", mtime)
+	audioInfo, err := os.Stat(audioPath)
+	if err != nil {
+		t.Fatalf("stat audio file: %v", err)
+	}
+	audioSize := audioInfo.Size()
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "gpt-4o-transcribe-diarize",
+		WhisperLanguage: "ko",
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("Collect() returned %d docs, want 1", len(docs))
+	}
+
+	spans := exp.GetSpans()
+	var found int
+	var span tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "transcription" {
+			found++
+			span = s
+		}
+	}
+	if found != 1 {
+		t.Fatalf("expected exactly 1 'transcription' span, got %d", found)
+	}
+
+	attrs := attrMap(span)
+	if got, want := attrs[telemetry.AttrGenAISystem], "whisper-self-hosted"; got != want {
+		t.Errorf("gen_ai.system = %q, want %q (httptest server is loopback → local)", got, want)
+	}
+	if got, want := attrs[telemetry.AttrGenAIRequestModel], "gpt-4o-transcribe-diarize"; got != want {
+		t.Errorf("gen_ai.request.model = %q, want %q", got, want)
+	}
+	if got, want := attrs[telemetry.AttrAudioSizeBytes], strconv.FormatInt(audioSize, 10); got != want {
+		t.Errorf("audio.size_bytes = %q, want %q", got, want)
+	}
+}
+
+// TestWhisperCollector_Collect_TranscriptionSpanRecordsErrorOnFailure
+// verifies that a failed transcription (partial-success skip at the
+// buildDocument level — see its doc comment) still leaves behind a
+// "transcription" span with the error recorded, so failed calls remain
+// visible in Langfuse even though they never produce a Document.
+func TestWhisperCollector_Collect_TranscriptionSpanRecordsErrorOnFailure(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	mtime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	writeDummyAudio(t, dir, "call.m4a", mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "gpt-4o-transcribe-diarize",
+	}
+	c := makeWhisperCollector(cfg, srv)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect() error: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("Collect() returned %d docs, want 0 (transcription failure is partial-success skip)", len(docs))
+	}
+
+	spans := exp.GetSpans()
+	var span tracetest.SpanStub
+	found := false
+	for _, s := range spans {
+		if s.Name == "transcription" {
+			span = s
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected a 'transcription' span even on failure")
+	}
+	if len(span.Events) == 0 {
+		t.Error("expected span.RecordError to add an exception event, got no events")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,6 +441,31 @@ type Config struct {
 	// insight documents are supporting hypotheses, not primary evidence.
 	// ASK_CONTEXT_INSIGHT_M env var, default 3.
 	AskContextInsightM int
+
+	// LLM observability (OpenTelemetry → self-hosted Langfuse, OTLP/HTTP).
+	// All three default to "" (disabled) — internal/telemetry.InitOTel
+	// configures a no-op TracerProvider when LangfuseOTLPEndpoint is empty,
+	// so an operator who never sets these three env vars sees zero behavior
+	// change (see internal/telemetry doc comment).
+	//
+	// LangfuseOTLPEndpoint is the FULL OTLP traces URL — used verbatim, NOT a
+	// bare host that gets "/v1/traces" appended (see InitOTel's doc comment
+	// for why WithEndpointURL is used over WithEndpoint).
+	//
+	// For this deployment: "http://100.77.20.12:3300/api/public/otel" (the
+	// Tailscale-interface binding of langfuse-web). Do NOT set this to the
+	// public https://langfuse.<domain> hostname — that sits behind Cloudflare
+	// Access, and a server-to-server OTLP POST with no browser session gets a
+	// silent 302-to-login instead of a real response, so every span is
+	// dropped with no error anywhere (see InitOTel's doc comment for the
+	// full explanation). LANGFUSE_OTLP_ENDPOINT env var.
+	LangfuseOTLPEndpoint string
+	// LangfusePublicKey / LangfuseSecretKey form the HTTP Basic Auth
+	// credentials Langfuse's OTLP receiver expects
+	// (Authorization: Basic base64(publicKey:secretKey)).
+	// LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY env vars.
+	LangfusePublicKey string
+	LangfuseSecretKey string
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -673,6 +698,12 @@ func Load() (*Config, error) {
 		AskTimeoutSeconds:  askTimeoutSeconds(),
 		AskContextTopK:     askContextTopK(),
 		AskContextInsightM: askContextInsightM(),
+
+		// #Langfuse observability — all default "" (disabled); see doc
+		// comment on LangfuseOTLPEndpoint above.
+		LangfuseOTLPEndpoint: os.Getenv("LANGFUSE_OTLP_ENDPOINT"),
+		LangfusePublicKey:    os.Getenv("LANGFUSE_PUBLIC_KEY"),
+		LangfuseSecretKey:    os.Getenv("LANGFUSE_SECRET_KEY"),
 	}, nil
 }
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -15,8 +15,36 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/baekenough/second-brain/internal/auth"
+	"github.com/baekenough/second-brain/internal/telemetry"
 )
+
+// tracerName is the OTel instrumentation scope name for every span created
+// in this package (span names below distinguish operations within it).
+// otel.Tracer(tracerName) is looked up fresh on every call rather than
+// cached in a package-level var: the global TracerProvider it resolves
+// against is only guaranteed to reflect internal/telemetry.InitOTel's
+// configuration for lookups performed AFTER InitOTel runs (see
+// go.opentelemetry.io/otel's global-provider delegation semantics), and
+// tests reconfigure the global provider per-test.
+const tracerName = "github.com/baekenough/second-brain/internal/llm"
+
+// genAISystem is the value used for the gen_ai.system span attribute on
+// every span in this package. This client speaks the OpenAI-compatible
+// /v1/chat/completions protocol (OpenAI, Azure OpenAI, or a local proxy such
+// as cliproxy — see the Client doc comment) and Client itself has no signal
+// distinguishing which backend a given baseURL actually points at, so
+// "openai" is used uniformly as the protocol-family identifier. This keeps
+// the attribute populated (Langfuse groups/prices by it) rather than
+// omitting it; it does not claim the traffic is literally served by OpenAI.
+const genAISystem = "openai"
+
+func tracer() oteltrace.Tracer { return otel.Tracer(tracerName) }
 
 // Client is an OpenAI-compatible chat completion client.
 // It communicates with any endpoint that speaks the /v1/chat/completions protocol
@@ -139,10 +167,24 @@ type chatResponse struct {
 			Content string `json:"content"`
 		} `json:"message"`
 	} `json:"choices"`
+	// Usage is optional: some OpenAI-compatible proxies omit it. A nil Usage
+	// (or a struct that never unmarshals because the field is entirely
+	// absent) simply means no gen_ai.usage.* span attributes are recorded
+	// for that call — see doRequest.
+	Usage *tokenUsage `json:"usage"`
 	Error *struct {
 		Message string `json:"message"`
 		Type    string `json:"type"`
 	} `json:"error"`
+}
+
+// tokenUsage is the OpenAI chat completions "usage" object, parsed so its
+// fields can be attached to spans as gen_ai.usage.input_tokens /
+// gen_ai.usage.output_tokens (OpenTelemetry GenAI semantic conventions).
+type tokenUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 // Complete sends a single-turn chat completion request.
@@ -158,10 +200,25 @@ func (c *Client) Complete(ctx context.Context, system, user string) (string, err
 // system is the system prompt; messages is the ordered conversation history
 // including the final user turn. The system message is always prepended.
 // 4xx responses are not retried. 5xx and network errors are retried up to 2 times.
+//
+// Tracing: the entire retry loop is wrapped in a single parent span
+// ("llm.complete") so that retry-induced latency and eventual failure are
+// visible as one logical operation, while each individual HTTP attempt gets
+// its own child span ("llm.complete.attempt", attribute llm.retry.attempt).
+// This mirrors the plan's explicit requirement — a lone "one span per call"
+// design would hide how much of the total latency/failure came from
+// retries.
 func (c *Client) CompleteWithMessages(ctx context.Context, system string, messages []Message) (string, error) {
 	if !c.Enabled() {
 		return "", fmt.Errorf("llm: client is not configured (missing base URL or model)")
 	}
+
+	ctx, span := tracer().Start(ctx, "llm.complete", oteltrace.WithAttributes(
+		attribute.String(telemetry.AttrGenAISystem, genAISystem),
+		attribute.String(telemetry.AttrGenAIRequestModel, c.model),
+		attribute.Int(telemetry.AttrGenAIRequestMaxTokens, c.maxTokens),
+	))
+	defer span.End()
 
 	allMessages := make([]Message, 0, len(messages)+1)
 	allMessages = append(allMessages, Message{Role: "system", Content: system})
@@ -177,12 +234,20 @@ func (c *Client) CompleteWithMessages(ctx context.Context, system string, messag
 	const maxRetries = 2
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		result, err := c.doRequest(ctx, reqBody)
+		result, usage, err := c.doRequestTraced(ctx, reqBody, attempt)
 		if err == nil {
+			if usage != nil {
+				span.SetAttributes(
+					attribute.Int(telemetry.AttrGenAIUsageInputTokens, usage.PromptTokens),
+					attribute.Int(telemetry.AttrGenAIUsageOutputTokens, usage.CompletionTokens),
+				)
+			}
 			return result, nil
 		}
 		if isClientError(err) {
 			// 4xx — do not retry.
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
 			return "", err
 		}
 		lastErr = err
@@ -192,7 +257,36 @@ func (c *Client) CompleteWithMessages(ctx context.Context, system string, messag
 			"error", err,
 		)
 	}
-	return "", fmt.Errorf("llm: all retries exhausted: %w", lastErr)
+	finalErr := fmt.Errorf("llm: all retries exhausted: %w", lastErr)
+	span.RecordError(finalErr)
+	span.SetStatus(codes.Error, finalErr.Error())
+	return "", finalErr
+}
+
+// doRequestTraced wraps a single doRequest attempt in a child span, recorded
+// under whatever span is already active in ctx (CompleteWithMessages' parent
+// "llm.complete" span). attempt is the zero-based retry index, recorded as
+// the llm.retry.attempt attribute so a specific attempt's latency/failure
+// can be correlated with its position in the retry sequence.
+func (c *Client) doRequestTraced(ctx context.Context, reqBody chatRequest, attempt int) (string, *tokenUsage, error) {
+	ctx, span := tracer().Start(ctx, "llm.complete.attempt", oteltrace.WithAttributes(
+		attribute.Int(telemetry.AttrLLMRetryAttempt, attempt),
+	))
+	defer span.End()
+
+	result, usage, err := c.doRequest(ctx, reqBody)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return "", nil, err
+	}
+	if usage != nil {
+		span.SetAttributes(
+			attribute.Int(telemetry.AttrGenAIUsageInputTokens, usage.PromptTokens),
+			attribute.Int(telemetry.AttrGenAIUsageOutputTokens, usage.CompletionTokens),
+		)
+	}
+	return result, usage, nil
 }
 
 // StreamWithMessages sends a multi-turn chat completion request with
@@ -203,10 +297,30 @@ func (c *Client) CompleteWithMessages(ctx context.Context, system string, messag
 // tokens to a caller that has already forwarded earlier deltas downstream
 // (e.g. to an SSE client). A 4xx/5xx status returned before any body is
 // read is reported as a plain error with onDelta never called.
-func (c *Client) StreamWithMessages(ctx context.Context, system string, messages []Message, onDelta func(string)) error {
+//
+// Tracing: the whole call is wrapped in a single "llm.stream" span (no
+// retry, so no attempt/parent split is needed — see CompleteWithMessages).
+// err is a named return so the deferred span finalizer can record whatever
+// error value the function ultimately returns, from any of its several
+// return points, without duplicating span.RecordError/SetStatus calls at
+// each one.
+func (c *Client) StreamWithMessages(ctx context.Context, system string, messages []Message, onDelta func(string)) (err error) {
 	if !c.Enabled() {
 		return fmt.Errorf("llm: client is not configured (missing base URL or model)")
 	}
+
+	ctx, span := tracer().Start(ctx, "llm.stream", oteltrace.WithAttributes(
+		attribute.String(telemetry.AttrGenAISystem, genAISystem),
+		attribute.String(telemetry.AttrGenAIRequestModel, c.model),
+		attribute.Int(telemetry.AttrGenAIRequestMaxTokens, c.maxTokens),
+	))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	allMessages := make([]Message, 0, len(messages)+1)
 	allMessages = append(allMessages, Message{Role: "system", Content: system})
@@ -312,60 +426,65 @@ func isClientError(err error) bool {
 }
 
 // doRequest performs a single HTTP round-trip to the chat completions endpoint.
-func (c *Client) doRequest(ctx context.Context, reqBody chatRequest) (string, error) {
+// doRequest performs one HTTP round-trip and returns the completion text
+// plus, when the response body includes an OpenAI-format "usage" object, the
+// token counts it reported (nil when absent — some OpenAI-compatible proxies
+// omit it). The usage return value feeds the gen_ai.usage.* span attributes
+// set by doRequestTraced/CompleteWithMessages.
+func (c *Client) doRequest(ctx context.Context, reqBody chatRequest) (string, *tokenUsage, error) {
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("llm: marshal request: %w", err)
+		return "", nil, fmt.Errorf("llm: marshal request: %w", err)
 	}
 
 	url := c.baseURL + "/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
-		return "", fmt.Errorf("llm: build request: %w", err)
+		return "", nil, fmt.Errorf("llm: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.tokens != nil {
 		tok, err := c.tokens.Token()
 		if err != nil {
-			return "", fmt.Errorf("llm: token source: %w", err)
+			return "", nil, fmt.Errorf("llm: token source: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("llm: HTTP request: %w", err)
+		return "", nil, fmt.Errorf("llm: HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("llm: read response body: %w", err)
+		return "", nil, fmt.Errorf("llm: read response body: %w", err)
 	}
 
 	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-		return "", &clientError{statusCode: resp.StatusCode, body: string(body)}
+		return "", nil, &clientError{statusCode: resp.StatusCode, body: string(body)}
 	}
 	if resp.StatusCode >= 500 {
-		return "", fmt.Errorf("llm: server error %d: %s", resp.StatusCode, string(body))
+		return "", nil, fmt.Errorf("llm: server error %d: %s", resp.StatusCode, string(body))
 	}
 
 	var chatResp chatResponse
 	if err := json.Unmarshal(body, &chatResp); err != nil {
-		return "", fmt.Errorf("llm: unmarshal response: %w", err)
+		return "", nil, fmt.Errorf("llm: unmarshal response: %w", err)
 	}
 
 	// Surface API-level errors embedded in a 200 response (some proxies do this).
 	if chatResp.Error != nil {
-		return "", &clientError{
+		return "", nil, &clientError{
 			statusCode: http.StatusOK,
 			body:       chatResp.Error.Message,
 		}
 	}
 
 	if len(chatResp.Choices) == 0 {
-		return "", fmt.Errorf("llm: response contains no choices")
+		return "", nil, fmt.Errorf("llm: response contains no choices")
 	}
 
-	return chatResp.Choices[0].Message.Content, nil
+	return chatResp.Choices[0].Message.Content, chatResp.Usage, nil
 }

--- a/internal/llm/client_otel_test.go
+++ b/internal/llm/client_otel_test.go
@@ -1,0 +1,268 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// These tests exercise the OTel span structure of internal/llm and are
+// intentionally NOT run in parallel (no t.Parallel()): they mutate the
+// process-global OTel TracerProvider via otel.SetTracerProvider, which the
+// package's other (parallel) tests never touch. Go's test runner completes
+// all non-parallel tests — including these — before resuming any test that
+// called t.Parallel(), so there is no overlap with the rest of this
+// package's test suite despite the shared global state.
+
+// withInMemoryTracer installs an SDK TracerProvider backed by an in-memory
+// span exporter (synchronous export via WithSyncer — no batching delay) as
+// the global provider for the duration of the test, and restores a no-op
+// provider on cleanup.
+func withInMemoryTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+	})
+	return exp
+}
+
+// chatResponseOKWithUsage builds an OpenAI-format chat completion response
+// body that additionally reports token usage, exercising the usage-parsing
+// path added for gen_ai.usage.* span attributes.
+func chatResponseOKWithUsage(content string, promptTokens, completionTokens int) []byte {
+	type msg struct {
+		Content string `json:"content"`
+	}
+	type choice struct {
+		Message msg `json:"message"`
+	}
+	type usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	}
+	type resp struct {
+		Choices []choice `json:"choices"`
+		Usage   usage    `json:"usage"`
+	}
+	data, _ := json.Marshal(resp{
+		Choices: []choice{{Message: msg{Content: content}}},
+		Usage:   usage{PromptTokens: promptTokens, CompletionTokens: completionTokens, TotalTokens: promptTokens + completionTokens},
+	})
+	return data
+}
+
+func TestClient_CompleteWithMessages_ParentAndAttemptSpans_OnRetry(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chatResponseOKWithUsage("recovered", 42, 7)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	got, err := c.Complete(context.Background(), "sys", "user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "recovered" {
+		t.Fatalf("want %q, got %q", "recovered", got)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 HTTP calls (2 failed attempts + 1 success), got %d", calls)
+	}
+
+	spans := exp.GetSpans()
+
+	var parents, children int
+	var parentSpan tracetest.SpanStub
+	for _, s := range spans {
+		switch s.Name {
+		case "llm.complete":
+			parents++
+			parentSpan = s
+		case "llm.complete.attempt":
+			children++
+		}
+	}
+
+	if parents != 1 {
+		t.Fatalf("expected exactly 1 parent 'llm.complete' span, got %d (spans=%v)", parents, spanNames(spans))
+	}
+	if children != 3 {
+		t.Fatalf("expected exactly 3 'llm.complete.attempt' child spans (one per HTTP call), got %d (spans=%v)", children, spanNames(spans))
+	}
+
+	// Every attempt span must be a child of the single parent span.
+	for _, s := range spans {
+		if s.Name != "llm.complete.attempt" {
+			continue
+		}
+		if s.Parent.SpanID() != parentSpan.SpanContext.SpanID() {
+			t.Errorf("attempt span %s has parent SpanID %s, want parent 'llm.complete' SpanID %s",
+				s.SpanContext.SpanID(), s.Parent.SpanID(), parentSpan.SpanContext.SpanID())
+		}
+		if s.Parent.TraceID() != parentSpan.SpanContext.TraceID() {
+			t.Errorf("attempt span has TraceID %s, want parent's TraceID %s", s.Parent.TraceID(), parentSpan.SpanContext.TraceID())
+		}
+	}
+
+	// GenAI attributes on the parent span.
+	attrs := attrMap(parentSpan)
+	if got := attrs["gen_ai.system"]; got != "openai" {
+		t.Errorf("gen_ai.system = %q, want %q", got, "openai")
+	}
+	if got := attrs["gen_ai.request.model"]; got != "gpt-test" {
+		t.Errorf("gen_ai.request.model = %q, want %q", got, "gpt-test")
+	}
+	if got := attrs["gen_ai.usage.input_tokens"]; got != "42" {
+		t.Errorf("gen_ai.usage.input_tokens = %q, want %q (from successful attempt's response)", got, "42")
+	}
+	if got := attrs["gen_ai.usage.output_tokens"]; got != "7" {
+		t.Errorf("gen_ai.usage.output_tokens = %q, want %q", got, "7")
+	}
+}
+
+func TestClient_CompleteWithMessages_SingleAttemptSpan_OnFirstTrySuccess(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chatResponseOK("hello")) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	if _, err := c.Complete(context.Background(), "sys", "user"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var parents, children int
+	for _, s := range spans {
+		switch s.Name {
+		case "llm.complete":
+			parents++
+		case "llm.complete.attempt":
+			children++
+		}
+	}
+	if parents != 1 || children != 1 {
+		t.Fatalf("expected 1 parent + 1 child span on first-try success, got parents=%d children=%d (spans=%v)", parents, children, spanNames(spans))
+	}
+}
+
+func TestClient_StreamWithMessages_SingleSpanWithGenAIAttributes(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\n")) //nolint:errcheck
+		w.Write([]byte("data: [DONE]\n\n"))                                                                  //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	var got string
+	err := c.StreamWithMessages(context.Background(), "sys", nil, func(delta string) { got += delta })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hi" {
+		t.Fatalf("want %q, got %q", "hi", got)
+	}
+
+	spans := exp.GetSpans()
+	var streamSpans int
+	var streamSpan tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "llm.stream" {
+			streamSpans++
+			streamSpan = s
+		}
+	}
+	if streamSpans != 1 {
+		t.Fatalf("expected exactly 1 'llm.stream' span, got %d (spans=%v)", streamSpans, spanNames(spans))
+	}
+
+	attrs := attrMap(streamSpan)
+	if got := attrs["gen_ai.system"]; got != "openai" {
+		t.Errorf("gen_ai.system = %q, want %q", got, "openai")
+	}
+	if got := attrs["gen_ai.request.model"]; got != "gpt-test" {
+		t.Errorf("gen_ai.request.model = %q, want %q", got, "gpt-test")
+	}
+}
+
+func TestClient_StreamWithMessages_ErrorRecordedOnSpan(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	err := c.StreamWithMessages(context.Background(), "sys", nil, func(string) {})
+	if err == nil {
+		t.Fatal("expected error from failing stream request")
+	}
+
+	spans := exp.GetSpans()
+	var streamSpan tracetest.SpanStub
+	found := false
+	for _, s := range spans {
+		if s.Name == "llm.stream" {
+			streamSpan = s
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an 'llm.stream' span even on failure, got spans=%v", spanNames(spans))
+	}
+	if len(streamSpan.Status.Description) == 0 && streamSpan.Status.Code == 0 {
+		t.Error("expected span status to reflect the error (RecordError/SetStatus), got zero-value status")
+	}
+	if len(streamSpan.Events) == 0 {
+		t.Error("expected span.RecordError to add an exception event, got no events")
+	}
+}
+
+// spanNames is a small debug helper for test failure messages.
+func spanNames(spans tracetest.SpanStubs) []string {
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// attrMap flattens a span's attributes into a string-keyed map for
+// convenient assertions (values stringified via their Emit()).
+func attrMap(s tracetest.SpanStub) map[string]string {
+	out := make(map[string]string, len(s.Attributes))
+	for _, kv := range s.Attributes {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}

--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -14,9 +14,28 @@ import (
 
 	tiktoken "github.com/pkoukk/tiktoken-go"
 	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/baekenough/second-brain/internal/auth"
+	"github.com/baekenough/second-brain/internal/telemetry"
 )
+
+// embedTracerName is the OTel instrumentation scope name for every span
+// created in this file. Looked up fresh via otel.Tracer() on each call
+// rather than cached in a package-level var — see the identical rationale
+// in internal/llm/client.go's tracer() helper.
+const embedTracerName = "github.com/baekenough/second-brain/internal/search"
+
+// embedGenAISystem is the gen_ai.system value for every embedding span:
+// EmbedClient always speaks OpenAI's /v1/embeddings protocol (see the
+// EmbedClient doc comment — embeddings are routed to OpenAI directly, never
+// through the generic chat proxy).
+const embedGenAISystem = "openai"
+
+func embedTracer() oteltrace.Tracer { return otel.Tracer(embedTracerName) }
 
 // embedRetryDelays defines the exponential backoff delays applied between
 // embed request retries. Consistent with the R004 error handling policy and
@@ -188,10 +207,29 @@ func (c *EmbedClient) Enabled() bool { return c.apiURL != "" }
 // When the server returns a Retry-After header with a longer delay, that delay
 // is honoured instead of the default backoff interval.
 // 4xx errors other than 429 are not retried.
-func (c *EmbedClient) Embed(ctx context.Context, text string) ([]float32, error) {
+//
+// Tracing: wrapped in a single "embedding.single" span. No span is created
+// when the client is disabled (Enabled()==false) — that path is a
+// configuration no-op, not an API call. err is a named return so the
+// deferred finalizer can record whichever error value the retry loop's many
+// return points ultimately produces, without repeating
+// span.RecordError/SetStatus at each one.
+func (c *EmbedClient) Embed(ctx context.Context, text string) (vec []float32, err error) {
 	if !c.Enabled() {
 		return nil, nil
 	}
+
+	ctx, span := embedTracer().Start(ctx, "embedding.single", oteltrace.WithAttributes(
+		attribute.String(telemetry.AttrGenAISystem, embedGenAISystem),
+		attribute.String(telemetry.AttrGenAIRequestModel, c.model),
+	))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	text = truncateForEmbed(text)
 
@@ -325,10 +363,28 @@ const (
 // A single item whose character count alone exceeds maxBatchChars is sent as
 // its own sub-batch (the existing per-document rune truncation makes this case
 // practically unreachable, but we handle it defensively).
-func (c *EmbedClient) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+//
+// Tracing: wrapped in a top-level "embedding.batch" span, with one child
+// "embedding.batch.subbatch" span per API call dispatched by embedBatchOnce
+// — so a slow or failing sub-batch is attributable within the overall batch
+// operation rather than only visible as aggregate latency. No span is
+// created when the client is disabled.
+func (c *EmbedClient) EmbedBatch(ctx context.Context, texts []string) (_ [][]float32, err error) {
 	if !c.Enabled() {
 		return make([][]float32, len(texts)), nil
 	}
+
+	ctx, span := embedTracer().Start(ctx, "embedding.batch", oteltrace.WithAttributes(
+		attribute.String(telemetry.AttrGenAISystem, embedGenAISystem),
+		attribute.String(telemetry.AttrGenAIRequestModel, c.model),
+	))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	truncated := make([]string, len(texts))
 	for i, t := range texts {
@@ -374,7 +430,25 @@ func (c *EmbedClient) EmbedBatch(ctx context.Context, texts []string) ([][]float
 // Transient errors (5xx, network failures) and 429 rate-limit responses are
 // retried up to embedMaxRetries times with exponential backoff (1s/2s/4s),
 // honouring the Retry-After header when present.
-func (c *EmbedClient) embedBatchOnce(ctx context.Context, texts []string) ([][]float32, error) {
+//
+// Tracing: each call is one "embedding.batch.subbatch" child span (nested
+// under whatever span is active in ctx — EmbedBatch's parent "embedding.batch"
+// span when called from there), tagged with embedding.batch_size so a
+// specific sub-batch's size can be correlated with its latency/failure.
+func (c *EmbedClient) embedBatchOnce(ctx context.Context, texts []string) (_ [][]float32, err error) {
+	ctx, span := embedTracer().Start(ctx, "embedding.batch.subbatch", oteltrace.WithAttributes(
+		attribute.String(telemetry.AttrGenAISystem, embedGenAISystem),
+		attribute.String(telemetry.AttrGenAIRequestModel, c.model),
+		attribute.Int(telemetry.AttrEmbeddingBatchSize, len(texts)),
+	))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
+
 	payload := map[string]interface{}{
 		"input": texts,
 		"model": c.model,

--- a/internal/search/embed_otel_test.go
+++ b/internal/search/embed_otel_test.go
@@ -1,0 +1,198 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/baekenough/second-brain/internal/telemetry"
+)
+
+// These tests exercise the OTel span structure of EmbedClient and are
+// intentionally NOT run in parallel (no t.Parallel()): they mutate the
+// process-global OTel TracerProvider via otel.SetTracerProvider, which the
+// rest of this package's tests never touch. Go's test runner completes all
+// non-parallel tests — including these — before resuming any test that
+// called t.Parallel(), so there is no overlap with this package's other
+// (parallel) tests despite the shared global state. See the identical
+// pattern and rationale in internal/llm/client_otel_test.go.
+func withInMemoryTracer(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+	})
+	return exp
+}
+
+func spanNames(spans tracetest.SpanStubs) []string {
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name
+	}
+	return names
+}
+
+func attrMap(s tracetest.SpanStub) map[string]string {
+	out := make(map[string]string, len(s.Attributes))
+	for _, kv := range s.Attributes {
+		out[string(kv.Key)] = kv.Value.Emit()
+	}
+	return out
+}
+
+func TestEmbed_SingleSpanWithGenAIAttributes(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	vec := fakeVec(1536)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embeddingResponse([][]float32{vec}))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewEmbedClient(srv.URL, "sk-test", "", "text-embedding-3-small", 1536)
+	if _, err := c.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found int
+	var span tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == "embedding.single" {
+			found++
+			span = s
+		}
+	}
+	if found != 1 {
+		t.Fatalf("expected exactly 1 'embedding.single' span, got %d (spans=%v)", found, spanNames(spans))
+	}
+
+	attrs := attrMap(span)
+	if got := attrs[telemetry.AttrGenAISystem]; got != "openai" {
+		t.Errorf("gen_ai.system = %q, want %q", got, "openai")
+	}
+	if got := attrs[telemetry.AttrGenAIRequestModel]; got != "text-embedding-3-small" {
+		t.Errorf("gen_ai.request.model = %q, want %q", got, "text-embedding-3-small")
+	}
+}
+
+func TestEmbed_DisabledClient_NoSpan(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	c := NewEmbedClient("https://api.openai.com/v1", "", "", "text-embedding-3-small", 1536)
+	if _, err := c.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if spans := exp.GetSpans(); len(spans) != 0 {
+		t.Fatalf("expected no spans for a disabled (no-op) client call, got %v", spanNames(spans))
+	}
+}
+
+// TestEmbedBatch_ParentAndSubBatchChildSpans verifies EmbedBatch's tracing
+// contract from the plan: one top-level "embedding.batch" parent span, and
+// one "embedding.batch.subbatch" child span per sub-batch actually
+// dispatched to the API (EmbedBatch splits large inputs into sub-batches
+// bounded by maxBatchChars=500,000 chars — see embed.go). 17 texts of
+// 30,000 characters each (510,000 chars total) are deliberately chosen to
+// force a split into >=2 sub-batches: each text sits comfortably under the
+// per-text truncateForEmbed ceiling (~32,000 chars for this repeated-phrase
+// content at the 8,000-token cap — verified empirically against the
+// embedded cl100k_base tokenizer), so truncation never alters these input
+// lengths and the sub-batch boundary math stays exactly predictable.
+func TestEmbedBatch_ParentAndSubBatchChildSpans(t *testing.T) {
+	exp := withInMemoryTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		vecs := make([][]float32, len(reqBody.Input))
+		for i := range vecs {
+			vecs[i] = fakeVec(4)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(embeddingResponse(vecs))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewEmbedClient(srv.URL, "sk-test", "", "text-embedding-3-small", 1536)
+
+	unit := strings.Repeat("hello world foo bar baz qux ", 1072)[:30000]
+	texts := make([]string, 17)
+	for i := range texts {
+		texts[i] = unit
+	}
+
+	vecs, err := c.EmbedBatch(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vecs) != len(texts) {
+		t.Fatalf("EmbedBatch returned %d vectors, want %d", len(vecs), len(texts))
+	}
+
+	spans := exp.GetSpans()
+	var parents, children int
+	var parentSpan tracetest.SpanStub
+	var subBatchSizeSum int
+	for _, s := range spans {
+		switch s.Name {
+		case "embedding.batch":
+			parents++
+			parentSpan = s
+		case "embedding.batch.subbatch":
+			children++
+			sz, _ := strconv.Atoi(attrMap(s)[telemetry.AttrEmbeddingBatchSize])
+			subBatchSizeSum += sz
+		}
+	}
+
+	if parents != 1 {
+		t.Fatalf("expected exactly 1 parent 'embedding.batch' span, got %d (spans=%v)", parents, spanNames(spans))
+	}
+	if children < 2 {
+		t.Fatalf("expected the 500,000-char sub-batch budget to split 17x30,000 chars into >=2 'embedding.batch.subbatch' spans, got %d (spans=%v)", children, spanNames(spans))
+	}
+	if subBatchSizeSum != len(texts) {
+		t.Errorf("sum of embedding.batch_size across sub-batch spans = %d, want %d (total input texts)", subBatchSizeSum, len(texts))
+	}
+
+	for _, s := range spans {
+		if s.Name != "embedding.batch.subbatch" {
+			continue
+		}
+		if s.Parent.SpanID() != parentSpan.SpanContext.SpanID() {
+			t.Errorf("sub-batch span has parent SpanID %s, want parent 'embedding.batch' SpanID %s",
+				s.Parent.SpanID(), parentSpan.SpanContext.SpanID())
+		}
+		if s.Parent.TraceID() != parentSpan.SpanContext.TraceID() {
+			t.Errorf("sub-batch span has TraceID %s, want parent's TraceID %s", s.Parent.TraceID(), parentSpan.SpanContext.TraceID())
+		}
+	}
+
+	attrs := attrMap(parentSpan)
+	if got := attrs[telemetry.AttrGenAISystem]; got != "openai" {
+		t.Errorf("parent gen_ai.system = %q, want %q", got, "openai")
+	}
+	if got := attrs[telemetry.AttrGenAIRequestModel]; got != "text-embedding-3-small" {
+		t.Errorf("parent gen_ai.request.model = %q, want %q", got, "text-embedding-3-small")
+	}
+}

--- a/internal/telemetry/attrs.go
+++ b/internal/telemetry/attrs.go
@@ -1,0 +1,57 @@
+package telemetry
+
+import "go.opentelemetry.io/otel/attribute"
+
+// GenAI semantic convention attribute keys used across the LLM/embedding/
+// transcription instrumentation in internal/llm, internal/search, and
+// internal/collector. Langfuse's OTLP receiver inspects these exact keys to
+// auto-populate provider/model/token/cost fields in its UI.
+//
+// These are plain string constants rather than sourced from
+// go.opentelemetry.io/otel/semconv/*: the GenAI conventions are experimental
+// and have changed key names across semconv releases (e.g. "gen_ai.system"
+// was renamed to "gen_ai.provider.name" starting in semconv v1.36.0, which
+// is newer than what this module vendors). Pinning to a semconv package
+// version would silently drift the wire attribute names Langfuse expects
+// away from what its docs (and this integration's plan) specify. Using
+// literal keys here keeps the contract explicit and independent of whichever
+// semconv version happens to be vendored.
+const (
+	// AttrGenAISystem identifies the GenAI provider/protocol family (e.g.
+	// "openai"). Set on every LLM/embedding/transcription span.
+	AttrGenAISystem = "gen_ai.system"
+	// AttrGenAIRequestModel is the model name requested (e.g.
+	// "gpt-4o-transcribe-diarize", "text-embedding-3-small").
+	AttrGenAIRequestModel = "gen_ai.request.model"
+	// AttrGenAIRequestMaxTokens is the max_tokens request parameter, when
+	// applicable (chat completions only).
+	AttrGenAIRequestMaxTokens = "gen_ai.request.max_tokens"
+	// AttrGenAIUsageInputTokens is the prompt/input token count reported by
+	// the provider's response, when available.
+	AttrGenAIUsageInputTokens = "gen_ai.usage.input_tokens"
+	// AttrGenAIUsageOutputTokens is the completion/output token count
+	// reported by the provider's response, when available.
+	AttrGenAIUsageOutputTokens = "gen_ai.usage.output_tokens"
+)
+
+// Operation-specific attributes that are NOT part of the GenAI semantic
+// conventions but add useful context for the batching/concurrency patterns
+// this codebase uses (sub-batched embeddings, worker-pool transcription).
+const (
+	// AttrEmbeddingBatchSize is the number of texts in an EmbedBatch
+	// sub-batch request.
+	AttrEmbeddingBatchSize = "embedding.batch_size"
+	// AttrAudioSizeBytes is the size in bytes of an audio file submitted for
+	// transcription.
+	AttrAudioSizeBytes = "audio.size_bytes"
+	// AttrLLMRetryAttempt is the zero-based attempt index of an individual
+	// LLM chat-completion request within CompleteWithMessages' retry loop.
+	AttrLLMRetryAttempt = "llm.retry.attempt"
+)
+
+// serviceNameAttr returns the OTel resource "service.name" attribute.
+// Kept as a tiny unversioned helper (see the doc comment above) rather than
+// importing a versioned semconv package for a single, schema-stable key.
+func serviceNameAttr(name string) attribute.KeyValue {
+	return attribute.String("service.name", name)
+}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -1,0 +1,124 @@
+// Package telemetry configures OpenTelemetry tracing for the second-brain
+// backend and exports spans to a self-hosted Langfuse instance over
+// OTLP/HTTP.
+//
+// Langfuse does not publish a Go SDK — only Python/JS/TS. The documented
+// integration path for other languages is the standard OpenTelemetry SDK
+// talking OTLP/HTTP directly to Langfuse's OTLP receiver
+// (POST {endpoint}/api/public/otel), authenticated with HTTP Basic Auth
+// (base64(publicKey:secretKey)). This package implements exactly that path;
+// it intentionally does not depend on any Langfuse-specific client library.
+//
+// Non-blocking guarantee: this package NEVER calls
+// sdktrace.WithBlocking(). Spans are exported via a BatchSpanProcessor with
+// a bounded export timeout, so a dead or unreachable Langfuse collector can
+// only ever cause buffered spans to be dropped once the queue fills — it can
+// never stall or fail application request handling.
+package telemetry
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// ServiceName identifies this process in the OTel resource `service.name`
+// attribute and is the value Langfuse groups traces by when multiple
+// services (server, collector, eval runner) export to the same project.
+const ServiceName = "second-brain"
+
+// batchTimeout and exportTimeout are fixed per the plan's non-blocking
+// requirement (see package doc): a short export timeout bounds how long a
+// stalled collector can hold buffered spans before they are dropped, and is
+// intentionally NOT configurable — making it operator-tunable would invite
+// accidentally reintroducing blocking behavior via a very large value.
+const (
+	batchTimeout  = 5 * time.Second
+	exportTimeout = 3 * time.Second
+)
+
+// InitOTel configures the process-global OpenTelemetry TracerProvider and
+// returns a shutdown function the caller must defer.
+//
+// When endpoint is empty, tracing is fully disabled: the global
+// TracerProvider is set to a no-op implementation (noop.NewTracerProvider)
+// so every otel.Tracer(...).Start(...) call anywhere in the codebase becomes
+// a safe, side-effect-free no-op. This is the default (unconfigured)
+// behavior in local dev and CI, where LANGFUSE_OTLP_ENDPOINT is unset.
+//
+// When endpoint is non-empty, spans are batched (sdktrace.BatchSpanProcessor
+// with WithBatchTimeout(5s)/WithExportTimeout(3s) — see package doc for why
+// WithBlocking() is never used) and exported over OTLP/HTTP to endpoint,
+// authenticated via HTTP Basic Auth using publicKey/secretKey (Langfuse's
+// documented OTLP ingestion contract). endpoint is used verbatim as the
+// full OTLP traces URL — it is NOT treated as a bare host that gets
+// "/v1/traces" appended, which is otlptracehttp's default behavior for
+// WithEndpoint (as opposed to WithEndpointURL, which this function uses).
+//
+// Example endpoint for this deployment: "http://100.77.20.12:3300/api/public/otel"
+// (the langfuse-web Tailscale-interface binding, port 3300 — see the ops
+// repo's Langfuse compose). Do NOT use the public hostname
+// (https://langfuse.<domain>) here: that hostname sits behind Cloudflare
+// Access, so a server-to-server OTLP POST with no browser session gets a
+// silent 302-to-login instead of a real response, and the span is dropped
+// with no error surfaced anywhere — the failure is invisible unless someone
+// checks the Langfuse UI and wonders why it's empty.
+//
+// The returned shutdown function flushes any buffered spans and releases the
+// exporter. Callers MUST wrap invocation of the returned func with a short
+// timeout (e.g. 5s) — see package doc: a dead collector must never block
+// process shutdown.
+func InitOTel(ctx context.Context, endpoint, publicKey, secretKey string) (func(context.Context) error, error) {
+	if endpoint == "" {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		return func(context.Context) error { return nil }, nil
+	}
+
+	exp, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpointURL(endpoint),
+		otlptracehttp.WithHeaders(map[string]string{
+			"Authorization": basicAuthHeader(publicKey, secretKey),
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: create OTLP HTTP exporter: %w", err)
+	}
+
+	res := resource.NewSchemaless(
+		// Plain "service.name" key rather than a versioned semconv import —
+		// this single attribute is stable across every semconv revision, so
+		// pinning a semconv package version purely for this one key is not
+		// worth the added dependency surface (see attrs.go doc comment for
+		// the fuller rationale, which applies to the GenAI attribute keys).
+		serviceNameAttr(ServiceName),
+	)
+
+	bsp := sdktrace.NewBatchSpanProcessor(exp,
+		sdktrace.WithBatchTimeout(batchTimeout),
+		sdktrace.WithExportTimeout(exportTimeout),
+		// WithBlocking() is deliberately never called — see package doc.
+	)
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(bsp),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+
+	return tp.Shutdown, nil
+}
+
+// basicAuthHeader returns the value of an HTTP Authorization header
+// implementing Basic Auth for (publicKey, secretKey), matching Langfuse's
+// documented OTLP ingestion contract: "Basic " + base64("publicKey:secretKey").
+func basicAuthHeader(publicKey, secretKey string) string {
+	raw := publicKey + ":" + secretKey
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(raw))
+}

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -1,0 +1,111 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// resetGlobalTracerProvider restores the process-global TracerProvider to a
+// no-op implementation between tests. otel.SetTracerProvider has no "unset"
+// API, so tests that call InitOTel (which mutates global state) must clean up
+// after themselves to avoid leaking a configured provider — and its
+// background export goroutines — into unrelated tests run later in the same
+// process.
+func resetGlobalTracerProvider() {
+	otel.SetTracerProvider(noop.NewTracerProvider())
+}
+
+// TestInitOTel_NoopWhenEndpointEmpty verifies that an empty endpoint fully
+// disables tracing: the global TracerProvider becomes a no-op, span creation
+// through it is harmless (never panics, never blocks), and the returned
+// shutdown function succeeds immediately. This is the "no OTLP/Langfuse
+// configuration present" path exercised by local dev and CI.
+func TestInitOTel_NoopWhenEndpointEmpty(t *testing.T) {
+	t.Cleanup(resetGlobalTracerProvider)
+
+	shutdown, err := InitOTel(context.Background(), "", "publicKey", "secretKey")
+	if err != nil {
+		t.Fatalf("InitOTel() with empty endpoint returned error: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("InitOTel() with empty endpoint returned a nil shutdown func")
+	}
+
+	_, span := otel.Tracer("test").Start(context.Background(), "noop-span")
+	if span.IsRecording() {
+		t.Error("span created after InitOTel(empty endpoint) unexpectedly reports IsRecording()==true; expected a no-op span")
+	}
+	span.End() // must not panic
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := shutdown(ctx); err != nil {
+		t.Errorf("shutdown() after empty-endpoint InitOTel returned error: %v", err)
+	}
+}
+
+// TestInitOTel_ConfiguresRealProviderWhenEndpointSet verifies that a
+// non-empty endpoint configures a real (non-no-op) SDK TracerProvider that
+// produces recording spans and successfully exports them with the expected
+// Basic Auth header. No real Langfuse instance or external network is
+// contacted: the endpoint is a local httptest.Server stub that accepts the
+// OTLP/HTTP POST and returns 200.
+func TestInitOTel_ConfiguresRealProviderWhenEndpointSet(t *testing.T) {
+	t.Cleanup(resetGlobalTracerProvider)
+
+	var gotAuthHeader atomic.Value // string
+	var exportCalled atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		exportCalled.Store(true)
+		gotAuthHeader.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	shutdown, err := InitOTel(context.Background(), srv.URL+"/api/public/otel", "publicKey", "secretKey")
+	if err != nil {
+		t.Fatalf("InitOTel() with configured endpoint returned error: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("InitOTel() with configured endpoint returned a nil shutdown func")
+	}
+
+	_, span := otel.Tracer("test").Start(context.Background(), "recording-span")
+	if !span.IsRecording() {
+		t.Error("span created after InitOTel(configured endpoint) reports IsRecording()==false; expected a real recording span")
+	}
+	span.End()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := shutdown(ctx); err != nil {
+		t.Errorf("shutdown() after configured InitOTel returned error: %v", err)
+	}
+
+	if !exportCalled.Load() {
+		t.Error("shutdown() did not flush the buffered span to the local stub OTLP server")
+	}
+	wantAuth := basicAuthHeader("publicKey", "secretKey")
+	if got, _ := gotAuthHeader.Load().(string); got != wantAuth {
+		t.Errorf("exported span Authorization header = %q, want %q", got, wantAuth)
+	}
+}
+
+// TestInitOTel_BasicAuthHeaderEncoding verifies the Basic Auth header value
+// construction contract (base64(publicKey:secretKey)) in isolation, since
+// InitOTel itself does not expose the underlying exporter's headers for
+// direct inspection.
+func TestInitOTel_BasicAuthHeaderEncoding(t *testing.T) {
+	got := basicAuthHeader("pk-lf-abc", "sk-lf-xyz")
+	const want = "Basic cGstbGYtYWJjOnNrLWxmLXh5eg=="
+	if got != want {
+		t.Errorf("basicAuthHeader() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## 요약

- LLM 호출·임베딩·전사의 지연과 실패를 볼 수단이 전혀 없던 상태를 해소. Langfuse는 ubuntu2에 배포 완료(Cloudflare Access 뒤)
- **Langfuse 전용 Go SDK가 없어** OpenTelemetry SDK + OTLP/HTTP 사용. Langfuse v3가 OTLP를 네이티브 수신
- **재시도 구조**: `llm.complete`(부모, 재시도 루프 전체) 1개 + `llm.complete.attempt`(자식, HTTP 시도별) N개. 500→500→200 시나리오에서 부모 1·자식 3과 `Parent.SpanID()` 일치를 테스트로 고정. `EmbedBatch`도 부모/서브배치 자식 동일 패턴
- **개인정보 미캡처**: span 속성은 모델명·토큰수·지연·에러만. 프롬프트·응답 본문·전사 텍스트는 넣지 않았고, **캡처 플래그 자체를 만들지 않음**(옵션으로 두면 언젠가 켜짐). 이 시스템의 프롬프트에는 SMS·통화 전사가 들어감
- **`WithBlocking()` 미사용** — 컬렉터가 죽어도 앱이 막히지 않음. `BatchSpanProcessor`(batch 5s / export 3s)
- **미설정 시 완전 비활성화**: `LANGFUSE_OTLP_ENDPOINT`/`PUBLIC_KEY`/`SECRET_KEY`가 비면 `noop.NewTracerProvider()`. 환경변수 없이 배포해도 기존 동작 그대로
- OTLP 엔드포인트는 **Tailscale 사설 경로**(`http://100.77.20.12:3300/api/public/otel`)를 씁니다. 공개 URL(`https://langfuse.baekenough.com`)은 Cloudflare Access 뒤라 서버가 보내면 302를 받고 trace가 조용히 버려집니다
- `go.mod`: `otel/sdk`, `otlptracehttp` 직접 추가. `go mod tidy`가 `otel`, `otel/trace`도 direct로 승격(코드가 직접 import)

## 변경 파일

**신규**
- `internal/telemetry/` (otel.go, attrs.go, otel_test.go)
- `internal/llm/client_otel_test.go`
- `internal/search/embed_otel_test.go`
- `internal/collector/whisper_otel_test.go`

**수정**
- `internal/llm/client.go`, `internal/search/embed.go`, `internal/collector/whisper.go`
- `internal/config/config.go`
- `cmd/server/main.go`, `cmd/collector/main.go`, `cmd/eval/main.go`
- `go.mod`, `go.sum`

## Test plan

- [x] `go build ./...` 로컬 통과
- [x] `go test ./internal/telemetry/... ./internal/llm/... ./internal/search/... ./internal/collector/... ./internal/config/...` 로컬 통과
- [ ] CI 6개 잡 전부 통과 확인