### PR TITLE
fix(llm): 추론 토큰이 응답 예산을 소진하는 문제 해결

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,16 @@ LLM_MODEL=gpt-4o-mini
 LLM_MAX_TOKENS=1500
 # Sampling temperature — 0.0 (deterministic) to 1.0 (creative). Default: 0.3
 LLM_TEMPERATURE=0.3
+# Reasoning ("thinking") control for reasoning models such as deepseek-v4-flash.
+#   disabled (default) — sends "thinking": {"type": "disabled"}
+#   enabled            — omits the parameter, leaving the endpoint's default
+# Reasoning tokens are billed against LLM_MAX_TOKENS: with reasoning on, long
+# documents burn the whole budget on reasoning and return an EMPTY completion
+# with finish_reason=length (measured: 25,388 reasoning chars, 0 content chars
+# at LLM_MAX_TOKENS=8000). Set "enabled" only against endpoints that both
+# support the parameter and are given a budget large enough for reasoning plus
+# the answer.
+LLM_THINKING=disabled
 
 # --- Summarizer worker control ---
 # Set SUMMARIZER_ENABLED=false on collector replicas that should NOT run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,14 @@ type Config struct {
 	LLMMaxTokens      int
 	LLMTemperature    float64
 	LLMTimeoutSeconds int // LLM_TIMEOUT_SECONDS — HTTP client timeout; default 120
+	// LLMThinking: LLM_THINKING env var — "disabled" (default) or "enabled".
+	// Reasoning models bill reasoning_content against max_tokens; on long
+	// reasoning the budget is spent before any visible content is produced
+	// and the response comes back empty with finish_reason="length". Both
+	// consumers of the client (summarizer, extraction worker) do mechanical
+	// structured-output work, so reasoning is off by default. Any value other
+	// than "enabled" is treated as "disabled".
+	LLMThinking string
 
 	// Slack (optional)
 	SlackBotToken string
@@ -541,6 +549,25 @@ func Load() (*Config, error) {
 		}
 	}
 
+	// LLM_THINKING: "disabled" (default) or "enabled". Anything else falls
+	// back to "disabled" with a warning — an unrecognised value must not
+	// silently re-enable reasoning and reintroduce empty completions.
+	// The literals mirror llm.ThinkingDisabled / llm.ThinkingEnabled; they are
+	// repeated rather than imported to keep config free of a dependency on
+	// internal/llm.
+	llmThinking := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_THINKING")))
+	switch llmThinking {
+	case "":
+		llmThinking = "disabled"
+	case "disabled", "enabled":
+		// valid
+	default:
+		slog.Warn("config: LLM_THINKING is invalid; using \"disabled\"",
+			"value", llmThinking,
+		)
+		llmThinking = "disabled"
+	}
+
 	// SUMMARIZER_BACKFILL_ENABLED: default true.
 	// Set =false to skip the ListUnsummarized scan when running a slow local LLM.
 	summarizerBackfill := true
@@ -601,6 +628,7 @@ func Load() (*Config, error) {
 		LLMMaxTokens:      llmMaxTokens,
 		LLMTemperature:    llmTemperature,
 		LLMTimeoutSeconds: llmTimeoutSeconds,
+		LLMThinking:       llmThinking,
 
 		SlackBotToken: os.Getenv("SLACK_BOT_TOKEN"),
 		SlackTeamID:   os.Getenv("SLACK_TEAM_ID"),

--- a/internal/config/config_llm_thinking_test.go
+++ b/internal/config/config_llm_thinking_test.go
@@ -1,0 +1,47 @@
+package config
+
+import "testing"
+
+// TestLoad_LLMThinking verifies LLM_THINKING parsing.
+//
+// Default is "disabled": deepseek-v4-flash bills reasoning_content against
+// max_tokens and returns an empty completion (finish_reason=length) on
+// documents whose reasoning runs long — the observed cause of ~16% extraction
+// failures. Only the literal "enabled" turns reasoning back on.
+func TestLoad_LLMThinking(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   string
+	}{
+		{name: "default_when_unset", unset: true, want: "disabled"},
+		{name: "explicit_disabled", envVal: "disabled", want: "disabled"},
+		{name: "explicit_enabled", envVal: "enabled", want: "enabled"},
+		{name: "case_insensitive_enabled", envVal: "Enabled", want: "enabled"},
+		{name: "whitespace_trimmed", envVal: " enabled ", want: "enabled"},
+		{name: "empty_uses_default", envVal: "", want: "disabled"},
+		{name: "unknown_value_uses_default", envVal: "low", want: "disabled"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "LLM_THINKING")
+			} else {
+				setenv(t, "LLM_THINKING", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.LLMThinking != tc.want {
+				t.Errorf("LLMThinking = %q, want %q", cfg.LLMThinking, tc.want)
+			}
+		})
+	}
+}

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -55,8 +56,34 @@ type Client struct {
 	tokens      auth.TokenSource // nil when no auth configured
 	maxTokens   int
 	temperature float64
-	httpClient  *http.Client
+	// thinking is the value serialised into the request's "thinking" field.
+	// nil means the field is omitted entirely from the request body (see
+	// Config.Thinking).
+	thinking   *thinkingParam
+	httpClient *http.Client
 }
