### PR TITLE
fix(search): RRF 점수 정수 나눗셈 버그 수정

### DIFF
--- a/internal/store/document.go
+++ b/internal/store/document.go
@@ -632,11 +632,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 		rrf AS (
 			SELECT
 				COALESCE(fts.id, vec.id, bigm.id, summvec.id, entity.id) AS id,
-				COALESCE(%g/(%g + fts.rank),     0)
-				+ COALESCE(%g/(%g + vec.rank),     0)
-				+ COALESCE(%g/(%g + bigm.rank),    0)
-				+ COALESCE(%g/(%g + summvec.rank), 0)
-				+ COALESCE(%g/(%g + entity.rank),  0) AS score
+				%s AS score
 			FROM fts
 			FULL OUTER JOIN vec     ON fts.id = vec.id
 			FULL OUTER JOIN bigm    ON COALESCE(fts.id, vec.id) = bigm.id
@@ -656,11 +652,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 		statusFilter, sourceFilter, excludeFilter,
 		statusFilter, sourceFilter, excludeFilter,
 		entityCTE,
-		w.FTSWeight, w.RRFK,
-		w.VecWeight, w.RRFK,
-		w.BigmWeight, w.RRFK,
-		w.SummaryVec, w.RRFK,
-		w.EntityWeight, w.RRFK,
+		buildRRFScoreExpr(w),
 		sortOrder(query.Sort, "d"))
 
 	rows, err := s.pg.pool.Query(ctx, q, args...)
@@ -677,6 +669,34 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 		results = results[:query.Limit]
 	}
 	return results, nil
+}
+
+// buildRRFScoreExpr renders the weighted-sum SQL expression that fuses the
+// five per-lane ranks (fts, vec, bigm, summvec, entity) into a single RRF
+// relevance score.
+//
+// Every weight/k value is explicitly cast to ::float8. Go's "%g" verb formats
+// a whole-number float64 without a decimal point (1.0 -> "1", 60.0 -> "60"),
+// and the default weights (FTS/Vec/Bigm=1.0, RRFK=60.0) all format this way.
+// Without the cast, PostgreSQL parses "1/(60 + fts.rank)" as `integer`
+// division: since rank is always >= 1, the denominator is always >= 61,
+// strictly greater than the numerator, so the result truncates to 0 for every
+// row. That collapsed the fts/vec/bigm lanes' contribution to `score` to zero
+// on every hybridSearch call, leaving the final ORDER BY with no real
+// relevance signal for the vast majority of the corpus.
+func buildRRFScoreExpr(w model.SearchWeights) string {
+	return fmt.Sprintf(
+		`COALESCE(%g::float8/(%g::float8 + fts.rank),     0)
+				+ COALESCE(%g::float8/(%g::float8 + vec.rank),     0)
+				+ COALESCE(%g::float8/(%g::float8 + bigm.rank),    0)
+				+ COALESCE(%g::float8/(%g::float8 + summvec.rank), 0)
+				+ COALESCE(%g::float8/(%g::float8 + entity.rank),  0)`,
+		w.FTSWeight, w.RRFK,
+		w.VecWeight, w.RRFK,
+		w.BigmWeight, w.RRFK,
+		w.SummaryVec, w.RRFK,
+		w.EntityWeight, w.RRFK,
+	)
 }
 
 // emptyEntityCTE is the entity lane when its RRF weight is zero: a

