### PR TITLE
fix(search): temporal 질의에 날짜 범위 필터 적용

### DIFF
--- a/internal/api/ask_retrieval.go
+++ b/internal/api/ask_retrieval.go
@@ -59,8 +59,20 @@ func assembleRetrieval(ctx context.Context, searcher documentSearcher, params in
 		// not a separate field — no such field exists on model.SearchQuery.
 		base.Weights.EntityWeight = 1.5
 	case params.Kind == intent.KindTemporal && params.Confidence >= confidenceThreshold:
-		// Approximation only (spec discrepancy #3): model.SearchQuery has no
-		// date-range field, so recency sort is the best available proxy.
+		// The window intent.Classify computed is passed through to the store,
+		// which applies it as a WHERE predicate inside every retrieval lane.
+		// This is the part that actually retrieves: recency sort alone only
+		// permutes the candidates a lane already selected, so a source that is four
+		// orders of magnitude smaller than the corpus (calendar: ~14 documents
+		// against ~18k SMS) never entered the candidate set to be sorted.
+		//
+		// Sort stays "recent" as a secondary preference — within a window,
+		// newest-first is the sensible reading order.
+		//
+		// Bounds may be nil (LLM-classified temporal intent carries no dates);
+		// nil means "unbounded on that side" and is passed through as-is.
+		base.OccurredFrom = params.OccurredFrom
+		base.OccurredTo = params.OccurredTo
 		base.Sort = "recent"
 	case params.Kind == intent.KindExactToken:
 		// Best-effort nudge toward the bigram-similarity lane; does not fix

--- a/internal/api/ask_retrieval_test.go
+++ b/internal/api/ask_retrieval_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/baekenough/second-brain/internal/intent"
 	"github.com/baekenough/second-brain/internal/model"
@@ -69,6 +70,134 @@ func TestAssembleRetrieval_KindTemporal_SortsRecent(t *testing.T) {
 
 	if searcher.calls[0].Sort != "recent" {
 		t.Errorf("Observed query Sort = %q, want %q", searcher.calls[0].Sort, "recent")
+	}
+}
+
+// TestAssembleRetrieval_KindTemporal_PropagatesOccurredRange pins the half of
+// the temporal lane that used to be dropped on the floor. intent.Classify
+// already computes an exact [from, to) window for "오늘"/"어제"/"지난달"/…, but
+// Stage 2 kept only Sort="recent" — and sorting cannot retrieve a document that
+// the store's candidate lanes never selected. The window has to reach
+// model.SearchQuery for the store to constrain the candidate pool at all.
+func TestAssembleRetrieval_KindTemporal_PropagatesOccurredRange(t *testing.T) {
+	t.Parallel()
+	searcher := &recordingSearcher{}
+	from := time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+	params := intent.Params{
+		RawQuery:     "오늘 일정에 대해 알려줘",
+		Kind:         intent.KindTemporal,
+		OccurredFrom: &from,
+		OccurredTo:   &to,
+		Confidence:   1.0,
+	}
+
+	if _, err := assembleRetrieval(context.Background(), searcher, params, 8, 3); err != nil {
+		t.Fatalf("assembleRetrieval() error = %v", err)
+	}
+
+	if len(searcher.calls) != 2 {
+		t.Fatalf("got %d calls, want 2", len(searcher.calls))
+	}
+	// Both lanes must carry the window: an insight lane left unbounded would
+	// reintroduce out-of-window material through the Inferred layer.
+	for i, name := range []string{"observed", "inferred"} {
+		q := searcher.calls[i]
+		if q.OccurredFrom == nil || !q.OccurredFrom.Equal(from) {
+			t.Errorf("%s query OccurredFrom = %v, want %s", name, q.OccurredFrom, from)
+		}
+		if q.OccurredTo == nil || !q.OccurredTo.Equal(to) {
+			t.Errorf("%s query OccurredTo = %v, want %s", name, q.OccurredTo, to)
+		}
+	}
+}
+
+// TestAssembleRetrieval_KindTemporal_NilBounds_NoRange covers the temporal
+// classification that carries no dates (the LLM path, which sets Kind without
+// computing a window). Recency sort remains the only available shaping; the
+// query must not gain a half-open window with a zero-value bound.
+func TestAssembleRetrieval_KindTemporal_NilBounds_NoRange(t *testing.T) {
+	t.Parallel()
+	searcher := &recordingSearcher{}
+	params := intent.Params{RawQuery: "최근에 뭐 있었지", Kind: intent.KindTemporal, Confidence: 0.8}
+
+	if _, err := assembleRetrieval(context.Background(), searcher, params, 8, 3); err != nil {
+		t.Fatalf("assembleRetrieval() error = %v", err)
+	}
+
+	q := searcher.calls[0]
+	if q.OccurredFrom != nil || q.OccurredTo != nil {
+		t.Errorf("query gained a window from a date-less temporal intent: from=%v to=%v", q.OccurredFrom, q.OccurredTo)
+	}
+	if q.Sort != "recent" {
+		t.Errorf("Sort = %q, want %q", q.Sort, "recent")
+	}
+}
+
+// TestAssembleRetrieval_LowConfidenceTemporal_NoRange pins that the window is
+// gated by the same confidence threshold as every other shaping decision. A
+// wrongly-classified temporal query that still narrowed the candidate pool
+// would turn a low-confidence guess into silently missing evidence.
+func TestAssembleRetrieval_LowConfidenceTemporal_NoRange(t *testing.T) {
+	t.Parallel()
+	searcher := &recordingSearcher{}
+	from := time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+	params := intent.Params{
+		RawQuery:     "그때 얘기",
+		Kind:         intent.KindTemporal,
+		OccurredFrom: &from,
+		OccurredTo:   &to,
+		Confidence:   0.2,
+	}
+
+	if _, err := assembleRetrieval(context.Background(), searcher, params, 8, 3); err != nil {
+		t.Fatalf("assembleRetrieval() error = %v", err)
+	}
+
+	q := searcher.calls[0]
+	if q.OccurredFrom != nil || q.OccurredTo != nil {
+		t.Errorf("low-confidence temporal query narrowed the candidate pool: from=%v to=%v", q.OccurredFrom, q.OccurredTo)
+	}
+}
+
+// TestAssembleRetrieval_KindTemporal_OneSidedWindow covers a bound-on-one-side
+// window ("이후"/"이전" style). Whichever side intent supplied must survive, and
+// the other must stay nil rather than being defaulted to a zero time.
+func TestAssembleRetrieval_KindTemporal_OneSidedWindow(t *testing.T) {
+	t.Parallel()
+	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+	searcher := &recordingSearcher{}
+	params := intent.Params{RawQuery: "8월 이후", Kind: intent.KindTemporal, OccurredFrom: &from, Confidence: 1.0}
+	if _, err := assembleRetrieval(context.Background(), searcher, params, 8, 3); err != nil {
+		t.Fatalf("assembleRetrieval() error = %v", err)
+	}
+	q := searcher.calls[0]
+	if q.OccurredFrom == nil || !q.OccurredFrom.Equal(from) {
+		t.Errorf("OccurredFrom = %v, want %s", q.OccurredFrom, from)
+	}
+	if q.OccurredTo != nil {
+		t.Errorf("OccurredTo = %v, want nil (intent supplied no upper bound)", q.OccurredTo)
+	}
+}
+
+// TestAssembleRetrieval_NonTemporalKinds_NoRange pins that no other intent kind
+// leaks a window into the query.
+func TestAssembleRetrieval_NonTemporalKinds_NoRange(t *testing.T) {
+	t.Parallel()
+	for _, params := range []intent.Params{
+		{RawQuery: "김대표", Kind: intent.KindEntity, Confidence: 0.9},
+		{RawQuery: "010-1234-5678", Kind: intent.KindExactToken, Confidence: 1.0},
+		{RawQuery: "요즘 어때", Kind: intent.KindGeneral, Confidence: 0},
+	} {
+		searcher := &recordingSearcher{}
+		if _, err := assembleRetrieval(context.Background(), searcher, params, 8, 3); err != nil {
+			t.Fatalf("Kind=%s: assembleRetrieval() error = %v", params.Kind, err)
+		}
+		if q := searcher.calls[0]; q.OccurredFrom != nil || q.OccurredTo != nil {
+			t.Errorf("Kind=%s gained a window: from=%v to=%v", params.Kind, q.OccurredFrom, q.OccurredTo)
+		}
 	}
 }
 

--- a/internal/intent/day_boundary_test.go
+++ b/internal/intent/day_boundary_test.go
@@ -1,0 +1,245 @@
+package intent_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/intent"
+)
+
+// ---------------------------------------------------------------------------
+// Window boundary semantics.
+//
+// Every range Classify produces is consumed as a HALF-OPEN interval
+// [OccurredFrom, OccurredTo): internal/store/document.go binds them to
+// `occurred_at >= $from AND occurred_at < $to` in every retrieval lane.
+//
+// The upper bounds used to be the last whole second of the period
+// (23:59:59.000). Under `<` that silently drops the final second — anything
+// stamped 23:59:59.000000001 through 23:59:59.999999999 falls outside "오늘".
+// It was harmless while OccurredTo was unused; it became a real hole the moment
+// the store started honouring it. These tests pin the bound at the START OF THE
+// NEXT PERIOD so the interval covers the whole period exactly once, and pin the
+// consequence (the last instant of the period is inside the window) so the
+// regression cannot come back through a "tidier-looking" 23:59:59.
+//
+// KST is used deliberately: the classifier resolves calendar days in
+// now.Location(), and a UTC-only test would pass even if the day boundary were
+// computed in the wrong zone.
+// ---------------------------------------------------------------------------
+
+// kst is Asia/Seoul as a fixed +09:00 zone. Korea observes no DST, so a fixed
+// offset is exact and keeps the test independent of the host's tzdata.
+var kst = time.FixedZone("KST", 9*60*60)
+
+// inHalfOpen reports whether ts falls in [from, to) — the exact predicate the
+// store applies. Tests assert through this rather than comparing bounds alone,
+// so they describe the behaviour users get, not an implementation detail.
+func inHalfOpen(ts, from, to time.Time) bool {
+	return !ts.Before(from) && ts.Before(to)
+}
+
+// TestClassify_WindowBoundsAreNextPeriodStart pins each deterministic date
+// phrase's upper bound to the start of the following period.
+func TestClassify_WindowBoundsAreNextPeriodStart(t *testing.T) {
+	t.Parallel()
+
+	// 2026-08-17 14:30 KST — a Monday, so the ISO week starts the same day.
+	now := time.Date(2026, 8, 17, 14, 30, 0, 0, kst)
+
+	cases := []struct {
+		name     string
+		question string
+		wantFrom time.Time
+		wantTo   time.Time
+	}{
+		{
+			name:     "오늘 ends at tomorrow 00:00, not 23:59:59",
+			question: "오늘 일정에 대해 알려줘",
+			wantFrom: time.Date(2026, 8, 17, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 18, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "어제 ends where 오늘 begins",
+			question: "어제 뭐 했지",
+			wantFrom: time.Date(2026, 8, 16, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 17, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "이번 주 ends at next Monday 00:00",
+			question: "이번 주 요약해줘",
+			wantFrom: time.Date(2026, 8, 17, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 24, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "지난달 ends at this month's first day",
+			question: "지난달에 뭐 있었지",
+			wantFrom: time.Date(2026, 7, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 1, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "explicit month ends at the next month's first day",
+			question: "2026년 6월 요약해줘",
+			wantFrom: time.Date(2026, 6, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 7, 1, 0, 0, 0, 0, kst),
+		},
+		{
+			// December must roll into the next YEAR, not produce month 13.
+			name:     "December rolls over into the next year",
+			question: "2026년 12월 요약해줘",
+			wantFrom: time.Date(2026, 12, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2027, 1, 1, 0, 0, 0, 0, kst),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
+			c := newClassifier(t, fake, now)
+
+			got, err := c.Classify(context.Background(), tc.question)
+			if err != nil {
+				t.Fatalf("Classify returned non-nil error (contract violation): %v", err)
+			}
+			if got.OccurredFrom == nil || !got.OccurredFrom.Equal(tc.wantFrom) {
+				t.Fatalf("OccurredFrom = %v, want %v", got.OccurredFrom, tc.wantFrom)
+			}
+			if got.OccurredTo == nil || !got.OccurredTo.Equal(tc.wantTo) {
+				t.Fatalf("OccurredTo = %v, want %v", got.OccurredTo, tc.wantTo)
+			}
+		})
+	}
+}
+
+// TestClassify_LastInstantOfPeriodIsInsideWindow is the regression pin. It
+// states the user-visible property directly: an event at the very last instant
+// of "오늘" is part of "오늘". A 23:59:59 upper bound fails every subtest here.
+func TestClassify_LastInstantOfPeriodIsInsideWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 14, 30, 0, 0, kst)
+
+	cases := []struct {
+		name        string
+		question    string
+		lastInstant time.Time // the final nanosecond of the period being named
+	}{
+		{
+			name:        "오늘",
+			question:    "오늘 일정에 대해 알려줘",
+			lastInstant: time.Date(2026, 8, 17, 23, 59, 59, int(time.Second-time.Nanosecond), kst),
+		},
+		{
+			name:        "어제",
+			question:    "어제 뭐 했지",
+			lastInstant: time.Date(2026, 8, 16, 23, 59, 59, int(time.Second-time.Nanosecond), kst),
+		},
+		{
+			name:        "이번 주",
+			question:    "이번 주 요약해줘",
+			lastInstant: time.Date(2026, 8, 23, 23, 59, 59, int(time.Second-time.Nanosecond), kst),
+		},
+		{
+			name:        "지난달",
+			question:    "지난달에 뭐 있었지",
+			lastInstant: time.Date(2026, 7, 31, 23, 59, 59, int(time.Second-time.Nanosecond), kst),
+		},
+		{
+			name:        "explicit month",
+			question:    "2026년 6월 요약해줘",
+			lastInstant: time.Date(2026, 6, 30, 23, 59, 59, int(time.Second-time.Nanosecond), kst),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
+			c := newClassifier(t, fake, now)
+
+			got, err := c.Classify(context.Background(), tc.question)
+			if err != nil {
+				t.Fatalf("Classify returned non-nil error: %v", err)
+			}
+			if got.OccurredFrom == nil || got.OccurredTo == nil {
+				t.Fatalf("Classify produced no window: from=%v to=%v", got.OccurredFrom, got.OccurredTo)
+			}
+
+			if !inHalfOpen(tc.lastInstant, *got.OccurredFrom, *got.OccurredTo) {
+				t.Errorf("an event at %s — the last instant of %s — falls outside the window [%s, %s); the final second of the period is being dropped",
+					tc.lastInstant, tc.name, *got.OccurredFrom, *got.OccurredTo)
+			}
+			// The complement: the first instant of the NEXT period must NOT be
+			// inside, or consecutive windows would overlap and double-count.
+			firstOfNext := tc.lastInstant.Add(time.Nanosecond)
+			if inHalfOpen(firstOfNext, *got.OccurredFrom, *got.OccurredTo) {
+				t.Errorf("%s: %s belongs to the next period but falls inside [%s, %s)",
+					tc.name, firstOfNext, *got.OccurredFrom, *got.OccurredTo)
+			}
+		})
+	}
+}
+
+// TestClassify_ConsecutiveDayWindowsTile pins that 어제 and 오늘 meet exactly:
+// no gap (an event would belong to neither) and no overlap (it would belong to
+// both). This is the property a half-open interval exists to provide.
+func TestClassify_ConsecutiveDayWindowsTile(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 17, 14, 30, 0, 0, kst)
+
+	classify := func(q string) intent.Params {
+		t.Helper()
+		fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
+		got, err := newClassifier(t, fake, now).Classify(context.Background(), q)
+		if err != nil {
+			t.Fatalf("Classify(%q) error: %v", q, err)
+		}
+		if got.OccurredFrom == nil || got.OccurredTo == nil {
+			t.Fatalf("Classify(%q) produced no window", q)
+		}
+		return got
+	}
+
+	yesterday := classify("어제 뭐 했지")
+	today := classify("오늘 일정에 대해 알려줘")
+
+	if !yesterday.OccurredTo.Equal(*today.OccurredFrom) {
+		t.Errorf("어제 ends at %s but 오늘 starts at %s — consecutive day windows must meet exactly",
+			*yesterday.OccurredTo, *today.OccurredFrom)
+	}
+}
+
+// TestClassify_DayBoundaryFollowsCallerTimezone pins that the calendar day is
+// resolved in the clock's own location. The reference instant below is late
+// evening in KST but the PREVIOUS day in UTC, so a classifier that silently
+// normalised to UTC would return the wrong day entirely.
+func TestClassify_DayBoundaryFollowsCallerTimezone(t *testing.T) {
+	t.Parallel()
+
+	// 2026-08-18 08:00 KST == 2026-08-17 23:00 UTC.
+	now := time.Date(2026, 8, 18, 8, 0, 0, 0, kst)
+
+	fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
+	got, err := newClassifier(t, fake, now).Classify(context.Background(), "오늘 일정에 대해 알려줘")
+	if err != nil {
+		t.Fatalf("Classify returned non-nil error: %v", err)
+	}
+	if got.OccurredFrom == nil || got.OccurredTo == nil {
+		t.Fatalf("Classify produced no window")
+	}
+
+	wantFrom := time.Date(2026, 8, 18, 0, 0, 0, 0, kst)
+	wantTo := time.Date(2026, 8, 19, 0, 0, 0, 0, kst)
+	if !got.OccurredFrom.Equal(wantFrom) || !got.OccurredTo.Equal(wantTo) {
+		t.Errorf("window = [%s, %s), want [%s, %s) — the day boundary must follow the caller's zone, not UTC",
+			*got.OccurredFrom, *got.OccurredTo, wantFrom, wantTo)
+	}
+}

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -189,30 +189,52 @@ func extractJSON(s string) string {
 	return s[start : end+1]
 }
 
