### PR TITLE
fix(intent): 날짜 창을 프로세스 로컬이 아닌 KST로 고정

### DIFF
--- a/internal/api/ask.go
+++ b/internal/api/ask.go
@@ -13,6 +13,7 @@ import (
 	"github.com/baekenough/second-brain/internal/intent"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/timeutil"
 )
 
 // AskRequest is the JSON body accepted by POST /api/v1/ask. ConversationID
@@ -70,30 +71,19 @@ type askErrorPayload struct {
 	Message string `json:"message"`
 }
 
-// kstLocation is the timezone used to render every date/time shown to the
-// model in the Stage 3 prompt: the current-date line in
-// buildAskSystemPrompt and each document's occurred_at in buildAskMessages.
-// Second Brain's users and ingested data are Korea-based, so dates are
-// always rendered in Asia/Seoul rather than the server process's local
-// timezone (which may be UTC in a container) — otherwise a request served
-// near local midnight could show the model the wrong calendar date and
-// reintroduce the exact bug this file fixes.
+// Every date/time shown to the model in the Stage 3 prompt — the current-date
+// line in buildAskSystemPrompt and each document's occurred_at in
+// buildAskMessages — is rendered in timeutil.KST(), never in the server
+// process's local timezone (which is UTC in the production container).
+// Second Brain's users and ingested data are Korea-based, so a request served
+// near the container's local midnight would otherwise show the model the wrong
+// calendar date and reintroduce the exact bug this file fixes.
 //
-// time.LoadLocation reads the OS tzdata database; the production image
-// (Dockerfile's runtime-base stage) installs the tzdata package for exactly
-// this reason. The time.FixedZone fallback below only matters for an
-// environment without a tzdata database (e.g. a minimal test sandbox) —
-// Korea observes no DST, so a fixed UTC+9 offset is equivalent to the IANA
-// zone at every point in time, not just an approximation.
-var kstLocation = loadKSTLocation()
-
-func loadKSTLocation() *time.Location {
-	loc, err := time.LoadLocation("Asia/Seoul")
-	if err != nil {
-		return time.FixedZone("KST", 9*60*60)
-	}
-	return loc
-}
+// The location is shared with internal/intent, which resolves the
+// "오늘"/"이번 주"/"지난달" retrieval windows in the same zone. One definition is
+// deliberate: a second copy would let the prompt's rendered date and the
+// retrieval window drift into disagreeing about which day "today" is. See
+// internal/timeutil/kst.go for the tzdata/fallback rationale.
 
 // koreanWeekdayNames is indexed by time.Weekday (Sunday=0 ... Saturday=6).
 var koreanWeekdayNames = [...]string{"일", "월", "화", "수", "목", "금", "토"}
@@ -115,7 +105,7 @@ func formatOccurredAt(t *time.Time) string {
 	if t == nil {
 		return "시각 정보 없음"
 	}
-	return formatKoreanDateTime(t.In(kstLocation))
+	return formatKoreanDateTime(t.In(timeutil.KST()))
 }
 
 // askSystemPromptTemplate is buildAskSystemPrompt's format string. It