--- a/internal/store/document_rrf_score_test.go
+++ b/internal/store/document_rrf_score_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// RRF score integer-division bug.
+//
+// hybridSearch fuses the five retrieval lanes (fts, vec, bigm, summvec,
+// entity) via a weighted RRF sum built by fmt.Sprintf("%g/(%g + <lane>.rank)",
+// weight, k). Go's "%g" verb formats a whole-number float64 WITHOUT a decimal
+// point (1.0 -> "1", 60.0 -> "60"). PostgreSQL then parses a bare numeral like
+// "1" or "60" as an `integer` literal rather than `numeric`/`double
+// precision`. Since every lane's rank is >= 1 and k defaults to 60, the
+// denominator (60 + rank) is always >= 61 -- strictly greater than a
+// numerator of 1 -- so "1/(60 + rank)" undergoes PostgreSQL's integer
+// division and truncates to 0 for every single row.
+//
+// The default weights (FTSWeight=1.0, VecWeight=1.0, BigmWeight=1.0,
+// RRFK=60.0) all format as bare integers via "%g", so in production this
+// zeroes out the fts/vec/bigm lanes' contribution to `score` on every
+// hybridSearch call. Only EntityWeight (default 0.5, which has a genuine
+// fractional part and so keeps its decimal point under "%g") survives as a
+// real float division -- and the entity lane is near-empty in production
+// (extraction only covers a small slice of the corpus), so most rows end up
+// with score=0 across the board. With the "ORDER BY score DESC" tie-break
+// providing no real signal, the final LIMIT selects whichever rows the query
+// planner's join order happens to emit first -- not the true top-N by
+// relevance. This is what caused "한영석" (a person searchable by 26 exact
+// FTS/bigm matches, all call-log/call-transcript/gmail) to return zero call
+// records: the SQL's join order consistently favoured secretary/calendar
+// documents once every lane collapsed to score=0.
+// ---------------------------------------------------------------------------
+
+// TestBuildRRFScoreExpr_NoBareIntegerDivision pins that every weight/k pair in
+// the RRF score expression is explicitly typed as floating point in the
+// generated SQL, regardless of how Go's "%g" verb happens to format the
+// underlying float64 value. A bare integer literal in a division context
+// (e.g. "1/(60 + fts.rank)") silently truncates to 0 in PostgreSQL for every
+// realistic rank value, collapsing that lane's contribution to the fused
+// score across the entire result set.
+func TestBuildRRFScoreExpr_NoBareIntegerDivision(t *testing.T) {
+	t.Parallel()
+
+	// Matches model.SearchWeights.Defaults(): FTS/Vec/Bigm=1.0, RRFK=60.0,
+	// EntityWeight=0.5 (the only weight whose default formats with a decimal
+	// point under "%g", which is exactly why this bug hid behind the entity
+	// lane's occasional nonzero score instead of surfacing as "always 0").
+	w := model.SearchWeights{
+		FTSWeight:    1.0,
+		VecWeight:    1.0,
+		BigmWeight:   1.0,
+		SummaryVec:   0.0,
+		EntityWeight: 0.5,
+		RRFK:         60.0,
+	}
+
+	got := buildRRFScoreExpr(w)
+
+	// These are the exact substrings PostgreSQL parses as integer division --
+	// if any of these appear, that lane's contribution silently truncates to
+	// 0 for every matching row.
+	bareIntegerDivisions := []string{
+		"1/(60 + fts.rank)",
+		"1/(60 + vec.rank)",
+		"1/(60 + bigm.rank)",
+	}
+	for _, bad := range bareIntegerDivisions {
+		if strings.Contains(got, bad) {
+			t.Errorf("buildRRFScoreExpr produced untyped integer division %q -- "+
+				"PostgreSQL truncates this to 0 for every row (rank >= 1, denominator >= 61 > numerator):\n%s",
+				bad, got)
+		}
+	}
+}


### PR DESCRIPTION
## 증상
사용자가 `/ask`에서 특정 인물을 물었더니 "데이터가 없다"고 답변. 실제로는 해당 인물 관련 문서가 47건 존재했음.

## 근본 원인
`hybridSearch()`가 RRF 점수 SQL을 `fmt.Sprintf("%g/(%g + fts.rank)", weight, k)`로 생성하는데, Go의 `%g`는 정수값 float64를 소수점 없이 포맷한다(`1.0`→`"1"`, `60.0`→`"60"`). 생성된 SQL `1/(60 + fts.rank)`를 PostgreSQL이 **정수 나눗셈**으로 계산하고, 분모가 항상 61 이상이라 **결과가 언제나 0**이 된다.

기본 가중치 FTS/Vec/Bigm이 전부 `1.0`, `RRFK`가 `60.0`이라 세 레인 모두 0점. `EntityWeight=0.5`만 소수점이 있어 살아남지만 엔티티가 142건분만 추출돼 사실상 비어 있음. 결과적으로 **코퍼스 전체에서 `score`가 거의 항상 0**이 되어 `ORDER BY score DESC`가 전부 동점 처리되고, 검색 결과가 플래너의 JOIN 순서에 좌우되는 임의값이 됐다(코퍼스 비중이 큰 secretary/llm-memory가 계속 상위 차지).

## 검증 (운영 DB, 읽기 전용)
- `SELECT 1/(60+5), 1.0/(60+5)` → `0` vs `0.0154` (정수 나눗셈 실증)
- 수정 전 `docStore.Search()` 상위 20건 전부 `score=0.000000`
- 수정 후 상위 20건 전부 관련 문서, score 0.0328→0.0257로 정상 하강
- 전체 파이프라인에서 관련 소스 0/20 → 10/20

## 수정
RRF 점수 SQL을 `buildRRFScoreExpr(w model.SearchWeights)`로 추출하고 각 리터럴에 `::float8` 캐스팅 추가. DB 불필요한 문자열 검증 테스트 추가(기존 `TestBuildEntityCTE_*` 패턴과 동일).

## 후속으로 분리한 것 (이 PR 범위 아님)
1. `internal/search/search.go`의 `mergeRRF`가 SQL이 계산한 가중 점수를 버리고 리스트 순번으로 재계산 — 수정 후에도 관련 없는 소스가 10/20 차지하는 원인
2. fts/vec/bigm/summvec CTE가 `LIMIT` 앞에 명시적 `ORDER BY` 없이 윈도 함수 정렬에 암묵 의존 — 이번 사례는 매치 수(26)가 LIMIT(40)보다 작아 영향 없었으나 정의되지 않은 동작에 기대는 구조
3. 통화 전사 25건이 `contact_name`을 title/tsv에 반영하지 않아 이름으로 검색되지 않음