-// monthRange returns [00:00:00 on day 1, 23:59:59 on the last day] of the
-// given year/month in loc. The last-day computation uses the standard Go
-// idiom: day 0 of the following month is the last day of the given month.
+// The three range helpers below all return a HALF-OPEN interval [from, to):
+// `from` is the first instant of the period and `to` is the first instant of
+// the NEXT period, never the period's own last second.
+//
+// This is not a stylistic choice. Params.OccurredFrom/OccurredTo are bound by
+// internal/store/document.go to `occurred_at >= $from AND occurred_at < $to` in
+// every retrieval lane. An upper bound of 23:59:59 under a strict `<` drops
+// everything in the final second of the period — and, worse, leaves a gap
+// between consecutive periods, so an event stamped in that gap belongs to
+// neither "어제" nor "오늘". Anchoring `to` to the next period's start makes
+// consecutive windows tile exactly: no gap, no overlap.
+//
+// All three resolve calendar boundaries in the caller's own location (the
+// clock's zone, via t.Location() / the loc argument), so "오늘" means today in
+// Seoul for a Seoul-based deployment rather than today in UTC.
+
+// monthRange returns [00:00:00 on day 1 of the given month, 00:00:00 on day 1
+// of the following month) in loc. December is handled by time.Date's own
+// normalisation: month 13 rolls over into January of the next year.
 func monthRange(year, month int, loc *time.Location) (time.Time, time.Time) {
 	from := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, loc)