@@ -143,7 +133,7 @@ const askSystemPromptTemplate = `당신은 사용자의 개인 지식 베이스�
 // so it could not resolve "내일"/"어제" and answered that it didn't know
 // what day it was.
 func buildAskSystemPrompt(now time.Time) string {
-	return fmt.Sprintf(askSystemPromptTemplate, formatKoreanDateTime(now.In(kstLocation)))
+	return fmt.Sprintf(askSystemPromptTemplate, formatKoreanDateTime(now.In(timeutil.KST())))
 }
 
 // writeSSEEvent writes one "event: <name>\ndata: <json>\n\n" frame and

--- a/internal/intent/day_boundary_test.go
+++ b/internal/intent/day_boundary_test.go
@@ -25,9 +25,11 @@ import (
 // consequence (the last instant of the period is inside the window) so the
 // regression cannot come back through a "tidier-looking" 23:59:59.
 //
-// KST is used deliberately: the classifier resolves calendar days in
-// now.Location(), and a UTC-only test would pass even if the day boundary were
-// computed in the wrong zone.
+// KST is used deliberately: the classifier resolves every calendar boundary in
+// Asia/Seoul (see internal/timeutil), so the expected bounds below are KST
+// instants. Whether the classifier HONOURS that regardless of the clock's own
+// zone is pinned separately — see TestClassify_DayBoundaryIsKSTRegardlessOfClockZone
+// below and kst_window_test.go, which inject a UTC clock the way production does.
 // ---------------------------------------------------------------------------
 
 // kst is Asia/Seoul as a fixed +09:00 zone. Korea observes no DST, so a fixed
@@ -217,29 +219,54 @@ func TestClassify_ConsecutiveDayWindowsTile(t *testing.T) {
 	}
 }
 
-// TestClassify_DayBoundaryFollowsCallerTimezone pins that the calendar day is
-// resolved in the clock's own location. The reference instant below is late
-// evening in KST but the PREVIOUS day in UTC, so a classifier that silently
-// normalised to UTC would return the wrong day entirely.
-func TestClassify_DayBoundaryFollowsCallerTimezone(t *testing.T) {
+// TestClassify_DayBoundaryIsKSTRegardlessOfClockZone pins that the calendar day
+// is resolved in Asia/Seoul whatever zone the clock carries.
+//
+// This test previously asserted the opposite contract ("the day boundary
+// follows the CALLER's zone") and passed while production was broken: it only
+// ever injected a KST clock, so it could not distinguish "resolves in KST" from
+// "resolves in whatever zone it was handed". Production hands it UTC — the
+// server and collector containers run as Etc/UTC — and the UTC-resolved day is
+// 9 hours behind the day the user means. Following the caller's zone is no
+// longer the desired behaviour; the window must be a KST day either way, so the
+// same instant is asserted here in both zones.
+//
+// The reference instant is chosen so the two zones disagree about the DATE, not
+// just the offset: a classifier that normalised to the clock's own zone returns
+// a window one whole day off for the UTC case.
+func TestClassify_DayBoundaryIsKSTRegardlessOfClockZone(t *testing.T) {
 	t.Parallel()
 
-	// 2026-08-18 08:00 KST == 2026-08-17 23:00 UTC.
-	now := time.Date(2026, 8, 18, 8, 0, 0, 0, kst)
-
-	fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
-	got, err := newClassifier(t, fake, now).Classify(context.Background(), "오늘 일정에 대해 알려줘")
-	if err != nil {
-		t.Fatalf("Classify returned non-nil error: %v", err)
-	}
-	if got.OccurredFrom == nil || got.OccurredTo == nil {
-		t.Fatalf("Classify produced no window")
+	// The same instant, twice: 2026-08-18 08:00 KST == 2026-08-17 23:00 UTC.
+	clocks := []struct {
+		name string
+		now  time.Time
+	}{
+		{name: "clock in KST", now: time.Date(2026, 8, 18, 8, 0, 0, 0, kst)},
+		{name: "clock in UTC (production)", now: time.Date(2026, 8, 17, 23, 0, 0, 0, time.UTC)},
 	}
 
 	wantFrom := time.Date(2026, 8, 18, 0, 0, 0, 0, kst)
 	wantTo := time.Date(2026, 8, 19, 0, 0, 0, 0, kst)
-	if !got.OccurredFrom.Equal(wantFrom) || !got.OccurredTo.Equal(wantTo) {
-		t.Errorf("window = [%s, %s), want [%s, %s) — the day boundary must follow the caller's zone, not UTC",
-			*got.OccurredFrom, *got.OccurredTo, wantFrom, wantTo)
+
+	for _, tc := range clocks {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
+			got, err := newClassifier(t, fake, tc.now).Classify(context.Background(), "오늘 일정에 대해 알려줘")
+			if err != nil {
+				t.Fatalf("Classify returned non-nil error: %v", err)
+			}
+			if got.OccurredFrom == nil || got.OccurredTo == nil {
+				t.Fatalf("Classify produced no window")
+			}
+
+			if !got.OccurredFrom.Equal(wantFrom) || !got.OccurredTo.Equal(wantTo) {
+				t.Errorf("window = [%s, %s), want [%s, %s) — the day boundary must be KST, not the clock's own zone",
+					*got.OccurredFrom, *got.OccurredTo, wantFrom, wantTo)
+			}
+		})
 	}
 }

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/baekenough/second-brain/internal/llm"
+	"github.com/baekenough/second-brain/internal/timeutil"
 )
 
 // Kind describes how Stage 2 should shape the retrieval query for a
@@ -91,7 +92,15 @@ Otherwise use "general".`
 // call when nothing matches. It never returns a non-nil error: every
 // failure path (LLM error, malformed response) degrades to KindGeneral.
 func (c *LLMClassifier) Classify(ctx context.Context, question string) (Params, error) {
-	now := c.nowFunc()
+	// Convert the clock to KST before any calendar arithmetic below reads a
+	// year/month/weekday off it. The server and collector containers run as
+	// Etc/UTC, so nowFunc() hands back a UTC instant whose calendar date is the
+	// PREVIOUS day for the first nine hours of every Korean day — and, at a
+	// month boundary, the previous month. Deriving "지난달" or the ISO week from
+	// the raw UTC value would then name the wrong period. The range helpers
+	// normalise to KST too (see their doc comments); doing it here as well keeps
+	// the month/weekday extracted in this function honest.
+	now := c.nowFunc().In(timeutil.KST())
 
 	if phoneRe.MatchString(question) {
 		return Params{RawQuery: question, Kind: KindExactToken, Confidence: 1.0}, nil
@@ -101,14 +110,14 @@ func (c *LLMClassifier) Classify(ctx context.Context, question string) (Params, 
 		year, errY := strconv.Atoi(m[1])
 		month, errM := strconv.Atoi(m[2])
 		if errY == nil && errM == nil && month >= 1 && month <= 12 {
-			from, to := monthRange(year, month, now.Location())
+			from, to := monthRange(year, month)
 			return Params{RawQuery: question, Kind: KindTemporal, OccurredFrom: &from, OccurredTo: &to, Confidence: 1.0}, nil
 		}
 	}
 
 	if lastMonthRe.MatchString(question) {
 		lm := now.AddDate(0, -1, 0)
-		from, to := monthRange(lm.Year(), int(lm.Month()), now.Location())
+		from, to := monthRange(lm.Year(), int(lm.Month()))
 		return Params{RawQuery: question, Kind: KindTemporal, OccurredFrom: &from, OccurredTo: &to, Confidence: 1.0}, nil
 	}
 
@@ -201,24 +210,37 @@ func extractJSON(s string) string {
 // neither "어제" nor "오늘". Anchoring `to` to the next period's start makes
 // consecutive windows tile exactly: no gap, no overlap.
 //
-// All three resolve calendar boundaries in the caller's own location (the
-// clock's zone, via t.Location() / the loc argument), so "오늘" means today in
-// Seoul for a Seoul-based deployment rather than today in UTC.
+// All three resolve calendar boundaries in timeutil.KST(), NOT in the clock's
+// own location. This is the fix for a production defect: the server and
+// collector containers run as Etc/UTC (docker-compose.local.yml sets
+// TZ: Asia/Seoul only on eval-runner), so t.Location() was UTC there and "오늘"
+// meant the UTC day — a window nine hours behind the Korean day the user and
+// the ingested documents live in. A calendar event at 18:00 KST fell outside
+// the container's "오늘" window and /ask could not retrieve it. Developer
+// machines are KST, so every local test run agreed with the user and only
+// production disagreed.
+//
+// Second Brain's users and data are Korea-based, so KST is the only calendar
+// these windows should ever be expressed in, whatever zone the caller's clock
+// carries. Each helper therefore converts its input rather than trusting it —
+// converting only at the call site would leave the next caller free to
+// reintroduce the bug.
 
-// monthRange returns [00:00:00 on day 1 of the given month, 00:00:00 on day 1
-// of the following month) in loc. December is handled by time.Date's own
+// monthRange returns [00:00:00 KST on day 1 of the given month, 00:00:00 KST on
+// day 1 of the following month). December is handled by time.Date's own
 // normalisation: month 13 rolls over into January of the next year.
-func monthRange(year, month int, loc *time.Location) (time.Time, time.Time) {
+func monthRange(year, month int) (time.Time, time.Time) {
+	loc := timeutil.KST()
 	from := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, loc)
 	to := time.Date(year, time.Month(month)+1, 1, 0, 0, 0, 0, loc)
 	return from, to
 }
 
-// dayRange returns [00:00:00 today, 00:00:00 tomorrow) for the calendar day
-// containing t, in t's own location.
+// dayRange returns [00:00:00 KST, next 00:00:00 KST) for the KST calendar day
+// containing the instant t, regardless of t's own location.
 func dayRange(t time.Time) (time.Time, time.Time) {
-	y, m, d := t.Date()
-	loc := t.Location()
+	loc := timeutil.KST()
+	y, m, d := t.In(loc).Date()
 	// time.Date normalises an out-of-range day (Aug 32 -> Sep 1), and computing
 	// the next midnight directly — rather than adding 24h to `from` — keeps the
 	// bound correct in zones that observe DST, where a calendar day is not
@@ -227,13 +249,16 @@ func dayRange(t time.Time) (time.Time, time.Time) {
 	return time.Date(y, m, d, 0, 0, 0, 0, loc), time.Date(y, m, d+1, 0, 0, 0, 0, loc)
 }
 
-// weekRange returns [Monday 00:00:00, next Monday 00:00:00) of the ISO week
-// containing t. The upper bound comes from the day AFTER Sunday, so the week
-// is closed by the start of the next week rather than by Sunday's last second.
+// weekRange returns [Monday 00:00:00 KST, next Monday 00:00:00 KST) of the ISO
+// week containing the instant t. The upper bound comes from the day AFTER
+// Sunday, so the week is closed by the start of the next week rather than by
+// Sunday's last second. The weekday is read in KST: near the day boundary the
+// UTC weekday can be the previous day, which would shift the whole week.
 func weekRange(t time.Time) (time.Time, time.Time) {
+	kstNow := t.In(timeutil.KST())
 	// time.Weekday: Sunday = 0 ... Saturday = 6. Convert to days since Monday.
-	daysSinceMonday := (int(t.Weekday()) + 6) % 7
-	monday := t.AddDate(0, 0, -daysSinceMonday)
+	daysSinceMonday := (int(kstNow.Weekday()) + 6) % 7
+	monday := kstNow.AddDate(0, 0, -daysSinceMonday)
 	from, _ := dayRange(monday)
 	y, m, d := from.Date()
 	return from, time.Date(y, m, d+7, 0, 0, 0, 0, from.Location())

--- a/internal/intent/intent_test.go
+++ b/internal/intent/intent_test.go
@@ -37,8 +37,16 @@ func newClassifier(t *testing.T, c llm.Completer, now time.Time) *intent.LLMClas
 }
 
 // fixedNow anchors all relative date-phrase tests to a stable reference
-// time (2026-08-17, a Monday) so results don't depend on the real clock.
+// time so results don't depend on the real clock. It is expressed in UTC on
+// purpose — that is what the production containers' clock returns — but note
+// that 2026-08-17 15:00 UTC is 2026-08-18 00:00 KST, and the classifier resolves
+// calendar boundaries in KST, so the windows below are KST periods anchored to
+// the 18th.
 var fixedNow = time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC)
+
+// kstZone mirrors internal/timeutil's location as a fixed +09:00 offset (Korea
+// observes no DST, so this is exact) for stating expected bounds.
+var kstZone = time.FixedZone("KST", 9*60*60)
 
 func TestLLMClassifier_Classify_DeterministicDatePhrases(t *testing.T) {
 	t.Parallel()
@@ -53,19 +61,19 @@ func TestLLMClassifier_Classify_DeterministicDatePhrases(t *testing.T) {
 		{
 			name:     "explicit year and month",
 			question: "2026년 6월 요약해줘",
-			wantFrom: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			wantFrom: time.Date(2026, 6, 1, 0, 0, 0, 0, kstZone),
 			// Half-open upper bound: the first instant of July, not June's last
 			// second. See the range helpers in intent.go and
 			// TestClassify_LastInstantOfPeriodIsInsideWindow.
-			wantTo:     time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			wantTo:     time.Date(2026, 7, 1, 0, 0, 0, 0, kstZone),
 			wantConfid: 1.0,
 		},
 		{
-			name:     "last month, relative to fixed now (2026-08-17)",
+			name:     "last month, relative to fixed now (2026-08-18 KST)",
 			question: "지난달에 뭐 있었지",
-			wantFrom: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			wantFrom: time.Date(2026, 7, 1, 0, 0, 0, 0, kstZone),
 			// Half-open: July's window closes at the first instant of August.
-			wantTo:     time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+			wantTo:     time.Date(2026, 8, 1, 0, 0, 0, 0, kstZone),
 			wantConfid: 1.0,
 		},
 	}

--- a/internal/intent/kst_window_test.go
+++ b/internal/intent/kst_window_test.go
@@ -1,0 +1,236 @@
+package intent_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/intent"
+)
+
+// ---------------------------------------------------------------------------
+// Production-condition regression: the clock is UTC.
+//
+// The server and collector containers run with TZ unset, i.e. Etc/UTC, so
+// time.Now() inside Classify returns an instant whose Location is UTC. The
+// range helpers used to resolve calendar boundaries in that location, which
+// made "오늘" mean "today in UTC" — a window shifted 9 hours behind the day the
+// user (and the ingested data) actually lives in. A calendar event at 18:00 KST
+// fell outside the container's "오늘" window and /ask could not find it.
+//
+// The pre-existing day-boundary tests injected a KST clock, so they asserted
+// the proposition "a KST caller gets KST days" — true both before and after the
+// bug. The tests below inject a UTC clock instead: they assert the proposition
+// production actually violated, "the window is a KST day no matter what zone
+// the clock carries". Every reference instant is deliberately chosen so its UTC
+// calendar date differs from its KST calendar date; a UTC-resolved window is
+// therefore a different day, not merely a different offset on the same day.
+// ---------------------------------------------------------------------------
+
+// classifyWindow runs Classify with a fixed clock and returns the window,
+// failing the test if no window was produced or the LLM fallback was reached.
+func classifyWindow(t *testing.T, now time.Time, question string) (time.Time, time.Time) {
+	t.Helper()
+
+	fake := &fakeCompleter{err: errors.New("LLM must not be called for a deterministic date match")}
+	got, err := newClassifier(t, fake, now).Classify(context.Background(), question)
+	if err != nil {
+		t.Fatalf("Classify(%q) returned non-nil error (contract violation): %v", question, err)
+	}
+	if got.Kind != intent.KindTemporal {
+		t.Fatalf("Classify(%q) Kind = %q, want %q", question, got.Kind, intent.KindTemporal)
+	}
+	if got.OccurredFrom == nil || got.OccurredTo == nil {
+		t.Fatalf("Classify(%q) produced no window: from=%v to=%v", question, got.OccurredFrom, got.OccurredTo)
+	}
+	return *got.OccurredFrom, *got.OccurredTo
+}
+
+// TestClassify_WindowsAreKSTWhenClockIsUTC is the core regression pin for the
+// production defect. The clock is 2026-08-17 23:00 UTC, which is
+// 2026-08-18 08:00 KST — the UTC date is the 17th, the KST date is the 18th.
+// Every window below must be anchored to the KST date.
+func TestClassify_WindowsAreKSTWhenClockIsUTC(t *testing.T) {
+	t.Parallel()
+
+	// 2026-08-18 08:00 KST expressed in UTC. 2026-08-18 is a Tuesday in KST,
+	// so its ISO week starts Monday 2026-08-17 KST.
+	nowUTC := time.Date(2026, 8, 17, 23, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		question string
+		wantFrom time.Time
+		wantTo   time.Time
+	}{
+		{
+			name:     "오늘 is the KST day, not the UTC day",
+			question: "오늘 일정에 대해 알려줘",
+			wantFrom: time.Date(2026, 8, 18, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 19, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "어제 is the KST previous day",
+			question: "어제 뭐 했지",
+			wantFrom: time.Date(2026, 8, 17, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 18, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "이번 주 starts at KST Monday midnight",
+			question: "이번 주 요약해줘",
+			wantFrom: time.Date(2026, 8, 17, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 24, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "지난달 spans KST month boundaries",
+			question: "지난달에 뭐 있었지",
+			wantFrom: time.Date(2026, 7, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 8, 1, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "explicit year-month spans KST month boundaries",
+			question: "2026년 6월 요약해줘",
+			wantFrom: time.Date(2026, 6, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 7, 1, 0, 0, 0, 0, kst),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			from, to := classifyWindow(t, nowUTC, tc.question)
+
+			if !from.Equal(tc.wantFrom) || !to.Equal(tc.wantTo) {
+				t.Fatalf("window = [%s, %s), want [%s, %s) — the window must be a KST period even though the clock is UTC",
+					from, to, tc.wantFrom, tc.wantTo)
+			}
+
+			// Reverse assertion: the first instant of the NEXT period must fall
+			// outside. Without it, a "fix" that merely widened the upper bound
+			// (e.g. to +9h, or to infinity) would pass the equality check above
+			// in spirit while double-counting the following period.
+			firstOfNext := tc.wantTo
+			if inHalfOpen(firstOfNext, from, to) {
+				t.Errorf("%s belongs to the next period but falls inside [%s, %s)", firstOfNext, from, to)
+			}
+			// ...and the last instant of the period must fall inside, so the
+			// window is not merely narrow enough to exclude the next period.
+			lastInstant := tc.wantTo.Add(-time.Nanosecond)
+			if !inHalfOpen(lastInstant, from, to) {
+				t.Errorf("%s is the last instant of the period but falls outside [%s, %s)", lastInstant, from, to)
+			}
+		})
+	}
+}
+
+// TestClassify_KSTCalendarWhenUTCClockIsInThePreviousMonth pins the harshest
+// form of the defect: an instant that is not merely the previous DAY in UTC but
+// the previous MONTH. At 2026-09-01 05:00 KST the user's "지난달" is August; a
+// UTC-resolved classifier reading 2026-08-31 20:00 would answer July — an
+// entire month off, silently.
+func TestClassify_KSTCalendarWhenUTCClockIsInThePreviousMonth(t *testing.T) {
+	t.Parallel()
+
+	// 2026-09-01 05:00 KST == 2026-08-31 20:00 UTC. 2026-09-01 is a Tuesday.
+	nowUTC := time.Date(2026, 8, 31, 20, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		question string
+		wantFrom time.Time
+		wantTo   time.Time
+	}{
+		{
+			name:     "오늘 is September 1 in KST",
+			question: "오늘 일정에 대해 알려줘",
+			wantFrom: time.Date(2026, 9, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 9, 2, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "어제 is August 31 in KST",
+			question: "어제 뭐 했지",
+			wantFrom: time.Date(2026, 8, 31, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 9, 1, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "지난달 is August, the month before the KST month",
+			question: "지난달에 뭐 있었지",
+			wantFrom: time.Date(2026, 8, 1, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 9, 1, 0, 0, 0, 0, kst),
+		},
+		{
+			name:     "이번 주 is the KST week straddling the month boundary",
+			question: "이번 주 요약해줘",
+			wantFrom: time.Date(2026, 8, 31, 0, 0, 0, 0, kst),
+			wantTo:   time.Date(2026, 9, 7, 0, 0, 0, 0, kst),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			from, to := classifyWindow(t, nowUTC, tc.question)
+
+			if !from.Equal(tc.wantFrom) || !to.Equal(tc.wantTo) {
+				t.Fatalf("window = [%s, %s), want [%s, %s) — the KST calendar, not the UTC clock's calendar, decides the period",
+					from, to, tc.wantFrom, tc.wantTo)
+			}
+			if inHalfOpen(tc.wantTo, from, to) {
+				t.Errorf("%s is the first instant of the next period but falls inside [%s, %s)", tc.wantTo, from, to)
+			}
+		})
+	}
+}
+
+// TestClassify_WindowIsIndependentOfClockZone states the invariant in its
+// general form: the SAME instant, expressed in different zones, must produce
+// the same window. This is what makes the classifier's behaviour independent of
+// the container's TZ environment variable — the property whose absence made
+// production disagree with every local test run.
+func TestClassify_WindowIsIndependentOfClockZone(t *testing.T) {
+	t.Parallel()
+
+	instant := time.Date(2026, 8, 18, 8, 0, 0, 0, kst) // == 2026-08-17 23:00 UTC
+
+	questions := []string{
+		"오늘 일정에 대해 알려줘",
+		"어제 뭐 했지",
+		"이번 주 요약해줘",
+		"지난달에 뭐 있었지",
+		"2026년 6월 요약해줘",
+	}
+
+	zones := []struct {
+		name string
+		loc  *time.Location
+	}{
+		{name: "UTC", loc: time.UTC},
+		{name: "KST", loc: kst},
+		// A zone on the other side of the date line: at this instant it is
+		// already 2026-08-18 in KST but still 2026-08-17 in Honolulu-like
+		// UTC-10, so a location-sensitive implementation cannot accidentally
+		// agree with KST here.
+		{name: "UTC-10", loc: time.FixedZone("HST", -10*60*60)},
+	}
+
+	for _, q := range questions {
+		q := q
+		t.Run(q, func(t *testing.T) {
+			t.Parallel()
+
+			wantFrom, wantTo := classifyWindow(t, instant.In(kst), q)
+			for _, z := range zones {
+				from, to := classifyWindow(t, instant.In(z.loc), q)
+				if !from.Equal(wantFrom) || !to.Equal(wantTo) {
+					t.Errorf("clock in %s: window = [%s, %s), want [%s, %s) — the same instant must yield the same window in every zone",
+						z.name, from, to, wantFrom, wantTo)
+				}
+			}
+		})
+	}
+}

--- a/internal/timeutil/kst.go
+++ b/internal/timeutil/kst.go
@@ -1,0 +1,45 @@
+// Package timeutil holds the single timezone Second Brain resolves calendar
+// boundaries and renders dates in.
+//
+// It exists because the process's own local timezone is NOT a safe default:
+// the server and collector containers run as Etc/UTC, while the developer
+// machines, the users, and every ingested document are Korea-based. Code that
+// reaches for time.Now().Location() therefore behaves one way in tests and a
+// different way in production — silently, and off by nine hours. Anything that
+// answers "which calendar day/week/month is this?" or renders a date for a
+// human (or for an LLM prompt) must go through KST rather than the process
+// local zone.
+package timeutil
+
+import "time"
+
+// kstOffsetSeconds is UTC+09:00, the fixed-fallback offset for Asia/Seoul.
+const kstOffsetSeconds = 9 * 60 * 60
+
+// kst is resolved once at package initialisation: the location never changes
+// during a process's lifetime, and *time.Location values are safe for
+// concurrent use.
+var kst = loadKST()
+
+// KST returns the Asia/Seoul location. It never returns nil, so callers can use
+// it directly in time.Date / Time.In without a nil check.
+//
+// time.LoadLocation reads the OS tzdata database; the production image
+// (Dockerfile's runtime-base stage) installs the tzdata package for exactly
+// this reason. The time.FixedZone fallback only matters for an environment
+// without a tzdata database (e.g. a minimal test sandbox, or a scratch image) —
+// Korea has observed no DST since 1988, so a fixed UTC+9 offset is equivalent
+// to the IANA zone at every point in time this system deals with, not merely an
+// approximation. Falling back rather than panicking keeps a missing tzdata
+// package from taking the whole service down.
+func KST() *time.Location {
+	return kst
+}
+
+func loadKST() *time.Location {
+	loc, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		return time.FixedZone("KST", kstOffsetSeconds)
+	}
+	return loc
+}

--- a/internal/timeutil/kst_test.go
+++ b/internal/timeutil/kst_test.go
@@ -1,0 +1,57 @@
+package timeutil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/timeutil"
+)
+
+// TestKST_IsNineHoursAheadOfUTC pins the property every caller depends on,
+// without depending on which of the two code paths produced the location
+// (IANA tzdata or the FixedZone fallback). Both must be UTC+09:00 at the
+// instants this system deals with; if the fallback were ever given a wrong
+// offset, or LoadLocation silently returned UTC, calendar windows would shift
+// by hours and the production defect this package exists to prevent would come
+// straight back.
+func TestKST_IsNineHoursAheadOfUTC(t *testing.T) {
+	t.Parallel()
+
+	loc := timeutil.KST()
+	if loc == nil {
+		t.Fatal("KST() returned nil; callers use it in time.Date without a nil check")
+	}
+
+	// Sampled across the year: Korea has observed no DST since 1988, so the
+	// offset must be identical in mid-winter and mid-summer. A zone that
+	// applied a summer-time shift would break the "지난달"/"이번 주" windows
+	// asymmetrically depending on when the question was asked.
+	for _, instant := range []time.Time{
+		time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC),
+	} {
+		_, offset := instant.In(loc).Zone()
+		if offset != 9*60*60 {
+			t.Errorf("at %s the KST offset is %d seconds, want %d (UTC+09:00)", instant, offset, 9*60*60)
+		}
+	}
+}
+
+// TestKST_ConvertsInstantToKoreanCalendarDate states the consequence directly:
+// an instant late in the UTC day is already the NEXT calendar day in Korea.
+// This is exactly the 9-hour discrepancy that made the container's "오늘"
+// disagree with the user's.
+func TestKST_ConvertsInstantToKoreanCalendarDate(t *testing.T) {
+	t.Parallel()
+
+	// 2026-08-17 23:00 UTC == 2026-08-18 08:00 KST.
+	got := time.Date(2026, 8, 17, 23, 0, 0, 0, time.UTC).In(timeutil.KST())
+
+	y, m, d := got.Date()
+	if y != 2026 || m != time.August || d != 18 {
+		t.Errorf("calendar date = %04d-%02d-%02d, want 2026-08-18", y, int(m), d)
+	}
+	if got.Hour() != 8 {
+		t.Errorf("hour = %d, want 8", got.Hour())
+	}
+}


### PR DESCRIPTION
## 증상

`/ask`에 "오늘 일정" 등 날짜 관련 질의를 하면 프로덕션에서 실제 KST 기준 오늘 문서가 검색 결과에서 누락되는 경우가 있었다. 예: 오늘 18:00 KST에 등록된 캘린더 문서가 `/ask`의 검색 창에서 빠짐.

## 근본 원인

PR #197에서 도입된 intent 날짜 범위 필터(`dayRange`/`weekRange`/`monthRange`)가 `nowFunc()`가 반환하는 `time.Time`의 Location을 그대로 사용해 "오늘"/"이번 주"/"지난달"의 경계를 계산했다. server/collector 컨테이너는 `Etc/UTC`로 실행되므로, 이 경계가 KST 하루가 아니라 UTC 하루로 계산됐다 — 최대 9시간의 오차.

`internal/api/ask.go`는 이미 `kstLocation`(Asia/Seoul, tzdata 로드 실패 시 FixedZone 폴백)으로 프롬프트에 보여주는 날짜를 명시적으로 KST로 렌더링하고 있었다. 하지만 검색 창을 계산하는 `internal/intent`는 이 처리를 공유하지 않고 프로세스 로컬 타임존에 의존했다 — 같은 리포 안에 시간대 처리가 두 갈래로 갈려 있었던 것이 원인이다.

## 왜 기존 테스트가 못 잡았나

개발 머신 타임존이 KST이기 때문에 로컬에서 실행한 테스트는 `nowFunc()`의 Location이 우연히 KST와 일치해 전부 통과했다. 프로덕션 컨테이너(UTC)에서만 어긋나는 유형의 버그라 CI/로컬 검증으로는 재현되지 않았다.

## 변경 내용

- `internal/timeutil` 신설: `KST()` 함수로 `time.LoadLocation("Asia/Seoul")` + 실패 시 `time.FixedZone("KST", 9*60*60)` 폴백을 단일 정의로 제공. 기존 `ask.go`의 tzdata/폴백 근거 주석을 이곳으로 이전
- `internal/api/ask.go`: 자체 `kstLocation`/`loadKSTLocation()` 정의 제거, `timeutil.KST()` 사용으로 교체 (동작 변경 없음)
- `internal/intent/intent.go`: `dayRange`/`weekRange`/`monthRange`가 입력 시각을 KST로 변환한 뒤 날짜·요일 경계를 계산하도록 수정. `monthRange`의 `loc` 파라미터를 제거해 잘못된 타임존이 주입될 경로를 원천 차단
- 회귀 테스트 추가 (`internal/intent/kst_window_test.go`, `internal/timeutil/kst_test.go`, 기존 `day_boundary_test.go`/`intent_test.go` 보강): UTC 클록을 주입해도 계산된 창이 KST 경계로 나오는지 검증. 특히 UTC 날짜와 KST 날짜가 서로 다른 날이 되는 시각, UTC 클록 기준으로는 전월이 되는 시각을 선택해 부분적인 수정으로는 걸러지도록 구성

이 수정은 `TZ` 환경변수 설정에 의존하지 않는다 — 배포 환경의 타임존 설정과 무관하게 항상 KST로 동작한다.

## 검증

- `TZ=Etc/UTC go test ./internal/intent/... ./internal/timeutil/... ./internal/api/...` 통과 확인
- `TZ=Asia/Seoul go test ./internal/intent/... ./internal/timeutil/... ./internal/api/...` 통과 확인
- 두 타임존 모두에서 동일한 KST 경계가 계산됨을 회귀 테스트로 고정

## 배포 후 확인사항

- `/ask`에 "오늘 일정에 대해 알려줘"를 물어 오늘 캘린더 문서(`60dc8aa6-7d11-44f3-91dd-a1c8c9371e88`)가 sources에 포함되는지 확인 필요
- `TZ` 환경변수는 여전히 미설정 상태이며, 로그 타임스탬프 등 이번 수정 범위 밖의 다른 로컬 타임존 의존 코드는 점검되지 않았다

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>