+
+// Thinking modes accepted by Config.Thinking.
+//
+// Reasoning models (e.g. deepseek-v4-flash) charge reasoning_content against
+// the same max_tokens budget as the visible completion. On inputs whose
+// reasoning runs long the budget is consumed entirely by reasoning and the
+// response comes back with zero-length content and finish_reason="length" —
+// measured on a 2,768-character document: max_tokens=8000 produced 25,388
+// reasoning characters and 0 content characters. Disabling reasoning on the
+// same document produced a complete answer in 750 completion tokens.
+//
+// Both users of this client (the summarizer and the extraction worker) do
+// mechanical structured-output work, so ThinkingDisabled is the default.
+const (
+	// ThinkingDisabled sends "thinking": {"type": "disabled"}.
+	ThinkingDisabled = "disabled"
+	// ThinkingEnabled omits the "thinking" field entirely, leaving the
+	// endpoint's own default in force. The field is omitted rather than sent
+	// as {"type":"enabled"} because OpenAI-compatible endpoints that do not
+	// implement this vendor parameter reject unknown fields with HTTP 400.
+	ThinkingEnabled = "enabled"
+)
 
 // Config holds the parameters required to construct a Client.
 //
@@ -76,6 +103,12 @@ type Config struct {
 	// Increase for slow local CPU inference (e.g. gemma3:4b) by setting
 	// LLM_TIMEOUT_SECONDS in the environment.
 	Timeout time.Duration
+	// Thinking controls the vendor "thinking" request parameter:
+	// ThinkingDisabled (or "", the zero value) sends
+	// "thinking": {"type": "disabled"}; ThinkingEnabled omits the field.
+	// Any other value is treated as ThinkingDisabled. Sourced from the
+	// LLM_THINKING environment variable via config.Config.LLMThinking.
+	Thinking string
 }
 
 // New returns a Client configured with the given Config.
@@ -98,8 +131,19 @@ func New(cfg Config, httpClient *http.Client) *Client {
 		tokens:      auth.Resolve(cfg.APIKey, cfg.AuthFile),
 		maxTokens:   cfg.MaxTokens,
 		temperature: cfg.Temperature,
+		thinking:    thinkingFor(cfg.Thinking),
 		httpClient:  httpClient,
 	}
+}
+
+// thinkingFor maps a Config.Thinking value to the request field value.
+// Returning nil means "omit the field" — see the ThinkingEnabled doc comment
+// for why enabling is expressed as an omission.
+func thinkingFor(mode string) *thinkingParam {
+	if strings.EqualFold(strings.TrimSpace(mode), ThinkingEnabled) {
+		return nil
+	}
+	return &thinkingParam{Type: ThinkingDisabled}
 }
 
 // Enabled reports whether the client has the minimum required configuration
@@ -147,7 +191,60 @@ type chatRequest struct {
 	Temperature float64   `json:"temperature"`
 	MaxTokens   int       `json:"max_tokens"`
 	Stream      bool      `json:"stream,omitempty"`
+	// Thinking is a POINTER with omitempty on purpose: encoding/json's
+	// omitempty does not treat an empty struct as empty, so a value type
+	// would serialise "thinking":{"type":""} on every request and any
+	// OpenAI-compatible endpoint that does not implement this vendor
+	// parameter would answer HTTP 400. nil omits the key entirely.
+	Thinking *thinkingParam `json:"thinking,omitempty"`
 }