-	to := time.Date(year, time.Month(month)+1, 0, 23, 59, 59, 0, loc)
+	to := time.Date(year, time.Month(month)+1, 1, 0, 0, 0, 0, loc)
 	return from, to
 }
 
-// dayRange returns [00:00:00, 23:59:59] for the calendar day containing t.
+// dayRange returns [00:00:00 today, 00:00:00 tomorrow) for the calendar day
+// containing t, in t's own location.
 func dayRange(t time.Time) (time.Time, time.Time) {
-	from := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
-	to := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, t.Location())
-	return from, to
+	y, m, d := t.Date()
+	loc := t.Location()
+	// time.Date normalises an out-of-range day (Aug 32 -> Sep 1), and computing
+	// the next midnight directly — rather than adding 24h to `from` — keeps the
+	// bound correct in zones that observe DST, where a calendar day is not
+	// always 24 hours long. Korea has no DST, but the helper should not depend
+	// on that.
+	return time.Date(y, m, d, 0, 0, 0, 0, loc), time.Date(y, m, d+1, 0, 0, 0, 0, loc)
 }
 
-// weekRange returns [Monday 00:00:00, Sunday 23:59:59] of the ISO week
-// containing t.
+// weekRange returns [Monday 00:00:00, next Monday 00:00:00) of the ISO week
+// containing t. The upper bound comes from the day AFTER Sunday, so the week
+// is closed by the start of the next week rather than by Sunday's last second.
 func weekRange(t time.Time) (time.Time, time.Time) {
 	// time.Weekday: Sunday = 0 ... Saturday = 6. Convert to days since Monday.
 	daysSinceMonday := (int(t.Weekday()) + 6) % 7
 	monday := t.AddDate(0, 0, -daysSinceMonday)
 	from, _ := dayRange(monday)
-	sunday := monday.AddDate(0, 0, 6)
-	_, to := dayRange(sunday)
-	return from, to
+	y, m, d := from.Date()
+	return from, time.Date(y, m, d+7, 0, 0, 0, 0, from.Location())
 }

--- a/internal/intent/intent_test.go
+++ b/internal/intent/intent_test.go
@@ -51,17 +51,21 @@ func TestLLMClassifier_Classify_DeterministicDatePhrases(t *testing.T) {
 		wantConfid float64
 	}{
 		{
-			name:       "explicit year and month",
-			question:   "2026년 6월 요약해줘",
-			wantFrom:   time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
-			wantTo:     time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC),
+			name:     "explicit year and month",
+			question: "2026년 6월 요약해줘",
+			wantFrom: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			// Half-open upper bound: the first instant of July, not June's last
+			// second. See the range helpers in intent.go and
+			// TestClassify_LastInstantOfPeriodIsInsideWindow.
+			wantTo:     time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
 			wantConfid: 1.0,
 		},
 		{
-			name:       "last month, relative to fixed now (2026-08-17)",
-			question:   "지난달에 뭐 있었지",
-			wantFrom:   time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
-			wantTo:     time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC),
+			name:     "last month, relative to fixed now (2026-08-17)",
+			question: "지난달에 뭐 있었지",
+			wantFrom: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			// Half-open: July's window closes at the first instant of August.
+			wantTo:     time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
 			wantConfid: 1.0,
 		},
 	}

--- a/internal/model/document.go
+++ b/internal/model/document.go
@@ -195,4 +195,22 @@ type SearchQuery struct {
 	UseHyDE            bool         // when true, expand query via HyDE before retrieval
 	Weights            SearchWeights // zero value uses defaults (k=60, equal weights)
 	UseRerank          bool         `json:"use_rerank,omitempty"` // when true, apply cross-encoder reranking post-retrieval
+
+	// OccurredFrom / OccurredTo constrain results to the half-open event-time
+	// window [OccurredFrom, OccurredTo) on documents.occurred_at. Either bound
+	// may be nil, meaning "unbounded on that side"; both nil disables the
+	// filter entirely.
+	//
+	// This is a CANDIDATE-POOL constraint, not a sort hint: the store applies
+	// it as a WHERE predicate inside every retrieval lane, exactly like
+	// SourceType/ExcludeSourceTypes. Sort="recent" cannot substitute for it —
+	// sorting can only reorder candidates that a lane already retrieved.
+	//
+	// Rows with occurred_at IS NULL are EXCLUDED whenever either bound is set.
+	// The comparison is deliberately made against occurred_at alone rather than
+	// COALESCE(occurred_at, collected_at): a large part of the corpus has a NULL
+	// occurred_at, and coalescing would silently reinterpret "ingested during
+	// the window" as "happened during the window".
+	OccurredFrom *time.Time
+	OccurredTo   *time.Time
 }

