### PR TITLE
fix(telemetry): OTLP 엔드포인트에 /v1/traces 경로 부착

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -448,9 +448,10 @@ type Config struct {
 	// so an operator who never sets these three env vars sees zero behavior
 	// change (see internal/telemetry doc comment).
 	//
-	// LangfuseOTLPEndpoint is the FULL OTLP traces URL — used verbatim, NOT a
-	// bare host that gets "/v1/traces" appended (see InitOTel's doc comment
-	// for why WithEndpointURL is used over WithEndpoint).
+	// LangfuseOTLPEndpoint is the OTLP *base* URL — InitOTel appends
+	// "/v1/traces" itself (verified against a live Langfuse deployment: the
+	// bare base path 404s, since Langfuse's own web app owns that route;
+	// see internal/telemetry's package doc "Endpoint path contract").
 	//
 	// For this deployment: "http://100.77.20.12:3300/api/public/otel" (the
 	// Tailscale-interface binding of langfuse-web). Do NOT set this to the

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -4,10 +4,23 @@
 //
 // Langfuse does not publish a Go SDK — only Python/JS/TS. The documented
 // integration path for other languages is the standard OpenTelemetry SDK
-// talking OTLP/HTTP directly to Langfuse's OTLP receiver
-// (POST {endpoint}/api/public/otel), authenticated with HTTP Basic Auth
-// (base64(publicKey:secretKey)). This package implements exactly that path;
-// it intentionally does not depend on any Langfuse-specific client library.
+// talking OTLP/HTTP directly to Langfuse's OTLP receiver, authenticated with
+// HTTP Basic Auth (base64(publicKey:secretKey)). This package implements
+// exactly that path; it intentionally does not depend on any
+// Langfuse-specific client library.
+//
+// Endpoint path contract (verified against a live deployment, not just
+// docs): the "endpoint" this package's callers configure (e.g.
+// LANGFUSE_OTLP_ENDPOINT) is Langfuse's OTLP *base* path
+// (".../api/public/otel"), NOT the literal traces-ingestion URL. Langfuse's
+// receiver actually listens at "{base}/v1/traces" — POSTing to the bare base
+// path returns the Langfuse web app's own 404 page (it's a valid route in
+// its Next.js router, just not the OTLP one), which otlptracehttp treats as
+// an ordinary failed export and silently drops the span after retries —
+// no crash, no visible error unless you go looking. This mirrors the
+// standard OTEL_EXPORTER_OTLP_ENDPOINT convention (base URL, "/v1/traces"
+// auto-appended), so InitOTel appends "/v1/traces" itself rather than
+// requiring every caller to remember to include it in the configured value.
 //
 // Non-blocking guarantee: this package NEVER calls
 // sdktrace.WithBlocking(). Spans are exported via a BatchSpanProcessor with
@@ -20,6 +33,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -28,6 +42,12 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
+
+// otlpTracesPath is appended to the configured base endpoint to form the
+// actual OTLP traces ingestion URL — see the package doc's "Endpoint path
+// contract" section for why this cannot simply be baked into the endpoint
+// value callers configure.
+const otlpTracesPath = "/v1/traces"
 
 // ServiceName identifies this process in the OTel resource `service.name`
 // attribute and is the value Langfuse groups traces by when multiple
@@ -55,12 +75,10 @@ const (
 //
 // When endpoint is non-empty, spans are batched (sdktrace.BatchSpanProcessor
 // with WithBatchTimeout(5s)/WithExportTimeout(3s) — see package doc for why
-// WithBlocking() is never used) and exported over OTLP/HTTP to endpoint,
-// authenticated via HTTP Basic Auth using publicKey/secretKey (Langfuse's
-// documented OTLP ingestion contract). endpoint is used verbatim as the
-// full OTLP traces URL — it is NOT treated as a bare host that gets
-// "/v1/traces" appended, which is otlptracehttp's default behavior for
-// WithEndpoint (as opposed to WithEndpointURL, which this function uses).
+// WithBlocking() is never used) and exported over OTLP/HTTP, authenticated
+// via HTTP Basic Auth using publicKey/secretKey (Langfuse's documented OTLP
+// ingestion contract). endpoint is the OTLP *base* URL — "/v1/traces" is
+// appended automatically (see the package doc's "Endpoint path contract").
 //
 // Example endpoint for this deployment: "http://100.77.20.12:3300/api/public/otel"
 // (the langfuse-web Tailscale-interface binding, port 3300 — see the ops
@@ -81,8 +99,10 @@ func InitOTel(ctx context.Context, endpoint, publicKey, secretKey string) (func(
 		return func(context.Context) error { return nil }, nil
 	}
 
+	tracesURL := strings.TrimRight(endpoint, "/") + otlpTracesPath
+
 	exp, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithEndpointURL(endpoint),
+		otlptracehttp.WithEndpointURL(tracesURL),
 		otlptracehttp.WithHeaders(map[string]string{
 			"Authorization": basicAuthHeader(publicKey, secretKey),
 		}),

--- a/internal/telemetry/otel_test.go
+++ b/internal/telemetry/otel_test.go
@@ -54,15 +54,30 @@ func TestInitOTel_NoopWhenEndpointEmpty(t *testing.T) {
 // TestInitOTel_ConfiguresRealProviderWhenEndpointSet verifies that a
 // non-empty endpoint configures a real (non-no-op) SDK TracerProvider that
 // produces recording spans and successfully exports them with the expected
-// Basic Auth header. No real Langfuse instance or external network is
-// contacted: the endpoint is a local httptest.Server stub that accepts the
-// OTLP/HTTP POST and returns 200.
+// Basic Auth header, POSTed to "{endpoint}/v1/traces" — NOT the bare
+// endpoint. This locks in a real deployment finding: Langfuse's OTLP
+// receiver lives at "{base}/v1/traces", and POSTing to the bare base path
+// (which otlptracehttp.WithEndpointURL would do if InitOTel used the
+// configured endpoint verbatim) hits Langfuse's own web app router and gets
+// a silently-swallowed 404 instead of a real export — see InitOTel's doc
+// comment "Endpoint path contract". The stub server below only accepts the
+// "/v1/traces" path and 404s everything else, so this test would have
+// caught that exact regression. No real Langfuse instance or external
+// network is contacted.
 func TestInitOTel_ConfiguresRealProviderWhenEndpointSet(t *testing.T) {
 	t.Cleanup(resetGlobalTracerProvider)
 
 	var gotAuthHeader atomic.Value // string
+	var gotPath atomic.Value       // string
 	var exportCalled atomic.Bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		if r.URL.Path != "/api/public/otel/v1/traces" {
+			// Mirrors the real Langfuse deployment: anything other than the
+			// exact OTLP traces path 404s via the web app's own router.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		exportCalled.Store(true)
 		gotAuthHeader.Store(r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusOK)
@@ -89,6 +104,9 @@ func TestInitOTel_ConfiguresRealProviderWhenEndpointSet(t *testing.T) {
 		t.Errorf("shutdown() after configured InitOTel returned error: %v", err)
 	}
 
+	if got, _ := gotPath.Load().(string); got != "/api/public/otel/v1/traces" {
+		t.Fatalf("exporter POSTed to path %q, want \"/api/public/otel/v1/traces\" (InitOTel must append /v1/traces to the configured base endpoint)", got)
+	}
 	if !exportCalled.Load() {
 		t.Error("shutdown() did not flush the buffered span to the local stub OTLP server")
 	}


### PR DESCRIPTION
## 요약
- PR #185로 들어간 OTel 계측이 **trace를 한 건도 전송하지 못하는 상태**였음
- 원인: `otlptracehttp.WithEndpointURL(endpoint)`가 설정값을 최종 URL로 그대로 사용. 설정값 `.../api/public/otel`은 Langfuse가 `OTEL_EXPORTER_OTLP_ENDPOINT`에 넣으라고 안내하는 **base URL**이며, 실제 수신기는 `{base}/v1/traces`
- 실측 (운영 Langfuse에 직접 요청):
  - `POST .../api/public/otel` → **404**
  - `POST .../api/public/otel/v1/traces` → **200**
- `BatchSpanProcessor`가 비차단이라 앱은 정상 동작하고 **trace만 조용히 유실**되는 형태 — 배포 후에도 "Langfuse에 아무것도 안 뜬다"로만 드러났을 문제
- 수정: endpoint를 base URL로 취급하고 InitOTel이 `/v1/traces`를 자동 부착. 표준 `OTEL_EXPORTER_OTLP_ENDPOINT` 규약과 일치

## 변경 파일
- `internal/telemetry/otel.go` — endpoint를 base URL로 취급, `otlpTracesPath` 상수 추가 및 부착
- `internal/config/config.go` — 주석을 base URL 규약으로 정정
- `internal/telemetry/otel_test.go` — 실제 배포에서 확인된 경로 계약을 회귀 테스트로 고정 (`/v1/traces` 외 경로는 404 반환하는 스텁 서버)

## 테스트 계획
- [x] `internal/telemetry/otel_test.go` 회귀 테스트로 정확한 경로(`{base}/v1/traces`) 검증
- [x] CI 전체 통과 확인 후 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)