+
+// thinkingParam is the vendor "thinking" request object, e.g.
+// {"type": "disabled"}.
+type thinkingParam struct {
+	Type string `json:"type"`
+}
+
+// finishReasonLength is the finish_reason a provider returns when generation
+// stopped because the max_tokens budget ran out.
+const finishReasonLength = "length"
+
+// ErrTruncated is the sentinel behind every *TruncatedError, so callers can
+// branch with errors.Is without depending on the struct type.
+var ErrTruncated = errors.New("llm: response truncated by token budget")
+
+// TruncatedError reports that generation stopped on the token budget
+// (finish_reason="length") rather than at a natural stop. Both variants are
+// errors:
+//
+//   - empty content: the whole budget was spent on reasoning_content, and the
+//     caller would otherwise see only a confusing "cannot parse empty JSON".
+//   - non-empty content: a partial completion. Passing it on as success
+//     silently loses data (half-parsed entities, half-written summaries).
+//
+// The response body is deliberately NOT a field of this error and never
+// appears in Error(): completions contain personal data (issue #194).
+type TruncatedError struct {
+	// FinishReason is the raw finish_reason reported by the provider.
+	FinishReason string
+	// CompletionTokens is the provider-reported completion token count, or 0
+	// when the response carried no usage block (streaming responses usually
+	// do not).
+	CompletionTokens int
+	// ContentLength is the byte length of the content that was produced —
+	// a length only, never the content itself.
+	ContentLength int
+}
+
+func (e *TruncatedError) Error() string {
+	return fmt.Sprintf(
+		"llm: generation stopped on the token budget (finish_reason=%q, completion_tokens=%d, content_length=%d); raise LLM_MAX_TOKENS or set LLM_THINKING=disabled",
+		e.FinishReason, e.CompletionTokens, e.ContentLength,
+	)
+}
+
+// Unwrap makes errors.Is(err, ErrTruncated) hold.
+func (e *TruncatedError) Unwrap() error { return ErrTruncated }
 
 // streamChunk is a single OpenAI-compatible streaming SSE data payload:
 // {"choices":[{"delta":{"content":"..."},"finish_reason":null}]}
@@ -166,6 +263,9 @@ type chatResponse struct {
 		Message struct {
 			Content string `json:"content"`
 		} `json:"message"`
+		// FinishReason is absent on some OpenAI-compatible proxies; an empty
+		// value is treated as "no signal" and never fails the request.
+		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 	// Usage is optional: some OpenAI-compatible proxies omit it. A nil Usage
 	// (or a struct that never unmarshals because the field is entirely
@@ -229,6 +329,7 @@ func (c *Client) CompleteWithMessages(ctx context.Context, system string, messag
 		Messages:    allMessages,
 		Temperature: c.temperature,
 		MaxTokens:   c.maxTokens,
+		Thinking:    c.thinking,
 	}
 
 	const maxRetries = 2
@@ -244,8 +345,13 @@ func (c *Client) CompleteWithMessages(ctx context.Context, system string, messag
 			}
 			return result, nil
 		}
