### PR TITLE
fix(search): keep chunk-vector results additive instead of displacing document matches

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -345,9 +345,38 @@ func (s *Service) searchChunksVector(ctx context.Context, queryVec []float32, li
 
 // mergeRRF fuses two ranked result lists using Reciprocal Rank Fusion.
 // k=60 is the standard RRF constant (same as the document store's fusion).
-// Results are deduplicated by document ID: when a document appears in both
-// lists, the RRF score from both ranks is summed. The merged list is
-// truncated to limit entries, ordered by descending RRF score.
+//
+// primary and secondary are NOT equal-standing evidence. primary is the
+// document store's own hybrid fusion of up to five independently-weighted
+// signals (fts/vec/bigm/summvec/entity — see hybridSearch in
+// internal/store/document.go); secondary is a single un-corroborated
+// semantic signal (raw chunk-embedding proximity, no term-match required).
+// Naively rank-fusing two lists of the same size with equal weight lets a
+// same-size secondary list that shares no documents with primary evict half
+// of primary's genuinely matched results — measured against production data
+// for the proper-noun query "한영석" (a name absent from every secretary
+// document): primary alone returned 20/20 documents containing the literal
+// name; the chunk-vector secondary list, fetched and deduplicated exactly as
+// production does, was 20/20 documents that did NOT contain the name at all
+// and shared zero IDs with primary. Equal-weight RRF replaced half of the
+// correct results with these unrelated documents.
+//
+// The fix keeps secondary genuinely supplementary rather than competing:
+//   - A document present in BOTH lists gets its score summed (boosted) —
+//     primary's document-level fusion and secondary's passage-level match
+//     independently agree the document is relevant, which is a real signal.
+//   - A document present ONLY in secondary is admitted as a new result ONLY
+//     while primary has not yet filled the requested page (limit). Once
+//     primary supplies `limit` results, a lone chunk-vector hit is not
+//     sufficient grounds to displace one of them.
+//   - When primary is short of `limit` (including empty), secondary still
+//     fills the remaining slots — preserving chunk search's designed roles:
+//     surfacing a passage in a long document that primary's document-level
+//     scoring missed, and acting as a semantic-only fallback when primary
+//     finds nothing.
+//
+// Results are deduplicated by document ID and the merged list is truncated
+// to limit entries, ordered by descending RRF score.
 func mergeRRF(primary, secondary []*model.SearchResult, limit int) []*model.SearchResult {
 	const k = 60.0
 
@@ -357,19 +386,29 @@ func mergeRRF(primary, secondary []*model.SearchResult, limit int) []*model.Sear
 	}
 	merged := make(map[uuid.UUID]*entry, len(primary)+len(secondary))
 
-	addList := func(list []*model.SearchResult) {
-		for rank, r := range list {
-			rrf := 1.0 / (k + float64(rank+1))
-			if e, ok := merged[r.ID]; ok {
-				e.score += rrf
-			} else {
-				cp := *r // shallow copy — do not mutate callers' slice
-				merged[r.ID] = &entry{result: &cp, score: rrf}
-			}
-		}
+	for rank, r := range primary {
+		rrf := 1.0 / (k + float64(rank+1))
+		cp := *r // shallow copy — do not mutate callers' slice
+		merged[r.ID] = &entry{result: &cp, score: rrf}
 	}
-	addList(primary)
-	addList(secondary)
+
+	// Slots still open for brand-new (secondary-only) documents. Negative or
+	// zero means primary already filled the page.
+	remaining := limit - len(primary)
+
+	for rank, r := range secondary {
+		rrf := 1.0 / (k + float64(rank+1))
+		if e, ok := merged[r.ID]; ok {
+			e.score += rrf
+			continue
+		}
+		if remaining <= 0 {
+			continue
+		}
+		cp := *r
+		merged[r.ID] = &entry{result: &cp, score: rrf}
+		remaining--
+	}
 
 	out := make([]*model.SearchResult, 0, len(merged))
 	for _, e := range merged {

--- a/internal/search/search_chunk_vector_test.go
+++ b/internal/search/search_chunk_vector_test.go
@@ -262,3 +262,89 @@ func TestSearchChunksVector_Empty(t *testing.T) {
 		t.Fatalf("want 0 results, got %d", len(got))
 	}
 }
+
+// TestMergeRRF_FullPrimary_SecondaryDoesNotDisplace reproduces the production
+// bug behind a proper-noun query ("한영석") returning "secretary 10 + call-log
+// 10" for a name that exists in zero secretary documents. Root cause,
+// confirmed against prod data: the chunk-vector secondary list is a single
+// un-corroborated semantic (embedding-only) signal with no term-match
+// requirement, while primary already fuses up to five independently-weighted
+// signals in the document store (fts/vec/bigm/summvec/entity). When primary
+// already fills the requested page with genuine matches, RRF's rank-only,
+// equal-weight fusion let a same-size secondary list that shares NO documents
+// with primary evict half of the correct results — reproduced exactly by this
+// test's 3-and-3, zero-overlap setup.
+func TestMergeRRF_FullPrimary_SecondaryDoesNotDisplace(t *testing.T) {
+	t.Parallel()
+
+	// primary: 3 documents that genuinely matched the query term (e.g. via
+	// fts/bigm), filling the requested limit.
+	p1 := uuid.MustParse("00000000-0000-0000-0000-000000000101")
+	p2 := uuid.MustParse("00000000-0000-0000-0000-000000000102")
+	p3 := uuid.MustParse("00000000-0000-0000-0000-000000000103")
+	primary := []*model.SearchResult{
+		makeSearchResult(p1, "call-log match 1", 0.9),
+		makeSearchResult(p2, "call-log match 2", 0.8),
+		makeSearchResult(p3, "call-log match 3", 0.7),
+	}
+
+	// secondary: 3 UNRELATED documents (no term overlap, no shared IDs with
+	// primary) that merely happen to be the closest embeddings by chance —
+	// exactly what the prod probe measured for the chunk-vector lane.
+	s1 := uuid.MustParse("00000000-0000-0000-0000-000000000201")
+	s2 := uuid.MustParse("00000000-0000-0000-0000-000000000202")
+	s3 := uuid.MustParse("00000000-0000-0000-0000-000000000203")
+	secondary := []*model.SearchResult{
+		makeSearchResult(s1, "unrelated secretary note 1", 0.95),
+		makeSearchResult(s2, "unrelated secretary note 2", 0.93),
+		makeSearchResult(s3, "unrelated secretary note 3", 0.91),
+	}
+
+	got := mergeRRF(primary, secondary, 3)
+
+	if len(got) != 3 {
+		t.Fatalf("want 3 results, got %d: %+v", len(got), got)
+	}
+	want := map[uuid.UUID]bool{p1: true, p2: true, p3: true}
+	for _, r := range got {
+		if !want[r.ID] {
+			t.Errorf("secondary-only document %s (%q) displaced a primary match; got %+v",
+				r.ID, r.Title, got)
+		}
+	}
+}
+
+// TestMergeRRF_PartialPrimary_SecondaryFillsRemainingSlots verifies that
+// secondary still supplies new documents — preserving its designed role of
+// surfacing passages the whole-document search missed, and of acting as a
+// semantic fallback — whenever primary does not already fill the page.
+func TestMergeRRF_PartialPrimary_SecondaryFillsRemainingSlots(t *testing.T) {
+	t.Parallel()
+
+	p1 := uuid.MustParse("00000000-0000-0000-0000-000000000301")
+	primary := []*model.SearchResult{
+		makeSearchResult(p1, "the one real match", 0.9),
+	}
+
+	s1 := uuid.MustParse("00000000-0000-0000-0000-000000000401")
+	s2 := uuid.MustParse("00000000-0000-0000-0000-000000000402")
+	secondary := []*model.SearchResult{
+		makeSearchResult(s1, "relevant passage in a long doc", 0.85),
+		makeSearchResult(s2, "another relevant passage", 0.80),
+	}
+
+	got := mergeRRF(primary, secondary, 3)
+
+	if len(got) != 3 {
+		t.Fatalf("want 3 results (1 primary + 2 secondary fill-in), got %d: %+v", len(got), got)
+	}
+	found := map[uuid.UUID]bool{}
+	for _, r := range got {
+		found[r.ID] = true
+	}
+	for _, id := range []uuid.UUID{p1, s1, s2} {
+		if !found[id] {
+			t.Errorf("want document %s present in merged results, got %+v", id, got)
+		}
+	}
+}


### PR DESCRIPTION
## 증상

인물명 `한영석` 검색 시 상위 20건이 `secretary 10 + call-log 10`. secretary 문서들은 해당 이름을 아예 포함하지 않음 (운영 DB 확인: 이름 포함 문서는 call-transcript 25 / call-log 21 / gmail 1, secretary 0건).

## 근본 원인 (운영 DB 실측)

- `primary` (문서 하이브리드 검색, 5개 신호 가중 융합) = call-log 20/20, 전부 실제 이름 포함
- `secondary` (청크 벡터 검색, 순수 의미 유사도) = secretary 20/20, 전부 이름 미포함, primary와 ID 중복 0건
- `mergeRRF`가 두 리스트를 순위만으로 동등 가중 합산해 절반을 교체

`search.go`의 기존 주석은 이미 "chunk signals are ADDITIVE... never replace"라고 적고 있었으나 구현이 그 의도를 어기고 있었음.

## 수정

secondary는 (a) primary에 이미 있는 문서의 점수를 boost만 하고, (b) primary가 `limit`을 못 채웠을 때 남은 슬롯만 채운다. 매직 넘버 없는 구조적 규칙이며 주석에 적힌 원래 설계를 복원.

검토 후 기각한 대안: 리스트별 고정 가중치, secondary의 k값 확대 — 둘 다 "몇으로 할지"의 근거가 없어 임의 상수가 됨.

## 결과

같은 질의에서 call-log 10 → 20. 기존 `mergeRRF` 테스트 5건 + insight 제외 테스트 2건 전부 통과 유지, 실패 테스트 2건 신규 추가.

## 후속 과제로 분리 (이 PR 범위 아님)

1. HNSW `ef_search` 정확도 — `hnsw.ef_search=40` (기본값)이 `status='active'` 필터와 결합되면 반환 top-40 중 37개가 브루트포스 정답과 불일치하고 실제 정답 15건을 누락. `ef_search=1000`으로도 15/40 불일치 잔존. `document.go`의 `vec`/`summvec`, `chunks.go`의 `SearchVector` 모두 영향
2. 문서 레벨 `vec`/`summvec` 레인도 동일한 "동등 가중" 구조 문제를 가짐
3. 통화 전사가 `contact_name`을 title/tsv에 미반영해 이름으로 검색 불가

🤖 Generated with [Claude Code](https://claude.com/claude-code)