--- a/internal/search/occurred_range_test.go
+++ b/internal/search/occurred_range_test.go
@@ -1,0 +1,227 @@
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Event-time window at the service seam.
+//
+// The store applies model.SearchQuery's occurred_at window as a WHERE predicate
+// in every one of its lanes. The service's two CHUNK lanes cannot: ChunkSearcher
+// takes only (vector|text, limit), and the rows it returns carry no occurred_at
+// at all (see chunkVecToSearchResult / chunkToSearchResult — they populate ID,
+// source, title, status and nothing else). So a windowed query that reaches
+// those lanes gets documents from outside the window, and there is no field on
+// the result to post-filter them by.
+//
+// That is not a cosmetic leak. mergeRRF fills the slots the primary lane left
+// empty — and a narrow window is precisely the case where the primary lane
+// returns two or three documents out of twenty. The chunk-FTS fallback is worse:
+// it fires exactly when the window matched nothing and replaces the honest empty
+// answer with unfiltered matches, i.e. it silently widens the window the user
+// asked for.
+//
+// These tests pin the only defensible behaviour available without a schema
+// change: when a window is set, the chunk lanes are skipped entirely.
+// ---------------------------------------------------------------------------
+
+var (
+	svcWindowFrom = time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+	svcWindowTo   = time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+)
+
+func windowedQuery() model.SearchQuery {
+	return model.SearchQuery{
+		Query:        "오늘 일정에 대해 알려줘",
+		Limit:        20,
+		OccurredFrom: &svcWindowFrom,
+		OccurredTo:   &svcWindowTo,
+	}
+}
+
+// TestServiceSearch_PassesWindowToStore is the wiring assertion: the store is
+// the only component that can honour the window, so it has to receive it
+// unmodified.
+func TestServiceSearch_PassesWindowToStore(t *testing.T) {
+	t.Parallel()
+
+	docs := &recordingDocSearcher{}
+	svc := NewService(docs, disabledEmbedder{})
+
+	if _, err := svc.Search(context.Background(), windowedQuery()); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	got := docs.gotQuery
+	if got.OccurredFrom == nil || !got.OccurredFrom.Equal(svcWindowFrom) {
+		t.Errorf("store received OccurredFrom = %v, want %s", got.OccurredFrom, svcWindowFrom)
+	}
+	if got.OccurredTo == nil || !got.OccurredTo.Equal(svcWindowTo) {
+		t.Errorf("store received OccurredTo = %v, want %s", got.OccurredTo, svcWindowTo)
+	}
+}
+
+// TestServiceSearch_WindowedQuery_ChunkVectorLaneDoesNotFill pins that an
+// unfiltered chunk hit cannot take one of the slots the windowed primary lane
+// left empty.
+func TestServiceSearch_WindowedQuery_ChunkVectorLaneDoesNotFill(t *testing.T) {
+	t.Parallel()
+
+	inWindowID := uuid.New()
+	outOfWindowID := uuid.New()
+
+	docs := &recordingDocSearcher{results: []*model.SearchResult{
+		makeSearchResult(inWindowID, "in-window calendar entry", 0.5),
+	}}
+	chunks := &mockChunkSearcher{vectorResults: []store.ChunkSearchResult{
+		{
+			Chunk:          store.Chunk{ID: 1, DocumentID: outOfWindowID, Content: "some message from last year"},
+			Score:          0.99,
+			DocumentSource: string(model.SourceSMS),
+			DocumentStatus: "active",
+		},
+	}}
+
+	svc := NewService(docs, stubEnabledEmbedder{}).WithChunkStore(chunks)
+	results, err := svc.Search(context.Background(), windowedQuery())
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	for _, r := range results {
+		if r.ID == outOfWindowID {
+			t.Fatalf("chunk vector lane filled a slot with a document the window cannot vouch for (id %s): %+v", r.ID, results)
+		}
+	}
+	if len(results) != 1 || results[0].ID != inWindowID {
+		t.Errorf("results = %+v, want only the store's in-window document %s", results, inWindowID)
+	}
+}
+
+// TestServiceSearch_WindowedQuery_EmptyPrimary_NoChunkFTSFallback pins the
+// honesty rule: a window that matches nothing must answer "nothing", not fall
+// back to a lane that ignores the window.
+func TestServiceSearch_WindowedQuery_EmptyPrimary_NoChunkFTSFallback(t *testing.T) {
+	t.Parallel()
+
+	docs := &recordingDocSearcher{} // window matched nothing
+	chunks := &mockChunkSearcher{ftsResults: []store.ChunkSearchResult{
+		{
+			Chunk:          store.Chunk{ID: 1, DocumentID: uuid.New(), Content: "a message from some other day"},
+			Rank:           0.8,
+			DocumentSource: string(model.SourceSMS),
+			DocumentStatus: "active",
+		},
+	}}
+
+	svc := NewService(docs, disabledEmbedder{}).WithChunkStore(chunks)
+	results, err := svc.Search(context.Background(), windowedQuery())
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Errorf("windowed query with no in-window documents returned %+v, want an empty result — widening the window silently is worse than an empty answer", results)
+	}
+}
+
+// TestServiceSearch_OneSidedWindow_SkipsChunkLanes covers the half-bounded
+// window; only one bound being set is still a window.
+func TestServiceSearch_OneSidedWindow_SkipsChunkLanes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		query model.SearchQuery
+	}{
+		{"from only", model.SearchQuery{Query: "q", Limit: 20, OccurredFrom: &svcWindowFrom}},
+		{"to only", model.SearchQuery{Query: "q", Limit: 20, OccurredTo: &svcWindowTo}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			docs := &recordingDocSearcher{}
+			chunks := &mockChunkSearcher{ftsResults: []store.ChunkSearchResult{
+				{
+					Chunk:          store.Chunk{ID: 1, DocumentID: uuid.New(), Content: "out of window"},
+					Rank:           0.8,
+					DocumentSource: string(model.SourceSMS),
+					DocumentStatus: "active",
+				},
+			}}
+			svc := NewService(docs, disabledEmbedder{}).WithChunkStore(chunks)
+
+			results, err := svc.Search(context.Background(), tc.query)
+			if err != nil {
+				t.Fatalf("Search returned error: %v", err)
+			}
+			if len(results) != 0 {
+				t.Errorf("results = %+v, want empty — a one-sided window is still a window", results)
+			}
+		})
+	}
+}
+
+// TestServiceSearch_NoWindow_ChunkLanesStillRun is the control that keeps the
+// guard narrow. Every non-temporal query — the overwhelming majority — must
+// keep both chunk lanes, or this fix would quietly delete a retrieval signal
+// from the whole system.
+func TestServiceSearch_NoWindow_ChunkLanesStillRun(t *testing.T) {
+	t.Parallel()
+
+	chunkDocID := uuid.New()
+
+	// Chunk-FTS fallback path: primary empty, no window.
+	docs := &recordingDocSearcher{}
+	chunks := &mockChunkSearcher{ftsResults: []store.ChunkSearchResult{
+		{
+			Chunk:          store.Chunk{ID: 1, DocumentID: chunkDocID, Content: "a chunk hit"},
+			Rank:           0.8,
+			DocumentSource: string(model.SourceSMS),
+			DocumentStatus: "active",
+		},
+	}}
+	svc := NewService(docs, disabledEmbedder{}).WithChunkStore(chunks)
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{Query: "budget", Limit: 20})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != chunkDocID {
+		t.Fatalf("results = %+v, want the chunk-FTS fallback hit %s", results, chunkDocID)
+	}
+
+	// Chunk-vector merge path: primary non-empty, no window.
+	primaryID := uuid.New()
+	docs2 := &recordingDocSearcher{results: []*model.SearchResult{makeSearchResult(primaryID, "primary", 0.5)}}
+	chunks2 := &mockChunkSearcher{vectorResults: []store.ChunkSearchResult{
+		{
+			Chunk:          store.Chunk{ID: 2, DocumentID: chunkDocID, Content: "a chunk hit"},
+			Score:          0.99,
+			DocumentSource: string(model.SourceSMS),
+			DocumentStatus: "active",
+		},
+	}}
+	svc2 := NewService(docs2, stubEnabledEmbedder{}).WithChunkStore(chunks2)
+
+	results2, err := svc2.Search(context.Background(), model.SearchQuery{Query: "budget", Limit: 20})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	var sawChunkDoc bool
+	for _, r := range results2 {
+		if r.ID == chunkDocID {
+			sawChunkDoc = true
+		}
+	}
+	if !sawChunkDoc {
+		t.Errorf("results = %+v, want the chunk-vector document %s to still fill a free slot when no window is set", results2, chunkDocID)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -214,11 +214,20 @@ func (s *Service) Search(ctx context.Context, q model.SearchQuery) ([]*model.Sea
 		return nil, fmt.Errorf("search store: %w", err)
 	}
 
+	// An event-time window is a hard constraint on WHICH documents may be
+	// returned, and only the document store can enforce it: ChunkSearcher takes
+	// no date range, and the rows it returns carry no occurred_at to post-filter
+	// on. Running the chunk lanes under a window would therefore reintroduce
+	// exactly the documents the window excluded — into the slots the (correctly
+	// narrowed) store result left empty. Skipping them keeps a windowed query
+	// answerable only from evidence that provably falls inside the window.
+	windowed := q.OccurredFrom != nil || q.OccurredTo != nil
+
 	// Chunk vector search: when per-chunk embeddings are available, run a
 	// chunk-level ANN search and merge its results into the candidate set via
 	// RRF. This is an ADDITIVE signal — the full-document path above always
 	// runs first, and chunk results are merged in rather than replacing it.
-	if s.chunkStore != nil && len(queryVec) > 0 {
+	if s.chunkStore != nil && len(queryVec) > 0 && !windowed {
 		chunkVecResults, cerr := s.searchChunksVector(ctx, queryVec, q.Limit)
 		if cerr != nil {
 			slog.Warn("search: chunk vector search failed, skipping",
@@ -230,7 +239,13 @@ func (s *Service) Search(ctx context.Context, q model.SearchQuery) ([]*model.Sea
 
 	// When the primary path (full-document FTS / hybrid) + chunk vector
 	// returned no results, fall back to chunk FTS.
-	if len(results) == 0 && s.chunkStore != nil {
+	//
+	// Not under a window: there, "no results" is the answer. The fallback
+	// cannot filter by date, so firing it here would turn "nothing happened
+	// today" into a list of matches from other days — silently widening the
+	// window the caller asked for, which is the one failure mode a date filter
+	// must never have.
+	if len(results) == 0 && s.chunkStore != nil && !windowed {
 		chunkResults, cerr := s.searchChunksFTS(ctx, q.Query, q.Limit)
 		if cerr != nil {
 			// Non-fatal: log and return the empty primary result set.

--- a/internal/store/document.go
+++ b/internal/store/document.go
@@ -417,6 +417,22 @@ func sortOrder(sort string, tableAlias string) string {
 // pg_bigm LIKE matching is added as an OR condition so that Korean queries lacking
 // morphological tsvector coverage are still retrieved via 2-gram index.
 func (s *DocumentStore) fulltextSearch(ctx context.Context, query model.SearchQuery) ([]*model.SearchResult, error) {
+	q, args := buildFulltextSearchQuery(query)
+
+	rows, err := s.pg.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("fulltext search: %w", err)
+	}
+	defer rows.Close()
+
+	return collectResults(rows, "fulltext")
+}
+
+// buildFulltextSearchQuery renders the non-vector search statement and its
+// positional arguments. Split out of fulltextSearch (which only executes it) so
+// the WHERE predicates — status, source type, and the occurred_at window — can
+// be asserted without a database, the same way buildEntityCTE is.
+func buildFulltextSearchQuery(query model.SearchQuery) (string, []interface{}) {
 	args := []interface{}{query.Query, query.Limit}
 
 	statusFilter := "AND status = 'active'"
@@ -435,6 +451,12 @@ func (s *DocumentStore) fulltextSearch(ctx context.Context, query model.SearchQu
 		excludeFilter = fmt.Sprintf("AND source_type <> ALL($%d)", len(args)+1)
 		args = append(args, query.ExcludeSourceTypes)
 	}
+
+	// Event-time window, applied in the WHERE clause for the same reason as in
+	// hybridSearch: this statement is capped by LIMIT $2, so the window has to
+	// constrain what is selected, not what is returned after selection.
+	var occurredFilter string
+	args, occurredFilter, _ = appendOccurredRangeFilters(args, query.OccurredFrom, query.OccurredTo)
 
 	// The LIKE pattern uses SQL string concatenation ('%%' || $1 || '%%') so that
 	// pg_bigm's gin_bigm_ops index is used automatically without embedding literal
@@ -455,20 +477,135 @@ func (s *DocumentStore) fulltextSearch(ctx context.Context, query model.SearchQu
 		%s
 		%s
 		%s
+		%s
 		ORDER BY %s
-		LIMIT $2`, statusFilter, sourceFilter, excludeFilter, sortOrder(query.Sort, ""))
+		LIMIT $2`, statusFilter, sourceFilter, excludeFilter, occurredFilter, sortOrder(query.Sort, ""))
 
-	rows, err := s.pg.pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, fmt.Errorf("fulltext search: %w", err)
+	return q, args
+}
+
+// appendOccurredRangeFilters binds the caller's event-time window to args and
+// returns the matching WHERE fragments in both the unqualified form (for the
+// CTEs that scan `documents` directly) and the `d.`-qualified form (for the
+// entity lane, which joins it). Both forms reference the SAME positional
+// parameters, so the two must always be produced by this one call.
+//
+// Three properties are deliberate and load-bearing:
+//
+//   - The bounds are bound as parameters, never interpolated. Every other
+//     fragment in this file is assembled with fmt.Sprintf; a timestamp spliced
+//     into the string would be an injection surface and a parse hazard.
+//   - The comparison is against occurred_at alone, not
+//     COALESCE(occurred_at, collected_at). A large share of the corpus has a
+//     NULL occurred_at, and coalescing would reinterpret "ingested during the
+//     window" as "happened during the window" — precisely the noise the window
+//     exists to remove. Rows with a NULL occurred_at are therefore excluded,
+//     which the SQL gets for free: a comparison against NULL is never true.
+//   - The window is half-open, [from, to). Consecutive windows tile without
+//     overlap and a document at exactly `to` belongs only to the next one.
+//
+// Either bound may be nil; both nil returns empty fragments and args unchanged.
+func appendOccurredRangeFilters(args []interface{}, from, to *time.Time) (newArgs []interface{}, plain, qualified string) {
+	var plainParts, qualifiedParts []string
+
+	if from != nil {
+		p := len(args) + 1
+		plainParts = append(plainParts, fmt.Sprintf("AND occurred_at >= $%d", p))
+		qualifiedParts = append(qualifiedParts, fmt.Sprintf("AND d.occurred_at >= $%d", p))
+		args = append(args, *from)
 	}
-	defer rows.Close()
+	if to != nil {
+		p := len(args) + 1
+		plainParts = append(plainParts, fmt.Sprintf("AND occurred_at < $%d", p))
+		qualifiedParts = append(qualifiedParts, fmt.Sprintf("AND d.occurred_at < $%d", p))
+		args = append(args, *to)
+	}
 
-	return collectResults(rows, "fulltext")
+	const sep = "\n\t\t\t"
+	return args, strings.Join(plainParts, sep), strings.Join(qualifiedParts, sep)
 }
 
 // hybridSearch combines full-text and vector search ranks via RRF.
 func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuery) ([]*model.SearchResult, error) {
+	w, err := s.resolveWeights(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	q, args := buildHybridSearchQuery(query, w)
+
+	rows, err := s.pg.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("hybrid search: %w", err)
+	}
+	defer rows.Close()
+
+	results, err := collectResults(rows, "hybrid")
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > query.Limit {
+		results = results[:query.Limit]
+	}
+	return results, nil
+}
+
+// resolveWeights turns the caller-supplied (possibly zero) weights into the
+// effective per-lane weights, applying the two gates that need runtime state:
+// the summary-vec coverage gate (a DB query) and the entity-lane env gate.
+// Kept separate from buildHybridSearchQuery so that query construction stays a
+// pure function of (query, weights) and is testable without a database.
+//
+// The error return is currently always nil — a failing coverage query degrades
+// to "lane disabled" rather than failing the search — but is kept so a future
+// hard failure has somewhere to go.
+func (s *DocumentStore) resolveWeights(ctx context.Context, query model.SearchQuery) (model.SearchWeights, error) {
+	w := query.Weights.Defaults()
+	// Coverage gate: apply only when the caller has not explicitly set a weight
+	// and has not explicitly disabled the summary-vec lane (#63).
+	// - DisableSummaryVec=true → Defaults() already set w.SummaryVec=0.0; skip gate.
+	// - SummaryVec>0 (explicit) → caller bypasses gate; use the value as-is.
+	// - SummaryVec==0 (unset)   → apply gate: enable when corpus coverage is sufficient.
+	if !query.Weights.DisableSummaryVec && query.Weights.SummaryVec == 0 {
+		// Coverage gate: "decide based on corpus coverage".  Defaults() preserved
+		// zero, so we resolve the effective weight here.
+		//
+		// - Coverage >= threshold → enable at DefaultSummaryVecWeight (0.8).
+		// - Coverage <  threshold → disable (0.0) to prevent systematic demotion
+		//   of un-summarised documents during backfill.
+		// - Coverage query error  → disable (safe fallback; avoids bias on error).
+		coverage, coverageErr := s.SummaryCoverageRatio(ctx)
+		if coverageErr == nil && coverage >= model.SummaryVecCoverageThreshold() {
+			w.SummaryVec = model.DefaultSummaryVecWeight
+		} else {
+			w.SummaryVec = 0.0
+		}
+	}
+
+	// Entity lane gate (#139): enable when ENTITY_EXTRACTION_ENABLED env var is set.
+	// EntityWeight<0 means explicit disable by caller; zero means "auto".
+	// The lane is a no-op when entities aren't in the DB — FULL OUTER JOIN is safe.
+	if w.EntityWeight == 0 {
+		if entityExtractionEnabled() {
+			w.EntityWeight = model.DefaultEntityWeight
+		}
+		// else: leave 0 — entity CTE contributes 0 to RRF score (no-op).
+	} else if w.EntityWeight < 0 {
+		w.EntityWeight = 0 // explicit disable
+	}
+
+	return w, nil
+}
+
+// buildHybridSearchQuery renders the five-lane RRF statement and its positional
+// arguments for the given query and already-resolved weights.
+//
+// Split out of hybridSearch so every lane's WHERE predicates are assertable
+// without a database. That matters most for filters that constrain the
+// candidate pool: each lane is capped by LIMIT $3, so a filter missing from one
+// lane does not merely widen that lane — it lets out-of-scope documents consume
+// candidate slots and push in-scope documents out of the fused result entirely.
+func buildHybridSearchQuery(query model.SearchQuery, w model.SearchWeights) (string, []interface{}) {
 	args := []interface{}{
 		query.Query,
 		pgvector.NewVector(query.Embedding),
@@ -504,6 +641,15 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 		args = append(args, query.ExcludeSourceTypes)
 	}
 
+	// Event-time window. Like the source filters, this constrains the candidate
+	// pool INSIDE every lane rather than reordering the fused result: each lane
+	// is capped by LIMIT $3, so an out-of-window document that reaches a lane
+	// consumes a candidate slot an in-window document needed. Sorting by
+	// recency (sortOrder) cannot substitute — it only permutes what the lanes
+	// already selected.
+	var occurredFilter, entityOccurredFilter string
+	args, occurredFilter, entityOccurredFilter = appendOccurredRangeFilters(args, query.OccurredFrom, query.OccurredTo)
+
 	// RRF formula: w / (k + rank), where w is the per-signal weight and k
 	// prevents very high scores for top-ranked results (standard k=60).
 	// Four CTEs (fts, vec, bigm, summvec) are merged via FULL OUTER JOIN.
@@ -517,48 +663,9 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 	// Weight parameters are injected as Go-formatted literals (not SQL params)
 	// because they are floats under our control, never from user input.
 	//
-	// Coverage gate (#63): SummaryVec is disabled when summary_embedding coverage
-	// is below the configured threshold (default 80%).  Without the gate, the
-	// +26.7% score ceiling for summarised documents causes systematic ranking
-	// bias during backfill — un-summarised documents are demoted even when they
-	// are more content-relevant.  Once the corpus reaches the threshold the
-	// weight activates automatically via the cached ratio (TTL 60 s).
-	// Callers may force-enable by setting query.Weights.SummaryVec explicitly.
-	w := query.Weights.Defaults()
-	// Coverage gate: apply only when the caller has not explicitly set a weight
-	// and has not explicitly disabled the summary-vec lane (#63).
-	// - DisableSummaryVec=true → Defaults() already set w.SummaryVec=0.0; skip gate.
-	// - SummaryVec>0 (explicit) → caller bypasses gate; use the value as-is.
-	// - SummaryVec==0 (unset)   → apply gate: enable when corpus coverage is sufficient.
-	if !query.Weights.DisableSummaryVec && query.Weights.SummaryVec == 0 {
-		// Coverage gate: "decide based on corpus coverage".  Defaults() preserved
-		// zero, so we resolve the effective weight here.
-		//
-		// - Coverage >= threshold → enable at DefaultSummaryVecWeight (0.8).
-		// - Coverage <  threshold → disable (0.0) to prevent systematic demotion
-		//   of un-summarised documents during backfill.
-		// - Coverage query error  → disable (safe fallback; avoids bias on error).
-		coverage, coverageErr := s.SummaryCoverageRatio(ctx)
-		if coverageErr == nil && coverage >= model.SummaryVecCoverageThreshold() {
-			w.SummaryVec = model.DefaultSummaryVecWeight
-		} else {
-			w.SummaryVec = 0.0
-		}
-	}
-
-	// Entity lane gate (#139): enable when ENTITY_EXTRACTION_ENABLED env var is set.
-	// EntityWeight<0 means explicit disable by caller; zero means "auto".
-	// The lane is a no-op when entities aren't in the DB — FULL OUTER JOIN is safe.
-	entityEnabled := entityExtractionEnabled()
-	if w.EntityWeight == 0 {
-		if entityEnabled {
-			w.EntityWeight = model.DefaultEntityWeight
-		}
-		// else: leave 0 — entity CTE contributes 0 to RRF score (no-op).
-	} else if w.EntityWeight < 0 {
-		w.EntityWeight = 0 // explicit disable
-	}
-
+	// Coverage gate (#63) and entity gate (#139) are resolved by resolveWeights
+	// before this function is called; w is the effective per-lane weighting.
+	//
 	// Build a normalised entity query: lower-cased, whitespace-trimmed tokens
 	// joined by OR for the entity name LIKE match. This enables partial-name
 	// matching (e.g. "홍길동" matches entity with normalized_name='홍길동').
@@ -575,7 +682,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 	// disabled (weight=0), we use a trivially-empty CTE to avoid syntax errors.
 	entityCTE := emptyEntityCTE
 	if w.EntityWeight > 0 {
-		entityCTE = buildEntityCTE(entityFilterParam, entityStatusFilter, entitySourceFilter, entityExcludeFilter)
+		entityCTE = buildEntityCTE(entityFilterParam, entityStatusFilter, entitySourceFilter, entityExcludeFilter, entityOccurredFilter)
 	}
 
 	q := fmt.Sprintf(`
@@ -591,6 +698,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 			%s
 			%s
 			%s
+			%s
 			LIMIT $3
 		),
 		vec AS (
@@ -598,6 +706,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 			       row_number() OVER (ORDER BY embedding <=> $2 ASC) AS rank
 			FROM documents
 			WHERE embedding IS NOT NULL
+			%s
 			%s
 			%s
 			%s
@@ -616,6 +725,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 			%s
 			%s
 			%s
+			%s
 			LIMIT $3
 		),
 		summvec AS (
@@ -623,6 +733,7 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 			       row_number() OVER (ORDER BY summary_embedding <=> $2 ASC) AS rank
 			FROM documents
 			WHERE summary_embedding IS NOT NULL
+			%s
 			%s
 			%s
 			%s
@@ -647,28 +758,15 @@ func (s *DocumentStore) hybridSearch(ctx context.Context, query model.SearchQuer
 		JOIN documents d ON d.id = rrf.id
 		ORDER BY %s
 		LIMIT $3`,
-		statusFilter, sourceFilter, excludeFilter,
-		statusFilter, sourceFilter, excludeFilter,
-		statusFilter, sourceFilter, excludeFilter,
-		statusFilter, sourceFilter, excludeFilter,
-		entityCTE,
+		statusFilter, sourceFilter, excludeFilter, occurredFilter, // fts
+		statusFilter, sourceFilter, excludeFilter, occurredFilter, // vec
+		statusFilter, sourceFilter, excludeFilter, occurredFilter, // bigm
+		statusFilter, sourceFilter, excludeFilter, occurredFilter, // summvec
+		entityCTE, // entity lane carries the same filters in d.-qualified form
 		buildRRFScoreExpr(w),
 		sortOrder(query.Sort, "d"))
 
-	rows, err := s.pg.pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, fmt.Errorf("hybrid search: %w", err)
-	}
-	defer rows.Close()
-
-	results, err := collectResults(rows, "hybrid")
-	if err != nil {
-		return nil, err
-	}
-	if len(results) > query.Limit {
-		results = results[:query.Limit]
-	}
-	return results, nil
+	return q, args
 }
 
 // buildRRFScoreExpr renders the weighted-sum SQL expression that fuses the
@@ -721,7 +819,7 @@ const emptyEntityCTE = `entity AS (SELECT NULL::uuid AS id, NULL::bigint AS rank
 // the lane's previous unfiltered form let soft-deleted and excluded documents
 // (including insights) into results whenever they were reachable by entity
 // name alone, and nothing in the test suite could observe it.
-func buildEntityCTE(entityFilterParam, statusFilter, sourceFilter, excludeFilter string) string {
+func buildEntityCTE(entityFilterParam, statusFilter, sourceFilter, excludeFilter, occurredRangeFilter string) string {
 	return fmt.Sprintf(`entity AS (
 			SELECT de.document_id AS id,
 			       row_number() OVER (ORDER BY COUNT(*) DESC, de.document_id ASC) AS rank
@@ -732,9 +830,10 @@ func buildEntityCTE(entityFilterParam, statusFilter, sourceFilter, excludeFilter
 			%s
 			%s
 			%s
+			%s
 			GROUP BY de.document_id
 			LIMIT $3
-		)`, entityFilterParam, statusFilter, sourceFilter, excludeFilter)
+		)`, entityFilterParam, statusFilter, sourceFilter, excludeFilter, occurredRangeFilter)
 }
 
 // entityExtractionEnabled reports whether entity extraction has been enabled

--- a/internal/store/document_entity_lane_test.go
+++ b/internal/store/document_entity_lane_test.go
@@ -23,7 +23,7 @@ import (
 func TestBuildEntityCTE_AppliesAllFilters(t *testing.T) {
 	t.Parallel()
 
-	got := buildEntityCTE("$4", "AND d.status = 'active'", "AND d.source_type = $5", "AND d.source_type <> ALL($6)")
+	got := buildEntityCTE("$4", "AND d.status = 'active'", "AND d.source_type = $5", "AND d.source_type <> ALL($6)", "")
 
 	fragments := []struct {
 		name string
@@ -50,7 +50,7 @@ func TestBuildEntityCTE_AppliesAllFilters(t *testing.T) {
 func TestBuildEntityCTE_FiltersPrecedeTheLimit(t *testing.T) {
 	t.Parallel()
 
-	got := buildEntityCTE("$4", "AND d.status = 'active'", "", "AND d.source_type <> ALL($5)")
+	got := buildEntityCTE("$4", "AND d.status = 'active'", "", "AND d.source_type <> ALL($5)", "")
 
 	limitAt := strings.Index(got, "LIMIT $3")
 	if limitAt < 0 {
@@ -68,7 +68,7 @@ func TestBuildEntityCTE_FiltersPrecedeTheLimit(t *testing.T) {
 func TestBuildEntityCTE_IncludeDeleted_OmitsStatusFilter(t *testing.T) {
 	t.Parallel()
 
-	got := buildEntityCTE("$4", "", "", "")
+	got := buildEntityCTE("$4", "", "", "", "")
 	if strings.Contains(got, "status") {
 		t.Errorf("entity CTE applied a status filter when none was requested:\n%s", got)
 	}

--- a/internal/store/document_occurred_range_test.go
+++ b/internal/store/document_occurred_range_test.go
@@ -1,0 +1,445 @@
+package store
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// occurred_at window filtering.
+//
+// A temporal question ("오늘 일정 알려줘") used to be answered by setting
+// Sort="recent" and nothing else. That is not a filter: sortOrder() only
+// reorders the candidate set each lane already produced, and every lane is
+// capped by LIMIT $3. When one source dominates the corpus by four orders of
+// magnitude, the in-window documents never enter the candidate set in the first
+// place, so no amount of reordering can surface them.
+//
+// The fix makes the window a WHERE predicate inside every lane, exactly like
+// the source-type filters. These tests pin that property per lane, because a
+// lane that silently drops the predicate keeps injecting out-of-window
+// documents into the fused result and is invisible at the API boundary.
+// ---------------------------------------------------------------------------
+
+var (
+	testWindowFrom = time.Date(2026, 8, 18, 0, 0, 0, 0, time.UTC)
+	testWindowTo   = time.Date(2026, 8, 19, 0, 0, 0, 0, time.UTC)
+)
+
+// laneNames lists every RRF lane that feeds the fused candidate set. The whole
+// point of the list is that it is exhaustive: a filter applied to four of five
+// lanes is still a broken filter.
+var laneNames = []string{"fts", "vec", "bigm", "summvec", "entity"}
+
+// laneBodies splits a hybrid-search statement into its per-lane CTE bodies so
+// each lane's WHERE clause can be asserted in isolation. Slicing by marker
+// (rather than searching the whole statement) is deliberate: the outer
+// ORDER BY also mentions occurred_at, so a whole-statement Contains check would
+// pass even if no lane filtered anything.
+func laneBodies(t *testing.T, q string) map[string]string {
+	t.Helper()
+
+	// Markers are ordered as they appear in the statement. The leading tab on
+	// "\tvec AS (" keeps it from matching inside "summvec AS (".
+	markers := []struct{ name, marker string }{
+		{"fts", "WITH fts AS ("},
+		{"vec", "\tvec AS ("},
+		{"bigm", "\tbigm AS ("},
+		{"summvec", "\tsummvec AS ("},
+		{"entity", "entity AS ("},
+		{"__end__", "\t\trrf AS ("},
+	}
+
+	starts := make([]int, len(markers))
+	prev := 0
+	for i, m := range markers {
+		at := strings.Index(q[prev:], m.marker)
+		if at < 0 {
+			t.Fatalf("statement has no %q marker (searching from offset %d):\n%s", m.marker, prev, q)
+		}
+		starts[i] = prev + at
+		prev = starts[i] + len(m.marker)
+	}
+
+	out := make(map[string]string, len(laneNames))
+	for i, m := range markers {
+		if m.name == "__end__" {
+			break
+		}
+		out[m.name] = q[starts[i]:starts[i+1]]
+	}
+	return out
+}
+
+// placeholderNum extracts the positional parameter number from a predicate
+// fragment such as "occurred_at >= $6".
+func placeholderNum(t *testing.T, fragment string) int {
+	t.Helper()
+	m := regexp.MustCompile(`\$(\d+)`).FindStringSubmatch(fragment)
+	if m == nil {
+		t.Fatalf("fragment %q binds no positional parameter", fragment)
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("fragment %q: bad parameter number: %v", fragment, err)
+	}
+	return n
+}
+
+// findPredicate returns the single line in body that contains needle.
+func findPredicate(t *testing.T, body, needle, lane string) string {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, needle) {
+			return strings.TrimSpace(line)
+		}
+	}
+	t.Fatalf("lane %q has no %q predicate:\n%s", lane, needle, body)
+	return ""
+}
+
+func rangeQuery() model.SearchQuery {
+	return model.SearchQuery{
+		Query:        "오늘 일정에 대해 알려줘",
+		Limit:        20,
+		Embedding:    []float32{0.1, 0.2, 0.3},
+		OccurredFrom: &testWindowFrom,
+		OccurredTo:   &testWindowTo,
+	}
+}
+
+// entityWeights forces the entity lane on so its body is a real CTE rather than
+// the disabled placeholder — otherwise the fifth lane could never be asserted.
+func entityWeights() model.SearchWeights {
+	return model.SearchWeights{RRFK: 60, FTSWeight: 1, VecWeight: 1, BigmWeight: 1, EntityWeight: 0.5}
+}
+
+// TestBuildHybridSearchQuery_OccurredRange_AppliesToEveryLane is the core
+// regression test: all five lanes must constrain occurred_at, because the
+// candidate cap is per lane.
+func TestBuildHybridSearchQuery_OccurredRange_AppliesToEveryLane(t *testing.T) {
+	t.Parallel()
+
+	q, _ := buildHybridSearchQuery(rangeQuery(), entityWeights())
+	bodies := laneBodies(t, q)
+
+	for _, lane := range laneNames {
+		body, ok := bodies[lane]
+		if !ok {
+			t.Fatalf("lane %q not found in statement", lane)
+		}
+		// The entity lane joins documents as d, so its columns are qualified.
+		col := "occurred_at"
+		if lane == "entity" {
+			col = "d.occurred_at"
+		}
+		if !strings.Contains(body, col+" >= $") {
+			t.Errorf("lane %q does not apply the lower bound (%s >= $N):\n%s", lane, col, body)
+		}
+		if !strings.Contains(body, col+" < $") {
+			t.Errorf("lane %q does not apply the upper bound (%s < $N):\n%s", lane, col, body)
+		}
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredRange_FiltersPrecedeTheLimit pins the
+// ordering that makes the predicate worth applying inside the lane at all: each
+// lane is capped by LIMIT $3, so filtering after the cap would let out-of-window
+// documents consume candidate slots.
+func TestBuildHybridSearchQuery_OccurredRange_FiltersPrecedeTheLimit(t *testing.T) {
+	t.Parallel()
+
+	q, _ := buildHybridSearchQuery(rangeQuery(), entityWeights())
+
+	for lane, body := range laneBodies(t, q) {
+		limitAt := strings.Index(body, "LIMIT $3")
+		if limitAt < 0 {
+			t.Fatalf("lane %q has no candidate cap:\n%s", lane, body)
+		}
+		for _, op := range []string{"occurred_at >= $", "occurred_at < $"} {
+			at := strings.Index(body, op)
+			if at < 0 {
+				continue // reported by the coverage test above
+			}
+			if at > limitAt {
+				t.Errorf("lane %q applies %q after its LIMIT (predicate at %d, limit at %d):\n%s", lane, op, at, limitAt, body)
+			}
+		}
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredRange_BindsParameters pins that the bounds
+// travel as positional parameters, not as interpolated text. This file's SQL is
+// assembled with fmt.Sprintf, which has already produced one production
+// incident; a timestamp spliced into the string would be both an injection
+// surface and a source of locale-dependent parse errors.
+func TestBuildHybridSearchQuery_OccurredRange_BindsParameters(t *testing.T) {
+	t.Parallel()
+
+	q, args := buildHybridSearchQuery(rangeQuery(), entityWeights())
+
+	if strings.Contains(q, "2026") {
+		t.Errorf("statement contains an interpolated timestamp literal:\n%s", q)
+	}
+
+	bodies := laneBodies(t, q)
+	fromIdx := placeholderNum(t, findPredicate(t, bodies["fts"], "occurred_at >= $", "fts"))
+	toIdx := placeholderNum(t, findPredicate(t, bodies["fts"], "occurred_at < $", "fts"))
+
+	for _, tc := range []struct {
+		name string
+		idx  int
+		want time.Time
+	}{
+		{"lower bound", fromIdx, testWindowFrom},
+		{"upper bound", toIdx, testWindowTo},
+	} {
+		if tc.idx < 1 || tc.idx > len(args) {
+			t.Fatalf("%s binds $%d but only %d args were supplied", tc.name, tc.idx, len(args))
+		}
+		got, ok := args[tc.idx-1].(time.Time)
+		if !ok {
+			t.Fatalf("%s: args[$%d] = %T, want time.Time", tc.name, tc.idx, args[tc.idx-1])
+		}
+		if !got.Equal(tc.want) {
+			t.Errorf("%s: args[$%d] = %s, want %s", tc.name, tc.idx, got, tc.want)
+		}
+	}
+
+	// Every lane must bind the SAME parameters — the fragments are rendered
+	// once and reused, so a divergence means a lane built its own args.
+	for _, lane := range laneNames {
+		col := "occurred_at"
+		if lane == "entity" {
+			col = "d.occurred_at"
+		}
+		if n := placeholderNum(t, findPredicate(t, bodies[lane], col+" >= $", lane)); n != fromIdx {
+			t.Errorf("lane %q binds lower bound to $%d, want $%d", lane, n, fromIdx)
+		}
+		if n := placeholderNum(t, findPredicate(t, bodies[lane], col+" < $", lane)); n != toIdx {
+			t.Errorf("lane %q binds upper bound to $%d, want $%d", lane, n, toIdx)
+		}
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredRange_ParametersSurviveOtherFilters pins
+// that the window's parameter numbers stay correct when the source-type filters
+// (which are appended to the same arg slice) are also active. An off-by-one
+// here binds a timestamp to a source-type placeholder and fails at runtime only.
+func TestBuildHybridSearchQuery_OccurredRange_ParametersSurviveOtherFilters(t *testing.T) {
+	t.Parallel()
+
+	src := model.SourceCalendar
+	query := rangeQuery()
+	query.SourceType = &src
+	query.ExcludeSourceTypes = []model.SourceType{model.SourceInsight}
+
+	q, args := buildHybridSearchQuery(query, entityWeights())
+	bodies := laneBodies(t, q)
+
+	fromIdx := placeholderNum(t, findPredicate(t, bodies["vec"], "occurred_at >= $", "vec"))
+	toIdx := placeholderNum(t, findPredicate(t, bodies["vec"], "occurred_at < $", "vec"))
+
+	from, ok := args[fromIdx-1].(time.Time)
+	if !ok || !from.Equal(testWindowFrom) {
+		t.Errorf("args[$%d] = %#v, want %s", fromIdx, args[fromIdx-1], testWindowFrom)
+	}
+	to, ok := args[toIdx-1].(time.Time)
+	if !ok || !to.Equal(testWindowTo) {
+		t.Errorf("args[$%d] = %#v, want %s", toIdx, args[toIdx-1], testWindowTo)
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredRange_HalfOpen pins the boundary
+// semantics: [from, to). The lower bound is inclusive, the upper bound
+// exclusive, so consecutive windows tile without overlapping and a document at
+// exactly `to` belongs to the next window only.
+func TestBuildHybridSearchQuery_OccurredRange_HalfOpen(t *testing.T) {
+	t.Parallel()
+
+	q, _ := buildHybridSearchQuery(rangeQuery(), entityWeights())
+	body := laneBodies(t, q)["fts"]
+
+	lower := findPredicate(t, body, "occurred_at >= $", "fts")
+	if strings.Contains(lower, "> $") && !strings.Contains(lower, ">= $") {
+		t.Errorf("lower bound is exclusive, want inclusive: %q", lower)
+	}
+	upper := findPredicate(t, body, "occurred_at < $", "fts")
+	if strings.Contains(upper, "<= $") {
+		t.Errorf("upper bound is inclusive, want exclusive: %q", upper)
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredRange_DoesNotCoalesce pins that the
+// predicate reads occurred_at directly. COALESCE(occurred_at, collected_at) —
+// the expression used for *sorting* — would reinterpret "ingested during the
+// window" as "happened during the window" for the large share of the corpus
+// whose occurred_at is NULL, quietly refilling the result with the same
+// dominant-source documents the window was meant to exclude.
+func TestBuildHybridSearchQuery_OccurredRange_DoesNotCoalesce(t *testing.T) {
+	t.Parallel()
+
+	q, _ := buildHybridSearchQuery(rangeQuery(), entityWeights())
+
+	for lane, body := range laneBodies(t, q) {
+		if strings.Contains(body, "COALESCE(") && strings.Contains(body, "collected_at") {
+			t.Errorf("lane %q coalesces occurred_at with collected_at in its filter:\n%s", lane, body)
+		}
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredFromOnly covers an open-ended window
+// ("since X"): only the lower bound is emitted, and NULL occurred_at rows are
+// still excluded because a NULL comparison is never true.
+func TestBuildHybridSearchQuery_OccurredFromOnly(t *testing.T) {
+	t.Parallel()
+
+	query := rangeQuery()
+	query.OccurredTo = nil
+
+	q, args := buildHybridSearchQuery(query, entityWeights())
+	for lane, body := range laneBodies(t, q) {
+		if !strings.Contains(body, "occurred_at >= $") {
+			t.Errorf("lane %q missing lower bound:\n%s", lane, body)
+		}
+		if strings.Contains(body, "occurred_at < $") {
+			t.Errorf("lane %q emitted an upper bound that was never requested:\n%s", lane, body)
+		}
+	}
+	if n := countTimeArgs(args); n != 1 {
+		t.Errorf("bound %d timestamps, want 1", n)
+	}
+}
+
+// TestBuildHybridSearchQuery_OccurredToOnly covers the mirror case ("until X").
+func TestBuildHybridSearchQuery_OccurredToOnly(t *testing.T) {
+	t.Parallel()
+
+	query := rangeQuery()
+	query.OccurredFrom = nil
+
+	q, args := buildHybridSearchQuery(query, entityWeights())
+	for lane, body := range laneBodies(t, q) {
+		if !strings.Contains(body, "occurred_at < $") {
+			t.Errorf("lane %q missing upper bound:\n%s", lane, body)
+		}
+		if strings.Contains(body, "occurred_at >= $") {
+			t.Errorf("lane %q emitted a lower bound that was never requested:\n%s", lane, body)
+		}
+	}
+	if n := countTimeArgs(args); n != 1 {
+		t.Errorf("bound %d timestamps, want 1", n)
+	}
+}
+
+// TestBuildHybridSearchQuery_NoRange_UnchangedStatement pins that queries
+// without a window are untouched — the overwhelming majority of searches.
+func TestBuildHybridSearchQuery_NoRange_UnchangedStatement(t *testing.T) {
+	t.Parallel()
+
+	query := rangeQuery()
+	query.OccurredFrom, query.OccurredTo = nil, nil
+	query.Sort = "recent" // the outer ORDER BY mentions occurred_at; must not confuse us
+
+	q, args := buildHybridSearchQuery(query, entityWeights())
+	for lane, body := range laneBodies(t, q) {
+		if strings.Contains(body, "occurred_at >= $") || strings.Contains(body, "occurred_at < $") {
+			t.Errorf("lane %q filtered by occurred_at without a window being requested:\n%s", lane, body)
+		}
+	}
+	if n := countTimeArgs(args); n != 0 {
+		t.Errorf("bound %d timestamps for a query with no window, want 0", n)
+	}
+}
+
+// TestBuildFulltextSearchQuery_OccurredRange covers the no-embedding path.
+// Search() falls back to it whenever the embedder is unavailable, so a window
+// that only works under hybrid search would fail exactly when the system is
+// already degraded.
+func TestBuildFulltextSearchQuery_OccurredRange(t *testing.T) {
+	t.Parallel()
+
+	query := rangeQuery()
+	query.Embedding = nil
+
+	q, args := buildFulltextSearchQuery(query)
+
+	lower := findPredicate(t, q, "occurred_at >= $", "fulltext")
+	upper := findPredicate(t, q, "occurred_at < $", "fulltext")
+
+	fromIdx, toIdx := placeholderNum(t, lower), placeholderNum(t, upper)
+	if got, ok := args[fromIdx-1].(time.Time); !ok || !got.Equal(testWindowFrom) {
+		t.Errorf("fulltext lower bound args[$%d] = %#v, want %s", fromIdx, args[fromIdx-1], testWindowFrom)
+	}
+	if got, ok := args[toIdx-1].(time.Time); !ok || !got.Equal(testWindowTo) {
+		t.Errorf("fulltext upper bound args[$%d] = %#v, want %s", toIdx, args[toIdx-1], testWindowTo)
+	}
+	if strings.Contains(q, "2026") {
+		t.Errorf("fulltext statement contains an interpolated timestamp literal:\n%s", q)
+	}
+
+	// The predicate must sit in the WHERE clause, ahead of ORDER BY/LIMIT.
+	whereEnd := strings.Index(q, "ORDER BY")
+	if whereEnd < 0 {
+		t.Fatalf("fulltext statement has no ORDER BY:\n%s", q)
+	}
+	if strings.Index(q, "occurred_at >= $") > whereEnd {
+		t.Errorf("fulltext window predicate appears after ORDER BY:\n%s", q)
+	}
+}
+
+// TestBuildFulltextSearchQuery_NoRange_UnchangedStatement mirrors the hybrid
+// no-window case.
+func TestBuildFulltextSearchQuery_NoRange_UnchangedStatement(t *testing.T) {
+	t.Parallel()
+
+	query := rangeQuery()
+	query.Embedding = nil
+	query.OccurredFrom, query.OccurredTo = nil, nil
+
+	q, args := buildFulltextSearchQuery(query)
+	if strings.Contains(q, "occurred_at >= $") || strings.Contains(q, "occurred_at < $") {
+		t.Errorf("fulltext statement filtered by occurred_at without a window:\n%s", q)
+	}
+	if n := countTimeArgs(args); n != 0 {
+		t.Errorf("bound %d timestamps for a query with no window, want 0", n)
+	}
+}
+
+// TestBuildEntityCTE_AppliesRangeFilter pins the entity lane's own contract at
+// the level the lane is built, complementing the whole-statement assertions
+// above. The lane is the one that joins documents instead of scanning it, so it
+// needs the d.-qualified fragment; handing it the unqualified one would be a
+// silent SQL error only a live query would reveal.
+func TestBuildEntityCTE_AppliesRangeFilter(t *testing.T) {
+	t.Parallel()
+
+	got := buildEntityCTE("$4", "AND d.status = 'active'", "", "", "AND d.occurred_at >= $5\nAND d.occurred_at < $6")
+
+	for _, want := range []string{"AND d.occurred_at >= $5", "AND d.occurred_at < $6"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("entity CTE missing %q:\n%s", want, got)
+		}
+	}
+	limitAt := strings.Index(got, "LIMIT $3")
+	if at := strings.Index(got, "d.occurred_at >= $5"); at < 0 || at > limitAt {
+		t.Errorf("entity CTE applies the window after its LIMIT (predicate %d, limit %d):\n%s", at, limitAt, got)
+	}
+}
+
+// countTimeArgs reports how many time.Time values were bound — a direct check
+// that no bound is silently appended (or dropped) from the arg slice.
+func countTimeArgs(args []interface{}) int {
+	n := 0
+	for _, a := range args {
+		if _, ok := a.(time.Time); ok {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## 증상
"오늘 일정" 같은 temporal 질의가 당일 캘린더 문서를 한 건도 검색하지 못함.

## 근본 원인
의도 파서(`internal/intent`)가 계산한 `OccurredFrom`/`OccurredTo`가 검색 계층으로 전달되지 않고 버려지고 있었다. `model.SearchQuery`에 날짜 범위 필드가 없어 `Sort="recent"`로 대체했으나, 정렬은 이미 만들어진 RRF 후보 집합의 순서만 바꿀 뿐 애초에 후보에 없는 문서를 끌어오지 못한다.

## 변경 내용
- `model.SearchQuery`에 `OccurredFrom`/`OccurredTo` 필드 추가
- RRF 5개 레인(fts/vec/bigm/summvec/entity)과 fulltext 검색에 `occurred_at` 범위 술어를 각 레인의 `LIMIT` 앞에 파라미터 바인딩으로 적용
- `occurred_at IS NULL` 문서는 범위 지정 시 제외 (`COALESCE` 미사용 — 수집 시각을 발생 시각으로 오인하는 오염 방지)
- 범위 지정 질의에서 청크 레인 2개를 건너뜀 (날짜를 전달할 수 없어 범위 밖 문서가 후보 슬롯을 차지하거나, 폴백으로 필터가 무력화됨)
- `dayRange`/`weekRange`/`monthRange` 상한을 다음 주기 시작으로 변경해 반개구간 `[from, to)`와 정합

## 검증 방법
- `internal/intent/day_boundary_test.go` (신규): 월 경계 등 날짜 계산 유닛 테스트
- `internal/search/occurred_range_test.go` (신규): RRF 레인별 범위 필터 적용 검증
- `internal/store/document_occurred_range_test.go` (신규): fulltext 검색 범위 필터 검증
- `internal/api/ask_retrieval_test.go`, `internal/store/document_entity_lane_test.go`, `internal/intent/intent_test.go` 갱신

## 배포 후 반드시 확인할 것
로컬 환경에 pgvector·pg_bigm 확장이 없어 vec/bigm/summvec 레인의 전체 SQL 파싱은 로컬 테스트로 검증되지 않았다. **배포 직후 실제 질의 1회로 SQL 문법 오류가 없는지 반드시 확인해야 한다.**

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>