-		if isClientError(err) {
+		if isClientError(err) || errors.Is(err, ErrTruncated) {
 			// 4xx — do not retry.
+			//
+			// Truncation is not retried either: the same prompt against the
+			// same budget deterministically exhausts it again, so retrying
+			// only bills three full max_tokens generations for one failure.
+			// The error tells the operator which knob to turn instead.
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return "", err
@@ -332,6 +438,7 @@ func (c *Client) StreamWithMessages(ctx context.Context, system string, messages
 		Temperature: c.temperature,
 		MaxTokens:   c.maxTokens,
 		Stream:      true,
+		Thinking:    c.thinking,
 	}
 
 	payload, err := json.Marshal(reqBody)
@@ -365,6 +472,17 @@ func (c *Client) StreamWithMessages(ctx context.Context, system string, messages
 		return &clientError{statusCode: resp.StatusCode, body: string(body)}
 	}
 
+	// finishReason keeps the last non-empty finish_reason seen on the stream:
+	// providers report it on the final chunk (often one carrying no content),
+	// and it is the only signal distinguishing a complete answer from one cut
+	// off by the token budget. Discarding it is what made budget exhaustion
+	// look like a JSON parse failure to callers.
+	var finishReason string
+	// contentLen accumulates delivered delta bytes so a truncation error can
+	// report a length without retaining the content itself.
+	var contentLen int
+	var sawDone bool
+
 	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -376,7 +494,8 @@ func (c *Client) StreamWithMessages(ctx context.Context, system string, messages
 			continue
 		}
 		if data == "[DONE]" {
-			return nil
+			sawDone = true
+			break
 		}
 
 		var chunk streamChunk
@@ -388,20 +507,38 @@ func (c *Client) StreamWithMessages(ctx context.Context, system string, messages
 		if len(chunk.Choices) == 0 {
 			continue
 		}
+		if fr := chunk.Choices[0].FinishReason; fr != nil && *fr != "" {
+			finishReason = *fr
+		}
 		if content := chunk.Choices[0].Delta.Content; content != "" {
+			contentLen += len(content)
 			onDelta(content)
 		}
 	}
 
-	// Prefer ctx.Err() over the raw scanner error: when the caller cancels
-	// (client disconnect, timeout), the underlying transport error message
-	// varies by platform/Go version, but the caller only needs to reliably
-	// detect "this was a cancellation" via errors.Is(err, context.Canceled).
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return fmt.Errorf("llm: stream canceled: %w", ctxErr)
+	if !sawDone {
+		// Prefer ctx.Err() over the raw scanner error: when the caller cancels
+		// (client disconnect, timeout), the underlying transport error message
+		// varies by platform/Go version, but the caller only needs to reliably
+		// detect "this was a cancellation" via errors.Is(err, context.Canceled).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return fmt.Errorf("llm: stream canceled: %w", ctxErr)
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("llm: read stream: %w", err)
+		}
 	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("llm: read stream: %w", err)
+
+	// Same verdict as the non-streaming path. Deltas already handed to
+	// onDelta are NOT retracted — the caller has typically forwarded them
+	// downstream already — but the call still fails so the caller does not
+	// treat a cut-off answer as complete. Streaming responses carry no usage
+	// block, hence CompletionTokens is left at 0.
+	if finishReason == finishReasonLength {
+		return &TruncatedError{
+			FinishReason:  finishReason,
+			ContentLength: contentLen,
+		}
 	}
 	return nil
 }
@@ -486,5 +623,23 @@ func (c *Client) doRequest(ctx context.Context, reqBody chatRequest) (string, *t
 		return "", nil, fmt.Errorf("llm: response contains no choices")
 	}
 
-	return chatResp.Choices[0].Message.Content, chatResp.Usage, nil
+	choice := chatResp.Choices[0]
+
+	// A budget-truncated completion is an error, whether the content is empty
+	// (reasoning ate the budget) or partial (silently lossy). Reported before
+	// returning any content so no caller can accidentally parse half a JSON
+	// document as a complete one.
+	if choice.FinishReason == finishReasonLength {
+		completionTokens := 0
+		if chatResp.Usage != nil {
+			completionTokens = chatResp.Usage.CompletionTokens
+		}
+		return "", chatResp.Usage, &TruncatedError{
+			FinishReason:     choice.FinishReason,
+			CompletionTokens: completionTokens,
+			ContentLength:    len(choice.Message.Content),
+		}
+	}
+
+	return choice.Message.Content, chatResp.Usage, nil
 }

--- a/internal/llm/client_thinking_test.go
+++ b/internal/llm/client_thinking_test.go
@@ -1,0 +1,434 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/llm"
+)
+
+// --- helpers ---
+
+// captureBody returns a handler that records the decoded JSON request body
+// into *dst and replies with a minimal successful completion.
+func captureBody(t *testing.T, dst *map[string]any, reply []byte) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			return
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Errorf("unmarshal request body: %v", err)
+			return
+		}
+		*dst = decoded
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(reply) //nolint:errcheck
+	}
+}
+
+// chatResponseFinish builds an OpenAI-format chat completion response body
+// with an explicit finish_reason and usage block.
+func chatResponseFinish(content, finishReason string, completionTokens int) []byte {
+	body := map[string]any{
+		"choices": []map[string]any{
+			{
+				"message":       map[string]any{"content": content},
+				"finish_reason": finishReason,
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     11,
+			"completion_tokens": completionTokens,
+			"total_tokens":      11 + completionTokens,
+		},
+	}
+	data, _ := json.Marshal(body)
+	return data
+}
+
+// sseChunkFinish builds an SSE data line carrying an optional content delta
+// and a finish_reason.
+func sseChunkFinish(content, finishReason string) string {
+	choice := map[string]any{
+		"delta":         map[string]any{"content": content},
+		"finish_reason": finishReason,
+	}
+	data, _ := json.Marshal(map[string]any{"choices": []map[string]any{choice}})
+	return "data: " + string(data) + "\n\n"
+}
+
+// sseServer replies with the given raw SSE payload.
+func sseServer(t *testing.T, payload string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, payload) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// --- (a) thinking field presence/omission ---
+
+func TestClient_Thinking_DisabledIsSentInRequestBody(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]any
+	srv := httptest.NewServer(captureBody(t, &got, chatResponseOK("ok")))
+	t.Cleanup(srv.Close)
+
+	c := llm.New(llm.Config{
+		BaseURL:  srv.URL,
+		Model:    "gpt-test",
+		APIKey:   "key",
+		Thinking: llm.ThinkingDisabled,
+	}, nil)
+
+	if _, err := c.Complete(context.Background(), "sys", "user"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	field, ok := got["thinking"]
+	if !ok {
+		t.Fatalf("request body must contain \"thinking\" when disabled; body=%v", keysOf(got))
+	}
+	obj, ok := field.(map[string]any)
+	if !ok {
+		t.Fatalf("thinking must be an object, got %T", field)
+	}
+	if obj["type"] != "disabled" {
+		t.Fatalf("thinking.type = %v, want \"disabled\"", obj["type"])
+	}
+}
+
+func TestClient_Thinking_EnabledOmitsField(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]any
+	srv := httptest.NewServer(captureBody(t, &got, chatResponseOK("ok")))
+	t.Cleanup(srv.Close)
+
+	c := llm.New(llm.Config{
+		BaseURL:  srv.URL,
+		Model:    "gpt-test",
+		APIKey:   "key",
+		Thinking: llm.ThinkingEnabled,
+	}, nil)
+
+	if _, err := c.Complete(context.Background(), "sys", "user"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := got["thinking"]; ok {
+		t.Fatalf("request body must NOT contain \"thinking\" when enabled (endpoints that do not know the parameter reject it); body=%v", keysOf(got))
+	}
+}
+
+func TestClient_Thinking_EmptyConfigDefaultsToDisabled(t *testing.T) {
+	t.Parallel()
+
+	var got map[string]any
+	srv := httptest.NewServer(captureBody(t, &got, chatResponseOK("ok")))
+	t.Cleanup(srv.Close)
+
+	// Zero-value Config.Thinking → disabled (the safe production default:
+	// reasoning_content burns the max_tokens budget and yields empty content).
+	c := llm.New(llm.Config{
+		BaseURL: srv.URL,
+		Model:   "gpt-test",
+		APIKey:  "key",
+	}, nil)
+
+	if _, err := c.Complete(context.Background(), "sys", "user"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	obj, ok := got["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("zero-value Thinking must default to disabled; body=%v", keysOf(got))
+	}
+	if obj["type"] != "disabled" {
+		t.Fatalf("thinking.type = %v, want \"disabled\"", obj["type"])
+	}
+}
+
+// (e, part 1) the streaming request body carries the same thinking setting.
+func TestClient_Thinking_AppliesToStreamingRequest(t *testing.T) {
+	t.Parallel()
+
+	var disabledBody, enabledBody map[string]any
+
+	streamReply := func(dst *map[string]any) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			raw, _ := io.ReadAll(r.Body)
+			var decoded map[string]any
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Errorf("unmarshal streaming request body: %v", err)
+				return
+			}
+			*dst = decoded
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, sseChunkFinish("hi", "")+"data: [DONE]\n\n") //nolint:errcheck
+		}
+	}
+
+	srvDisabled := httptest.NewServer(streamReply(&disabledBody))
+	t.Cleanup(srvDisabled.Close)
+	srvEnabled := httptest.NewServer(streamReply(&enabledBody))
+	t.Cleanup(srvEnabled.Close)
+
+	cDisabled := llm.New(llm.Config{BaseURL: srvDisabled.URL, Model: "m", APIKey: "k", Thinking: llm.ThinkingDisabled}, nil)
+	if err := cDisabled.StreamWithMessages(context.Background(), "sys", nil, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	obj, ok := disabledBody["thinking"].(map[string]any)
+	if !ok || obj["type"] != "disabled" {
+		t.Fatalf("streaming request must carry thinking.type=disabled; got %v", disabledBody["thinking"])
+	}
+
+	cEnabled := llm.New(llm.Config{BaseURL: srvEnabled.URL, Model: "m", APIKey: "k", Thinking: llm.ThinkingEnabled}, nil)
+	if err := cEnabled.StreamWithMessages(context.Background(), "sys", nil, func(string) {}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := enabledBody["thinking"]; ok {
+		t.Fatalf("streaming request must omit thinking when enabled; body=%v", keysOf(enabledBody))
+	}
+}
+
+// --- (b) finish_reason=length + empty content → error ---
+
+func TestClient_Complete_LengthWithEmptyContentIsError(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chatResponseFinish("", "length", 8000)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	got, err := c.Complete(context.Background(), "sys", "user")
+	if err == nil {
+		t.Fatalf("expected error for finish_reason=length with empty content, got content %q", got)
+	}
+	if got != "" {
+		t.Fatalf("no content must be returned alongside a truncation error, got %q", got)
+	}
+
+	var te *llm.TruncatedError
+	if !errors.As(err, &te) {
+		t.Fatalf("error must be a *llm.TruncatedError, got %T: %v", err, err)
+	}
+	if !errors.Is(err, llm.ErrTruncated) {
+		t.Fatalf("errors.Is(err, llm.ErrTruncated) must hold, got: %v", err)
+	}
+	if te.FinishReason != "length" {
+		t.Fatalf("FinishReason = %q, want \"length\"", te.FinishReason)
+	}
+	if te.CompletionTokens != 8000 {
+		t.Fatalf("CompletionTokens = %d, want 8000", te.CompletionTokens)
+	}
+	if te.ContentLength != 0 {
+		t.Fatalf("ContentLength = %d, want 0", te.ContentLength)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "length") || !strings.Contains(msg, "8000") {
+		t.Fatalf("error message must name finish_reason and completion tokens, got: %s", msg)
+	}
+	// Truncation is deterministic — retrying burns the same budget again.
+	if calls != 1 {
+		t.Fatalf("truncation must not be retried, got %d calls", calls)
+	}
+}
+
+// --- (c) finish_reason=length + non-empty content → error (silent data loss) ---
+
+func TestClient_Complete_LengthWithPartialContentIsError(t *testing.T) {
+	t.Parallel()
+
+	const partial = `{"entities":[{"name":"dummy-alpha","typ`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chatResponseFinish(partial, "length", 8000)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	got, err := c.Complete(context.Background(), "sys", "user")
+	if err == nil {
+		t.Fatal("truncated (non-empty) content must be an error, not a silent partial result")
+	}
+	if got != "" {
+		t.Fatalf("truncated content must not be returned to the caller, got %q", got)
+	}
+	var te *llm.TruncatedError
+	if !errors.As(err, &te) {
+		t.Fatalf("error must be a *llm.TruncatedError, got %T: %v", err, err)
+	}
+	if te.ContentLength != len(partial) {
+		t.Fatalf("ContentLength = %d, want %d", te.ContentLength, len(partial))
+	}
+}
+
+// --- (d) finish_reason=stop → unchanged happy path ---
+
+func TestClient_Complete_StopUnchanged(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chatResponseFinish(`{"entities":[]}`, "stop", 12)) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	got, err := c.Complete(context.Background(), "sys", "user")
+	if err != nil {
+		t.Fatalf("unexpected error on finish_reason=stop: %v", err)
+	}
+	if got != `{"entities":[]}` {
+		t.Fatalf("got %q, want %q", got, `{"entities":[]}`)
+	}
+}
+
+// A response with no finish_reason at all (proxies that omit it) must keep
+// working exactly as before.
+func TestClient_Complete_MissingFinishReasonUnchanged(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(chatResponseOK("plain answer")) //nolint:errcheck
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newClient(t, srv.URL, "key")
+	got, err := c.Complete(context.Background(), "sys", "user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "plain answer" {
+		t.Fatalf("got %q, want %q", got, "plain answer")
+	}
+}
+
+// --- (e) streaming applies the same verdict ---
+
+func TestClient_Stream_LengthFinishReasonIsError(t *testing.T) {
+	t.Parallel()
+
+	payload := sseChunkFinish("partial ", "") +
+		sseChunkFinish("output", "length") +
+		"data: [DONE]\n\n"
+	srv := sseServer(t, payload)
+
+	c := newClient(t, srv.URL, "key")
+	var seen strings.Builder
+	err := c.StreamWithMessages(context.Background(), "sys", nil, func(d string) {
+		seen.WriteString(d)
+	})
+	if err == nil {
+		t.Fatal("streaming must report finish_reason=length as an error")
+	}
+	var te *llm.TruncatedError
+	if !errors.As(err, &te) {
+		t.Fatalf("error must be a *llm.TruncatedError, got %T: %v", err, err)
+	}
+	if te.ContentLength != len("partial output") {
+		t.Fatalf("ContentLength = %d, want %d", te.ContentLength, len("partial output"))
+	}
+	if seen.String() != "partial output" {
+		t.Fatalf("deltas already delivered before truncation must not be suppressed, got %q", seen.String())
+	}
+}
+
+func TestClient_Stream_StopFinishReasonUnchanged(t *testing.T) {
+	t.Parallel()
+
+	payload := sseChunkFinish("hello ", "") +
+		sseChunkFinish("world", "stop") +
+		"data: [DONE]\n\n"
+	srv := sseServer(t, payload)
+
+	c := newClient(t, srv.URL, "key")
+	var seen strings.Builder
+	if err := c.StreamWithMessages(context.Background(), "sys", nil, func(d string) {
+		seen.WriteString(d)
+	}); err != nil {
+		t.Fatalf("unexpected error on finish_reason=stop: %v", err)
+	}
+	if seen.String() != "hello world" {
+		t.Fatalf("got %q, want %q", seen.String(), "hello world")
+	}
+}
+
+// --- (f) the error must never carry the response body ---
+
+func TestClient_TruncationError_DoesNotLeakResponseBody(t *testing.T) {
+	t.Parallel()
+
+	// Stand-in for personally identifying text a real completion may contain.
+	const marker = "DUMMY-PII-MARKER-ZZZ"
+
+	t.Run("non-streaming", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(chatResponseFinish(`{"name":"`+marker+`"`, "length", 8000)) //nolint:errcheck
+		}))
+		t.Cleanup(srv.Close)
+
+		c := newClient(t, srv.URL, "key")
+		_, err := c.Complete(context.Background(), "sys", "user")
+		if err == nil {
+			t.Fatal("expected truncation error")
+		}
+		if strings.Contains(err.Error(), marker) {
+			t.Fatalf("error message leaks response content: %s", err.Error())
+		}
+	})
+
+	t.Run("streaming", func(t *testing.T) {
+		t.Parallel()
+		srv := sseServer(t, sseChunkFinish(marker, "length")+"data: [DONE]\n\n")
+
+		c := newClient(t, srv.URL, "key")
+		err := c.StreamWithMessages(context.Background(), "sys", nil, func(string) {})
+		if err == nil {
+			t.Fatal("expected truncation error")
+		}
+		if strings.Contains(err.Error(), marker) {
+			t.Fatalf("error message leaks streamed content: %s", err.Error())
+		}
+	})
+}
+
+// keysOf returns the sorted-ish key set of a decoded JSON body for failure
+// messages (never the values — bodies may contain personal data).
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/worker/extraction_log_redaction_test.go
+++ b/internal/worker/extraction_log_redaction_test.go
@@ -1,0 +1,69 @@
+package worker
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestParseRelationActionResponse_LogDoesNotLeakRawResponse asserts the parse
+// failure path never writes raw LLM output to the log (issue #194: real names,
+// phone numbers and e-mail addresses were landing in the "response" field).
+//
+// Only a length and a content-free shape fingerprint may be logged.
+//
+// Not parallel: it swaps the process-wide default slog handler.
+func TestParseRelationActionResponse_LogDoesNotLeakRawResponse(t *testing.T) {
+	// Fabricated stand-ins — never real personal data.
+	const (
+		name  = "DUMMYNAME-ALPHA"
+		phone = "010-0000-0000"
+		mail  = "dummy-alpha@example.invalid"
+	)
+	raw := `{"entities":[{"name":"` + name + `","phone":"` + phone + `","email":"` + mail + `"` +
+		strings.Repeat(" ", 300) // long enough to exercise any truncation branch
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	if _, err := parseRelationActionResponse(raw); err == nil {
+		t.Fatal("expected a parse error for truncated JSON")
+	}
+
+	logged := buf.String()
+	if logged == "" {
+		t.Fatal("expected a warning to be logged")
+	}
+	for _, secret := range []string{name, phone, mail} {
+		if strings.Contains(logged, secret) {
+			t.Fatalf("log leaks raw LLM response (%q): %s", secret, logged)
+		}
+	}
+	if strings.Contains(logged, "response=") {
+		t.Fatalf("the raw \"response\" log field must be gone entirely: %s", logged)
+	}
+	if !strings.Contains(logged, "response_len") {
+		t.Fatalf("log should still record the response length for diagnosis: %s", logged)
+	}
+}
+
+// TestParseRelationActionResponse_LogsEmptyResponseShape covers the failure
+// mode that motivated this change: the model returned a zero-length body, and
+// the log said only "failed to parse LLM JSON" with an empty response field.
+func TestParseRelationActionResponse_LogsEmptyResponseShape(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	if _, err := parseRelationActionResponse(""); err == nil {
+		t.Fatal("expected a parse error for an empty response")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "empty") {
+		t.Fatalf("an empty completion must be identifiable from the log alone: %s", logged)
+	}
+}

--- a/internal/worker/extraction_worker.go
+++ b/internal/worker/extraction_worker.go
@@ -581,6 +581,32 @@ type extractionWireResponse struct {
 //
 // Fallback path: if Decode still fails (e.g. leading prose before the JSON
 // object), retry against the substring from the first '{' to the last '}'.
+// llmResponseShape classifies a completion into one of a fixed set of
+// content-free labels, for logging in place of the response itself.
+//
+// It returns only values drawn from the closed vocabulary below, so no part of
+// the model's output — which may contain personal data — can reach the logs
+// through it (issue #194). "empty" is the label for the failure this was built
+// for: a reasoning model that spends its whole max_tokens budget on
+// reasoning_content and returns zero visible characters.
+func llmResponseShape(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	switch {
+	case trimmed == "":
+		return "empty"
+	case strings.HasPrefix(trimmed, "```"):
+		return "fenced-block"
+	case strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}"):
+		return "json-object"
+	case strings.HasPrefix(trimmed, "{"):
+		return "json-object-unterminated"
+	case strings.HasPrefix(trimmed, "["):
+		return "json-array"
+	default:
+		return "non-json-text"
+	}
+}
+
 func parseRelationActionResponse(raw string) (*ExtractionResult, error) {
 	trimmed := strings.TrimSpace(raw)
 	if strings.HasPrefix(trimmed, "```") {
@@ -598,11 +624,16 @@ func parseRelationActionResponse(raw string) (*ExtractionResult, error) {
 		}
 	}
 	if err != nil {
-		truncated := raw
-		if len(truncated) > 200 {
-			truncated = truncated[:200] + "...[truncated]"
-		}
-		slog.Warn("extraction: failed to parse LLM JSON", "error", err, "response", truncated)
+		// The raw completion is NEVER logged: extraction runs over messages,
+		// call transcripts and mail, so a response prefix routinely carries
+		// real names, phone numbers and e-mail addresses (issue #194). A
+		// length plus a content-free shape fingerprint is enough to tell the
+		// three failure modes apart (empty completion, cut-off JSON, prose).
+		slog.Warn("extraction: failed to parse LLM JSON",
+			"error", err,
+			"response_len", len(raw),
+			"response_shape", llmResponseShape(raw),
+		)
 		return nil, fmt.Errorf("parse extraction response: %w", err)
 	}
 


### PR DESCRIPTION
## 증상

`deepseek-v4-flash`는 추론 모델이며 `reasoning_content`가 `max_tokens`를 함께 소진한다. 추론이 길어지는 문서에서 예산을 전부 태우고 본문을 0자 반환한 채 `finish_reason='length'`로 끝나, 추출 워커가 문서의 약 16%에서 실패했다. 로그에는 "failed to parse LLM JSON"으로만 찍혀 원인이 가려져 있었다.

## 근본 원인 (실측 표)

같은 문서로 비교:

| 설정 | 결과 |
|---|---|
| `max_tokens=8000` (기존) | 빈 응답, completion 8000 토큰 전액 낭비 |
| `thinking=disabled` | 정상 완결, completion 750 토큰 |

## 변경 내용

- `LLM_THINKING` 설정 추가(기본 disabled). disabled일 때만 요청 본문에 `thinking` 필드를 실어 보내고, enabled면 필드를 생략해 이 파라미터를 모르는 엔드포인트와의 호환성 유지
- 스트리밍/비스트리밍 양쪽 요청에 동일 적용
- `finish_reason='length'`를 `TruncatedError`로 표면화. 잘린 content는 호출자에게 반환하지 않는다. 절단은 재시도하지 않는다(같은 예산이면 결정론적으로 재소진되므로)
- 추출 워커 파싱 실패 로그에서 LLM 원본 응답 제거, 길이와 폐쇄 어휘 형태값만 기록 (#194)

**server/collector의 `llm.Config.Thinking` 배선은 이 PR에 없다.** `thinkingFor`의 제로값이 disabled이므로 배선 없이도 추론은 비활성화된다. 배선은 `LLM_THINKING=enabled`를 존중하기 위한 것으로, 우리가 원하는 기본값이 아니라서 후속 PR로 미룬다. `cmd/server/main.go`는 Part B 그래프 배선 작업과 겹쳐 있어 이번 PR 범위에서 제외했다.

## 검증

- 신규 유닛 테스트: `internal/llm/client_thinking_test.go`, `internal/config/config_llm_thinking_test.go`, `internal/worker/extraction_log_redaction_test.go`

## 배포 후 확인사항

- collector 재기동 후 추출 실패율이 16%에서 떨어지는지 확인 필요
- `LLM_THINKING=enabled` 경로는 실서버로 검증되지 않았고 스텁 기준으로만 "필드 생략"이 보장됨
- `cmd/server/main.go` / `cmd/collector/main.go` 배선이 없어 `LLM_THINKING=enabled`는 현재 무시된다. 기본값(disabled)만 실효하며, 이는 의도된 운영값이다. 배선은 후속 PR에서 처리한다

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)