### PR TITLE
feat(graph): Neo4j 지식 그래프 투영과 읽기 API

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -107,3 +107,16 @@ LLM_MEMORY_DB_HOST_PATH=/Users/user/workspace/llm-memory/data/memory.sqlite
 # Collector가 ro 마운트하는 호스트 개인데이터 경로 (사용자 환경에 맞게 설정)
 # GMAIL_HOST_PATH=/Users/<you>/workspace/private/secretary/gmail
 # CALENDAR_HOST_PATH=/Users/<you>/workspace/private/secretary/calendar
+
+# --- 지식 그래프 파생 투영 (Part B) ---
+# Neo4j 는 PostgreSQL 에서 파생된 재구축 가능한 투영이다(백업 불필요).
+# NEO4J_PASSWORD 가 비어 있으면 compose 가 즉시 실패한다(무단 기동 방지).
+NEO4J_PASSWORD=
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USERNAME=neo4j
+# 투영 워커는 기본 비활성이다. true 로 바꿔야 collector 가 Neo4j 에 쓴다.
+GRAPH_PROJECTION_ENABLED=false
+GRAPH_PROJECTION_INTERVAL=5m
+GRAPH_PROJECTION_BATCH_SIZE=500
+# 값을 바꾸면 다음 tick 에 그래프를 통째로 지우고 워터마크 0 부터 재구축한다.
+GRAPH_PROJECTION_RESET_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,33 @@ jobs:
         run: bash scripts/ci-checks.sh
       - name: docker compose config validation
         run: |
-          # Validate compose interpolation / syntax without requiring .env.local.
-          # Create stub env files so docker compose config can parse the file
-          # without failing on missing env_file references. Real secrets are not
-          # needed — only the YAML structure and variable interpolation are checked.
-          touch .env.local web/.env.local
+          # Validate compose interpolation / syntax without requiring real secrets.
+          # compose enforces some variables with ${VAR:?...} guards (e.g. NEO4J_PASSWORD)
+          # to prevent silently starting with an empty secret. A blank .env.local stub
+          # would trip those guards, so instead derive the stub from .env.local.example:
+          # any variable compose requires via :? MUST be documented there, and this step
+          # enforces that invariant — if a required var is missing from the example file,
+          # docker compose config will fail here just as it would with a truly empty env.
+          if [ -f .env.local.example ]; then
+            grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .env.local.example | while IFS='=' read -r key val; do
+              if [ -z "$val" ]; then
+                echo "${key}=ci-stub-value"
+              else
+                echo "${key}=${val}"
+              fi
+            done > .env.local
+          else
+            touch .env.local
+          fi
+          # web/ has no .env.local.example yet; keep it as an empty stub.
+          touch web/.env.local
           set +e
-          ERR_OUTPUT=$(docker compose -f docker-compose.local.yml config --quiet 2>&1 >/dev/null)
+          # docker compose only auto-loads a file literally named ".env" for
+          # ${VAR} interpolation — env_file: entries (which point at .env.local)
+          # are NOT used for interpolation, only for container runtime env.
+          # --env-file must be passed explicitly so the derived stub above is
+          # actually seen by ${NEO4J_PASSWORD:?...}-style required-var guards.
+          ERR_OUTPUT=$(docker compose --env-file .env.local -f docker-compose.local.yml config --quiet 2>&1 >/dev/null)
           CONFIG_EXIT=$?
           set -e
           # Filter out known acceptable warnings (unset optional vars like AUTH_URL)

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/baekenough/second-brain/internal/collector"
 	"github.com/baekenough/second-brain/internal/collector/extractor"
 	"github.com/baekenough/second-brain/internal/config"
+	"github.com/baekenough/second-brain/internal/graph"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/scheduler"
 	"github.com/baekenough/second-brain/internal/search"
@@ -309,6 +310,47 @@ func run() error {
 			return
 		}
 		structuralSignalWorker.Run(ctx)
+	}()
+
+	// --- Graph projection worker (Part B) ---
+	// Gated by its OWN flag, not EXTRACTION_ENABLED: extraction is a decision
+	// about LLM spend, projection is not, so folding them into one switch would
+	// remove the ability to turn off just one of them. Default is off.
+	//
+	// Neo4j is a derived projection — a connection failure must never take the
+	// collector down with it. A failure here disables projection for the
+	// lifetime of this process (restart the collector once Neo4j is up); that
+	// is the deliberate counterpart to not declaring depends_on: neo4j in
+	// compose.
+	gv := os.Getenv("GRAPH_PROJECTION_ENABLED")
+	graphEnabled := gv == "true" || gv == "1"
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if !graphEnabled {
+			// Block until shutdown so the WaitGroup stays balanced.
+			slog.Info("graph projection disabled (set GRAPH_PROJECTION_ENABLED=true to enable)")
+			<-ctx.Done()
+			return
+		}
+		gc, err := graph.New(ctx, graph.Config{
+			URI:      os.Getenv("NEO4J_URI"),
+			Username: os.Getenv("NEO4J_USERNAME"),
+			Password: os.Getenv("NEO4J_PASSWORD"),
+		})
+		if err != nil {
+			slog.Error("graph projection disabled — neo4j unavailable", "error", err)
+			<-ctx.Done()
+			return
+		}
+		defer func() { _ = gc.Close(context.Background()) }()
+		worker.NewGraphProjectionWorker(worker.GraphProjectionWorkerConfig{
+			Source:     store.NewGraphSource(pg),
+			Projector:  graph.NewProjector(gc),
+			Interval:   envDuration("GRAPH_PROJECTION_INTERVAL", 5*time.Minute),
+			BatchSize:  envInt("GRAPH_PROJECTION_BATCH_SIZE", 500),
+			ResetToken: os.Getenv("GRAPH_PROJECTION_RESET_TOKEN"),
+		}).Run(ctx)
 	}()
 
 	// --- Note enrichment worker (Capture backend) ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/baekenough/second-brain/internal/api"
 	"github.com/baekenough/second-brain/internal/config"
+	"github.com/baekenough/second-brain/internal/graph"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/store"
@@ -123,6 +124,7 @@ func run() error {
 		AuthFile:    cfg.LLMAuthFile,
 		MaxTokens:   cfg.LLMMaxTokens,
 		Temperature: cfg.LLMTemperature,
+		Thinking:    cfg.LLMThinking,
 	}, nil)
 	if llmClient.Enabled() {
 		slog.Info("LLM client configured", "url", cfg.LLMAPIURL, "model", cfg.LLMModel)
@@ -147,6 +149,27 @@ func run() error {
 		WithNotes(docStore, chunkStore, embedClient).
 		WithAskConfig(time.Duration(cfg.AskTimeoutSeconds)*time.Second, cfg.AskContextTopK, cfg.AskContextInsightM).
 		WithAskSessions(askSessionStore)
+
+	// --- Graph read API (Part B, optional) ---
+	// Wired only when both NEO4J_URI and NEO4J_PASSWORD are present. A
+	// connection failure logs a warning and leaves the graph routes
+	// unregistered: the API server must never fail to start because a derived
+	// projection is unavailable.
+	if neo4jURI, neo4jPassword := os.Getenv("NEO4J_URI"), os.Getenv("NEO4J_PASSWORD"); neo4jURI != "" && neo4jPassword != "" {
+		graphClient, err := graph.New(ctx, graph.Config{
+			URI:      neo4jURI,
+			Username: os.Getenv("NEO4J_USERNAME"),
+			Password: neo4jPassword,
+		})
+		if err != nil {
+			slog.Warn("graph read API disabled — neo4j unavailable", "error", err)
+		} else {
+			defer func() { _ = graphClient.Close(context.Background()) }()
+			srv = srv.WithGraph(graph.NewReader(graphClient))
+			slog.Info("graph read API enabled")
+		}
+	}
+
 	httpServer := &http.Server{
 		Addr:         ":" + cfg.Port,
 		Handler:      srv.Handler(),

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -277,6 +277,49 @@ services:
         condition: service_started
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # neo4j — 지식 그래프 파생 투영. PostgreSQL이 진실의 원천이므로 이 볼륨은
+  #   버려도 된다(백업 요구사항 없음, 재구축은 GRAPH_PROJECTION_RESET_TOKEN).
+  #   포트는 127.0.0.1 에만 바인딩한다 — Browser(7474)는 인증만 통과하면
+  #   그래프 전체를 조회하므로 cloudflared ingress에 호스트명을 두지 않는다.
+  #   server/collector 에 depends_on 을 걸지 않는다: Neo4j 가 죽어도 수집·
+  #   검색·/ask 는 돌아야 한다(워커는 다음 tick 재시도, API 는 503).
+  # ---------------------------------------------------------------------------
+  neo4j:
+    image: neo4j:5.26-community
+    ports:
+      - "127.0.0.1:7687:7687"
+      - "127.0.0.1:7474:7474"
+    environment:
+      # ${VAR} 치환은 env_file이 아니라 --env-file/셸에서 온다. 그래서
+      # --env-file 없이 기동하면 아래 :? 가 조용한 오작동 대신 즉시 실패시킨다.
+      NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+      # 헬스체크용 사본. 이름이 NEO4J_ 로 시작하면 안 된다: 엔트리포인트가
+      # NEO4J_* 를 전부 neo4j.conf 설정으로 번역하므로 NEO4J_PASSWORD 는
+      # 설정 "PASSWORD" 가 되어 strict validation 이 기동을 거부한다
+      # ("Unrecognized setting. No declared setting with name: PASSWORD").
+      SB_NEO4J_PASSWORD: "${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+      NEO4J_server_memory_heap_initial__size: "512m"   # 관계 수천 개 규모.
+      NEO4J_server_memory_heap_max__size: "512m"       # 과할당은 다른 컨테이너를
+      NEO4J_server_memory_pagecache_size: "256m"       # 밀어낼 뿐이다.
+      # 질의 로그는 파라미터(=실명)를 그대로 남기므로 끈다. 설정 키는
+      # server.* 가 아니라 db.* 다 — server.logs.query.enabled 는 5.26 에
+      # 존재하지 않는 이름이라 strict validation 이 기동을 거부한다
+      # ("Unrecognized setting"). 5.26.29 스크래치 컨테이너로 실측 확인.
+      NEO4J_db_logs_query_enabled: "OFF"
+      # Community 에디션은 질의 로깅 자체가 없어 위 설정만으로도 유출이 없지만,
+      # 이 값의 기본값이 true 라 에디션이 바뀌는 순간 파라미터가 남는다.
+      NEO4J_db_logs_query_parameter__logging__enabled: "false"
+    volumes:
+      - neo4jdata:/data                                # /logs 는 내보내지 않는다
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"$${SB_NEO4J_PASSWORD}\" 'RETURN 1' >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 40s
+    restart: unless-stopped
+
 # -----------------------------------------------------------------------------
 # Named volumes
 # -----------------------------------------------------------------------------
@@ -286,3 +329,6 @@ volumes:
     # 파일시스템 권한 충돌이 발생할 수 있으므로 named volume 을 사용한다.
   ollama_models:
     # ollama 모델 파일 영속 볼륨. 컨테이너 재생성 시 재다운로드 방지.
+  neo4jdata:
+    # 지식 그래프 파생 투영 전용 볼륨. PostgreSQL 이 진실의 원천이므로
+    # 삭제해도 투영 워커가 워터마크 0 부터 다시 만들어 낸다(백업 불필요).

--- a/docs/superpowers/plans/2026-08-18-actions-briefing.md
+++ b/docs/superpowers/plans/2026-08-18-actions-briefing.md
@@ -1,0 +1,588 @@
+# Part C — 액션·브리핑 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 이미 쌓이고 있는 `actions` 테이블을 사용자가 소비할 수 있게 만든다 — 열린 액션 조회 API, 멱등 상태 변경 API, 근거가 강제된 온디맨드 브리핑, 그리고 이 셋을 쓰는 화면.
+
+**Architecture:** Go 백엔드에 읽기 전용 액션 조회와 멱등 상태 변경 엔드포인트를 추가하고, 그 위에 "열린 액션 집합 해시"를 캐시 키로 쓰는 온디맨드 브리핑 생성기를 얹는다. 브리핑은 원격 DeepSeek에 문장 단위 구조화 JSON을 요구하고, 서버가 문장별 근거 document id를 화이트리스트로 검증해 통과 못 한 문장을 폐기한다. 프런트는 Next.js BFF 라우트로 백엔드를 프록시하고 `/actions` 화면 하나를 추가한다.
+
+**Tech Stack:** Go + chi + pgx/pgxpool + PostgreSQL, 원격 DeepSeek(`llm.Completer`, thinking disabled), Next.js 16 + React 19 + bun, Cloudflare Access(JWT는 `web/src/proxy.ts`가 이미 처리).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-knowledge-graph-actions-feedback-design.md` — Part C는 §7(§7.1 구조 신호, §7.2 병합, §7.3 브리핑, §7.4 실패 모드), 스키마 §5.4, `identity_key` 불변식 §5.5, 프라이버시 §11.
+
+---
+
+## Global Constraints
+
+이 절의 제약은 모든 Task에 암묵적으로 포함된다.
+
+- **스키마 변경 금지.** `migrations/022_actions.sql`은 이미 프로덕션에 적용되어 있고 데이터(액션 약 450건, 증가 중)가 쌓이는 중이다. Part C는 신규 마이그레이션을 만들지 않는다. 컬럼이 부족해 보이면 조회 시점 계산으로 해결하고, 그래도 안 되면 멈추고 보고한다.
+- **`identity_key` 불변식.** `action_status.identity_key`가 `actions.identity_key`를 참조하고, 재추출 후에도 사용자의 `done`/`ignored` 판단이 살아남아야 한다(§5.5). 상태를 `actions.id`로 참조하는 코드를 절대 쓰지 않는다. `identity_key`를 재계산·정규화·재생성하는 코드도 쓰지 않는다 — Part C는 이 값을 **읽고 그대로 되돌려주기만** 한다.
+- **닫힌 어휘.** `kind` 4종(`awaiting_my_reply`는 구조적으로만 산출 / `my_commitment` / `their_commitment` / `scheduled`), `detected_by` 3종(`structural`/`llm`/`both`), `state` 3종(`open`/`done`/`ignored`). 값은 `internal/model/action.go` 상수를 쓴다 — 새 문자열 리터럴을 만들지 않는다. `detected_by`와 `confidence`는 화면에 그대로 노출한다(§7.4의 LLM 환각 방어책).
+- **LLM은 원격 API만.** 로컬 추론(ollama 등) 기동 금지. 모델은 DeepSeek이고 **thinking 비활성화**다 — `internal/llm/client.go`의 `ThinkingDisabled`가 이미 기본값이므로 브리핑 경로에서 이를 뒤집지 않는다(추론 토큰이 예산을 태우는 문제가 실측 확인됨).
+- **패키지 매니저는 bun.** `web/`에서 `npm`을 쓰면 `package-lock.json`이 생겨 CI(`bun --frozen-lockfile`)가 깨진다. `bun install` / `bun run build` / `bun run lint`.
+- **인증은 이미 있다.** 웹의 Cloudflare Access JWT 검증은 `web/src/proxy.ts`가 처리한다. 새 인증 코드를 만들지 않는다. Go의 `/api/v1/*`는 기존 Bearer `apiKey` 미들웨어를 그대로 탄다.
+- **프로덕션 = macmini `docker compose -f docker-compose.local.yml`, `--env-file .env.local` 필수.** k8s가 아니다. `--env-file`을 빼면 볼륨이 기본값 경로로 떨어져 컨테이너가 죽는다.
+- **동시 작업 중인 파일 금지**: `internal/graph/**`, `internal/worker/graph_projection_worker*.go`, `internal/store/graph_source*.go`, `internal/model/projection.go`, `cmd/collector/main.go`, `internal/llm/client.go`. `internal/config/config.go`는 Task 12에서만, 구조체 끝에 필드를 추가하는 방식으로만 만진다.
+- **개인정보**: 액션 요약과 상대방 이름에 실명·전화번호·이메일이 들어간다. Task 8의 로깅 규약이 **모든 Task에 소급 적용**된다.
+- **기능 플래그**: 모든 신규 엔드포인트는 플래그로 끌 수 있어야 한다(롤백 절).
+- **커밋**: Task마다 커밋. `git add -A` / `git add .` 금지 — 파일을 명시적으로 나열한다.
+
+---
+
+## 확정 판단 (설계 §13 미결 사항 중 Part C 해당분)
+
+| 항목 | 확정 | 근거 |
+|---|---|---|
+| 90일 자동 보관 방식 | **조회 쿼리 필터링만.** `action_status.state`에 새 값을 추가하지 않는다. 기본 조건에 `a.observed_at > now() - interval '90 days'`를 넣고 `include_archived=true`로 해제 가능하게 한다. | §7.4가 이미 그렇게 확정. 새 state 도입은 기존 행의 의미를 바꿔 데이터 마이그레이션을 유발하며 "스키마 변경 금지"와 충돌한다. |
+| `confidence` 스케일 | **0–1 연속값.** | 마이그레이션이 `NUMERIC(3,2) CHECK (0..1)`로 이미 못박음. 범주형 해석은 불가능. |
+| 신뢰도 하한 기본값 | **없음(0.0 = 미적용).** `min_confidence` 파라미터로 지정, 화면은 0.0에서 시작. | 프로덕션 confidence 분포를 아직 모른다. 임의 하한(예: 0.7)을 기본값으로 박으면 구조 신호(기본 1.00)만 남고 LLM 액션이 통째로 사라지는 무성한 실패가 가능하다. 관측 후 조정한다. |
+| 브리핑 캐시 키 | §7.3의 `hash(열린 identity_key 집합 + 최신 문서 시각)`에 **프롬프트 버전 상수와 모델 이름을 추가**한다. | §7.3 그대로면 프롬프트를 고쳐 배포해도 캐시가 옛 문장을 반환한다. 프롬프트도 입력이므로 확장이지 위반이 아니다. **설계 대비 달라진 판단 — 보고 대상.** |
+| "최신 문서 occurred_at"의 구현 | 조회된 액션들의 `observed_at` 최대값으로 대체한다. | 별도 쿼리가 필요 없고, 액션을 만들지 않는 문서만 유입된 경우 브리핑 내용이 바뀔 이유가 없으므로 캐시 유지가 오히려 옳다. **설계 대비 달라진 판단 — 보고 대상.** |
+
+---
+
+## File Structure
+
+**신규 (Go)**
+
+| 파일 | 책임 |
+|---|---|
+| `internal/store/actions_query.go` (+`_test.go`) | `ListOpenActions`, `SetActionState`. 기존 `internal/store/actions.go`(쓰기 전용, Part A 소유)와 분리해 워커 작업과의 충돌을 피한다. |
+| `internal/api/actions.go` (+`_test.go`) | `GET /api/v1/actions`, `POST /api/v1/actions/{identity_key}/status`. |
+| `internal/briefing/input.go`, `cache.go`, `prompt.go`, `validate.go`, `generate.go`, `redact.go`, `doc.go` (+각 `_test.go`) | 브리핑 순수 로직. HTTP·DB 비의존. |
+| `internal/api/briefing.go` (+`_test.go`) | `GET /api/v1/briefing` — 위 조각을 조립. |
+
+**신규 (Web)**
+
+| 파일 | 책임 |
+|---|---|
+| `web/src/app/api/actions/route.ts` | BFF 프록시 — 목록 조회. |
+| `web/src/app/api/actions/[key]/status/route.ts` | BFF 프록시 — 상태 변경. |
+| `web/src/app/api/briefing/route.ts` | BFF 프록시 — 브리핑. |
+| `web/src/app/actions/page.tsx` | `/actions` 화면 셸(`"use client"`, `/ask` 페이지와 같은 관례). |
+| `web/src/app/actions/ActionList.tsx` | 목록 + 완료/무시 조작. |
+| `web/src/app/actions/BriefingPanel.tsx` | 브리핑 문장 + 근거 링크. |
+
+**수정**: `internal/api/router.go`(필드·옵션·라우트), `cmd/server/main.go`(배선), `internal/config/config.go`(플래그 3개), `web/src/lib/types.ts`, `web/src/lib/api.ts`, `web/src/app/dashboard/page.tsx`(진입 링크).
+
+---
+
+## Task 1: 액션 조회 스토어
+
+**Files:** Create `internal/store/actions_query.go`, `internal/store/actions_query_test.go`
+
+**Interfaces**
+- Consumes: `model.Action` / `model.ActionKind` / `model.ActionState`(`internal/model/action.go`), `*store.Postgres`(기존 `NewActionStore` 생성자 관례).
+- Produces:
+  - `type ActionFilter struct { Kinds []model.ActionKind; Counterpart string; DueBefore *time.Time; MinConfidence float64; IncludeArchived bool; Sort string; Limit int }`
+  - `type ActionListItem struct { model.Action; State model.ActionState; CounterpartName string }`
+  - `func NewActionQueryStore(pg *Postgres) *ActionQueryStore`
+  - `func (s *ActionQueryStore) ListOpenActions(ctx context.Context, f ActionFilter) ([]ActionListItem, error)`
+
+**설계 메모**
+- `action_status` 행이 없는 액션이 존재할 수 있다. **LEFT JOIN + `COALESCE(st.state,'open')`**으로 읽는다. INNER JOIN이면 상태 행 없는 액션이 통째로 사라진다.
+- 기본 동작은 `done`/`ignored` 제외 → `COALESCE(st.state,'open') = 'open'`.
+- `counterpart_entity_id`는 nullable. `entities`를 LEFT JOIN해 표시용 이름을 얻는다. 이름 컬럼은 `internal/store/entities.go`에서 실제 컬럼명을 확인해 맞춘다.
+- 정렬은 **화이트리스트 매핑을 통과한 상수만** SQL에 이어붙인다. 사용자 입력을 `ORDER BY`에 넣지 않는다. `"due"` → `a.due_at ASC NULLS LAST, a.observed_at DESC`; `"confidence"` → `a.confidence DESC, a.observed_at DESC`; 그 외/빈 값 → `"due"` 폴백.
+- 응답 크기 상한은 **스토어에서** 클램프한다(핸들러만 믿지 않는다): `Limit<=0`이면 50, `>200`이면 200.
+
+쿼리 뼈대:
+
+```sql
+SELECT a.identity_key, a.document_id, a.thread_key, a.kind, a.summary,
+       a.counterpart_entity_id, a.due_at, a.detected_by, a.confidence, a.observed_at,
+       COALESCE(st.state,'open') AS state, COALESCE(e.normalized_name,'') AS counterpart_name
+FROM actions a
+LEFT JOIN action_status st ON st.identity_key = a.identity_key
+LEFT JOIN entities e       ON e.id = a.counterpart_entity_id
+WHERE COALESCE(st.state,'open') = 'open'
+  AND ($1::boolean OR a.observed_at > now() - interval '90 days')
+  AND ($2::text[] IS NULL OR a.kind = ANY($2::text[]))
+  AND ($3::text = '' OR COALESCE(e.normalized_name,'') ILIKE '%' || $3 || '%')
+  AND ($4::timestamptz IS NULL OR (a.due_at IS NOT NULL AND a.due_at <= $4))
+  AND a.confidence >= $5::numeric
+```
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** 이 프로젝트는 SQL을 스텁으로 검증할 수 없다는 것을 이미 비싸게 배웠다(`RETURNING`에서 `EXCLUDED` 참조 불가 사건). **실제 DB에 임시 행을 넣고 정리하는 방식**을 쓴다 — `internal/store/document_rrf_score_test.go`가 쓰는 테스트 DB 헬퍼를 그대로 재사용하고, `TEST_DATABASE_URL` 미설정 시 `t.Skip`한다. 시드 데이터의 요약·상대방 이름은 전부 `"dummy summary"` 같은 가공 더미로 쓴다. 검증할 것 3가지:
+
+```go
+// (1) done/ignored 제외: identity_key 3건(open/done/ignored)을 심고 open 1건만 나오는지
+// (2) 상태 행 없는 액션이 살아남고 State == model.StateOpen 인지
+// (3) Limit 클램프: 100000을 넘겨도 반환 행이 200 이하인지
+got, err := NewActionQueryStore(pg).ListOpenActions(ctx, ActionFilter{})
+if len(keysWithTestPrefix(got)) != 1 { t.Fatalf("want only the open action, got %v", got) }
+```
+
+각 테스트는 `t.Cleanup`에서 `DELETE FROM actions WHERE identity_key LIKE 'action:test-%'`로 정리한다(`action_status`는 FK CASCADE로 따라 지워진다).
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/store/ -run TestListOpenActions -v` → FAIL `undefined: NewActionQueryStore`
+- [ ] **Step 3: 구현.** 위 SQL + `pgx` `Query`/`Scan`. `counterpart_entity_id`와 `due_at`은 포인터로 스캔.
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/store/ -run TestListOpenActions -v` → PASS (DB 미설정이면 SKIP되므로 CI에서 재확인)
+- [ ] **Step 5: 커밋.** `git add internal/store/actions_query.go internal/store/actions_query_test.go && git commit -m "feat(actions): add ListOpenActions query store"`
+
+---
+
+## Task 2: 액션 조회 API
+
+**Files:** Create `internal/api/actions.go`, `internal/api/actions_test.go`; Modify `internal/api/router.go`
+
+**Interfaces**
+- Consumes: Task 1의 `store.ActionFilter`, `store.ActionListItem`.
+- Produces:
+  - `type ActionLister interface { ListOpenActions(ctx context.Context, f store.ActionFilter) ([]store.ActionListItem, error) }`
+  - `type ActionStateSetter interface { SetActionState(ctx context.Context, identityKey string, state model.ActionState, note string) (bool, error) }` (Task 3/4에서 구현체가 붙는다. Task 2에서는 `nil`을 넘겨도 컴파일된다.)
+  - `func (s *Server) WithActions(lister ActionLister, setter ActionStateSetter) *Server`
+  - `func (s *Server) listActionsHandler(w http.ResponseWriter, r *http.Request)`
+  - 응답: `{"actions":[{"identity_key","document_id","thread_key","kind","summary","counterpart_name","due_at","detected_by","confidence","observed_at","state"}],"count":N,"truncated":bool}`
+
+**설계 메모**
+- 쿼리 파라미터: `kind`(반복 가능, `model.IsValidActionKind` 밖이면 400), `counterpart`(부분 일치), `due_before`(RFC3339), `min_confidence`(0–1 실수, 범위 밖 400), `sort`(`due`|`confidence`), `limit`(1–200), `include_archived=true`.
+- `truncated`는 `len(actions) == 유효 limit`일 때 true — 사용자가 "더 있는지"를 알 수 있어야 한다.
+- 라우트는 `s.actionLister != nil`일 때만 등록한다. 플래그 off면 **404**(500이 아니다).
+- 400 본문에 사용자 입력을 되돌려주지 않는다. `counterpart` 값이 실명일 수 있으므로 `"invalid counterpart filter"` 같은 고정 문구만 쓴다(Task 8 규약).
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** `stubActionLister`(받은 `ActionFilter`를 기록)를 정의하고 3가지를 검증한다. 서버 생성 인자 순서는 `cmd/server/main.go:135`의 `api.NewServer(docStore, searchSvc, feedbackStore, evalStore, llmClient, filesystemPath, apiKey)`를 따르고, 테스트에서의 관례는 기존 `internal/api/ask_test.go`를 확인해 맞춘다.
+
+```go
+// (1) 필터 파싱: ?kind=my_commitment&kind=scheduled&sort=confidence&limit=10&min_confidence=0.5
+//     → lister.got.Kinds 2개, Sort=="confidence", Limit==10, MinConfidence==0.5
+// (2) ?kind=invent_a_kind → 400
+// (3) WithActions 미호출 서버 → GET /api/v1/actions 가 404
+srv := NewServer(nil, nil, nil, nil, nil, "", "").WithActions(lister, nil)
+srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/actions?kind=scheduled", nil))
+if rec.Code != http.StatusOK { t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String()) }
+```
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/api/ -run TestListActionsHandler -v` → FAIL `srv.WithActions undefined`
+- [ ] **Step 3: 구현.** `actions.go`에 파서·핸들러, `router.go`에 필드·옵션·등록. 등록 위치는 기존 인증 그룹 안(`r.Post("/api/v1/feedback", ...)` 근처):
+
+```go
+if s.actionLister != nil { r.Get("/api/v1/actions", s.listActionsHandler) }
+```
+
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/api/ -run TestListActionsHandler -v` → PASS; `go build ./...` → 성공
+- [ ] **Step 5: 커밋.** `git add internal/api/actions.go internal/api/actions_test.go internal/api/router.go && git commit -m "feat(actions): add GET /api/v1/actions"`
+
+---
+
+## Task 3: 액션 상태 변경 스토어 (멱등)
+
+**Files:** Modify `internal/store/actions_query.go`, `internal/store/actions_query_test.go`
+
+**Interfaces**
+- Produces: `func (s *ActionQueryStore) SetActionState(ctx context.Context, identityKey string, state model.ActionState, note string) (found bool, err error)`
+
+**설계 메모 — 멱등성의 정확한 의미**
+
+같은 요청을 두 번 보내면 **DB 상태가 완전히 같아야 한다.** `DO UPDATE SET resolved_at = now()`는 호출할 때마다 타임스탬프가 움직이므로 멱등이 아니다. 상태가 실제로 바뀔 때만 갱신한다.
+
+```sql
+INSERT INTO action_status (identity_key, state, resolved_by, resolved_at, note)
+VALUES ($1, $2, 'user', now(), NULLIF($3,''))
+ON CONFLICT (identity_key) DO UPDATE SET
+    state       = EXCLUDED.state,
+    resolved_by = EXCLUDED.resolved_by,
+    note        = COALESCE(EXCLUDED.note, action_status.note),
+    resolved_at = CASE WHEN action_status.state IS DISTINCT FROM EXCLUDED.state
+                       THEN EXCLUDED.resolved_at ELSE action_status.resolved_at END
+RETURNING identity_key
+```
+
+- `RETURNING`에서 `EXCLUDED`를 참조하지 않는다 — 이 프로젝트에서 이미 런타임 에러로 확인된 함정이다. 위 쿼리는 `identity_key`만 반환하므로 안전하다.
+- 없는 키로 INSERT하면 FK 위반(SQLSTATE `23503`)이다. 이를 500이 아니라 404로 매핑하기 위해 `errors.As(err, &pgErr) && pgErr.Code == "23503"`이면 `found=false, err=nil`을 반환한다.
+- 허용 state는 `done`/`ignored`/`open` 3종. `open`도 허용하는 이유는 사용자가 실수로 완료 처리한 것을 되돌릴 수 있어야 하기 때문이다. 검증은 스토어와 핸들러 양쪽에서 한다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** 실제 DB 기반. 두 가지:
+
+```go
+// (1) 멱등: SetActionState(done)를 두 번 호출 → resolved_at 이 움직이지 않아야 한다
+first := readResolvedAt(t, pg, key)
+_, _ = s.SetActionState(ctx, key, model.StateDone, "")
+if second := readResolvedAt(t, pg, key); !second.Equal(first) {
+    t.Fatalf("resolved_at moved on repeat call: %v -> %v (not idempotent)", first, second)
+}
+// (2) 없는 키 → err == nil && found == false (FK 위반이 500으로 새지 않아야 한다)
+```
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/store/ -run TestSetActionState -v` → FAIL `SetActionState undefined`
+- [ ] **Step 3: 구현.** 위 SQL + `pgconn.PgError` 코드 분기.
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/store/ -run TestSetActionState -v` → PASS
+- [ ] **Step 5: 커밋.** `git add internal/store/actions_query.go internal/store/actions_query_test.go && git commit -m "feat(actions): add idempotent SetActionState"`
+
+---
+
+## Task 4: 액션 상태 변경 API
+
+**Files:** Modify `internal/api/actions.go`, `internal/api/actions_test.go`, `internal/api/router.go`
+
+**Interfaces**
+- Consumes: Task 3의 `SetActionState`.
+- Produces: `func (s *Server) setActionStateHandler(w http.ResponseWriter, r *http.Request)`; 라우트 `POST /api/v1/actions/{identity_key}/status`; 본문 `{"state":"done|ignored|open","note":"..."}`; 응답 `200 {"identity_key":"...","state":"done"}`, 미존재 `404 {"error":"action not found"}`.
+
+**설계 메모**
+- `identity_key`는 `action:<16 hex>` 형태(`internal/action/identity.go`의 `BuildIdentityKey`가 `"action:%x"`로 8바이트를 찍는다). 경로 파라미터로 받아 `^action:[0-9a-f]{16}$`로 **형태만** 검증한다. 재계산하지 않는다. 형태가 다르면 400.
+- 메서드는 POST. PATCH도 의미상 맞지만 기존 BFF·프런트가 POST 관례를 쓰고 있어 일관성을 택한다.
+- `note`는 개인정보가 될 수 있으므로 로그 금지(Task 8). 길이는 500자로 자른다.
+- 라우트는 `s.actionSetter != nil`일 때만 등록한다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** `stubActionSetter`(받은 키·state 기록, `found` 주입)로 3가지:
+
+```go
+// (1) POST /api/v1/actions/action:0123456789abcdef/status {"state":"done"}
+//     → 200, setter 가 그 키와 model.StateDone 을 받았는지
+// (2) found=false → 404
+// (3) 잘못된 키 형태("not-an-action-key") 와 잘못된 state("archived") → 각각 400
+```
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/api/ -run TestSetActionStateHandler -v` → FAIL(라우트 미등록으로 404)
+- [ ] **Step 3: 구현.** `router.go`에 `if s.actionSetter != nil { r.Post("/api/v1/actions/{identity_key}/status", s.setActionStateHandler) }`. chi는 경로 세그먼트 안의 콜론을 문제없이 처리한다.
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/api/ -v` → PASS; `go vet ./...` → 무경고
+- [ ] **Step 5: 커밋.** `git add internal/api/actions.go internal/api/actions_test.go internal/api/router.go && git commit -m "feat(actions): add POST /api/v1/actions/{key}/status"`
+
+---
+
+## Task 5: 브리핑 입력 해시와 캐시
+
+**Files:** Create `internal/briefing/input.go`, `cache.go`, `input_test.go`, `cache_test.go`
+
+**Interfaces**
+- Consumes: 없음(순수 패키지 — `internal/store`를 import하지 않는다. 변환은 API 계층이 한다).
+- Produces:
+  - `type InputAction struct { IdentityKey, Kind, Summary, CounterpartName, DocumentID, DetectedBy string; DueAt *time.Time; Confidence float64 }`
+  - `type Input struct { Actions []InputAction; LatestDocumentAt time.Time; Model string }`
+  - `type Sentence struct { Text string; DocumentIDs []string; IdentityKeys []string }`
+  - `type Result struct { Sentences []Sentence; Degraded bool; DroppedCount int; GeneratedAt time.Time }`
+  - `func (in Input) CacheKey() string`
+  - `func NewCache(capacity int) *Cache`, `func (c *Cache) Get(key string) (Result, bool)`, `func (c *Cache) Put(key string, r Result)`
+  - `const PromptVersion = "briefing-v1"` (파일은 Task 6의 `prompt.go`지만 해시가 참조하므로 이 상수만 Task 5에서 먼저 만든다)
+
+**설계 메모 — 캐시 키와 무효화**
+
+키 = `sha256( PromptVersion + "|" + Model + "|" + LatestDocumentAt(RFC3339, UTC) + "|" + 정렬된 identity_key들을 개행으로 이은 문자열 )`.
+
+무효화는 **자동**이다. TTL도 명시적 invalidate도 없다.
+
+| 사건 | 키가 바뀌는 이유 |
+|---|---|
+| 새 액션 생성 | identity_key 집합에 원소 추가 |
+| 사용자가 완료/무시 처리 | 그 키가 열린 집합에서 빠짐 |
+| 액션 자체가 갱신되어 관측 시각 전진 | `LatestDocumentAt` 전진 |
+| 프롬프트 수정 후 배포 | `PromptVersion` 변경 |
+| 모델 교체 | `Model` 변경 |
+
+**정렬 필수.** 정렬하지 않으면 DB 행 순서가 흔들릴 때마다 키가 달라져 캐시가 사실상 동작하지 않는다.
+**요약 텍스트는 키에 넣지 않는다.** 같은 `identity_key`는 정의상 같은 실제 액션이고(§5.5), 재추출로 문구가 미세하게 달라진 것 때문에 브리핑을 재생성할 이유가 없다. 부수 효과로 키 계산 입력에서 개인정보가 빠지므로 **키 해시 자체는 로그에 남겨도 안전하다**(Task 8).
+
+캐시는 프로세스 내 소형 LRU(용량 8)로 충분하다 — 사용자 1명, 열린 집합은 자주 바뀌지 않는다. 서버 재시작 시 비워지는 것은 허용한다(첫 요청이 한 번 더 LLM을 부를 뿐). 동시 요청 대비 `sync.Mutex`로 보호한다. `map[string]Result` + 삽입 순서 슬라이스면 되고, 용량 8에 자료구조를 더 얹지 않는다(YAGNI).
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** 4가지:
+
+```go
+// (1) 행 순서가 달라도 키가 같아야 한다
+if a.CacheKey() != b.CacheKey() { t.Fatal("cache key depends on row order; sort identity_keys before hashing") }
+// (2) Summary 만 다르고 identity_key 가 같으면 키가 같아야 한다
+// (3) 열린 액션 추가 시, 그리고 LatestDocumentAt 전진 시 키가 달라져야 한다
+// (4) NewCache(2)에 3개를 Put 하면 가장 오래된 것이 축출된다
+```
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/briefing/ -v` → FAIL(패키지 없음)
+- [ ] **Step 3: 구현.** `CacheKey`는 `identity_key`만 모아 `sort.Strings` 후 해시.
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/briefing/ -v` → PASS
+- [ ] **Step 5: 커밋.** `git add internal/briefing/input.go internal/briefing/cache.go internal/briefing/input_test.go internal/briefing/cache_test.go && git commit -m "feat(briefing): add input hashing and LRU cache"`
+
+---
+
+## Task 6: 브리핑 LLM 출력 스키마와 근거 강제
+
+**Files:** Create `internal/briefing/prompt.go`, `validate.go`, `generate.go`, `validate_test.go`, `generate_test.go`
+
+**Interfaces**
+- Consumes: Task 5의 `Input`/`InputAction`/`Sentence`/`Result`; `llm.Completer`(`CompleteWithMessages(ctx, systemPrompt string, msgs []llm.Message) (string, error)` — 시그니처는 `internal/worker/entity_worker.go:41` 근처 사용례로 확인한다. `internal/llm/client.go`는 열지 않는다).
+- Produces: `func Validate(raw string, in Input) (Result, error)`, `func Generate(ctx context.Context, c llm.Completer, in Input) (Result, error)`, `const PromptVersion`.
+
+**핵심: 근거 강제를 어떻게 구현하는가**
+
+§7.3은 "모든 문장에 근거 document id 강제, 없거나 존재하지 않는 id를 단 문장은 폐기"를 요구한다. 이를 **프롬프트로 부탁하지 않고 서버가 기계적으로 강제**한다. 4단계다.
+
+**(1) 출력 스키마를 문장 단위로 강제한다.** 산문 문단을 요구하면 근거를 문장에 붙일 수 없다. 다음 JSON만 반환하게 한다.
+
+```json
+{"sentences":[{"text":"...","document_ids":["<uuid>"],"identity_keys":["action:<hex16>"]}]}
+```
+
+**(2) 허용 id 화이트리스트를 서버가 만든다.** LLM에 넘긴 `Input.Actions`의 `DocumentID`와 `IdentityKey`를 각각 집합으로 모은다. **프롬프트에 등장하지 않은 id는 정의상 환각이다.**
+
+**(3) 문장 단위로 검증·폐기한다.** 전체 응답을 버리지 않는다 — 한 문장의 실패가 나머지 유효 문장까지 죽이면 브리핑이 사실상 항상 빈다.
+
+| 조건 | 판정 |
+|---|---|
+| `document_ids`가 비었다 | 문장 폐기 |
+| `document_ids`에 화이트리스트 밖 값이 하나라도 있다 | 문장 폐기 |
+| `text`가 공백이다 | 문장 폐기 |
+| `text`가 400자를 넘는다 | 문장 폐기(문장이 아니라 문단을 반환한 것) |
+| `identity_keys`에 화이트리스트 밖 값이 있다 | 그 키만 제거, 문장은 유지(근거 문서는 유효하므로) |
+
+**(4) 전부 폐기되면 degraded 폴백.** `Degraded=true`로 표시하고 **LLM 없이** 결정적으로 만든 문장을 반환한다: 열린 액션을 종류별로 세어 `"응답 대기 3건, 내 약속 2건, 상대 약속 1건, 예정 4건."` 형태의 한 문장을 만들고 그 액션들의 `DocumentID`를 근거로 붙인다. 카운트는 창작이 아니므로 근거 강제 원칙을 위반하지 않는다. 화면은 `Degraded`를 보고 "요약 생성 실패 — 집계만 표시" 배지를 띄운다(Task 11).
+
+**JSON 디코딩**: `json.NewDecoder(strings.NewReader(s)).Decode(&v)`를 쓴다(`json.Unmarshal`이 아니라). 모델이 JSON 앞뒤에 부연 텍스트나 코드 펜스를 붙이는 실패는 이 프로젝트에서 이미 관측됐고, `internal/worker/extraction_worker.go:675`의 `decodeRelationActionJSON`이 같은 대응(펜스 제거 → 첫 `{`부터 마지막 `}`까지 슬라이싱)을 구현해 뒀다. **복사하지 말고 같은 전략을 독립 구현한다** — 그 함수는 Part A 소유이고 전용 타입에 묶여 있다.
+
+**프롬프트 요건(`prompt.go`)**: 한국어로 답할 것. 위 JSON만 출력(코드 펜스·머리말 금지). 각 문장은 제공된 액션에서 유래해야 하며 `document_ids`에는 그 액션의 `document_id`를 그대로 복사할 것. **"새 id를 만들지 말라, 목록에 없는 id를 쓰면 그 문장은 버려진다"를 명시**한다(검증 규칙을 알려주면 준수율이 오른다). 문장 수 상한 6, 우선순위는 기한 임박 > `awaiting_my_reply` > `my_commitment` > 나머지. 액션 목록은 `identity_key/kind/due_at/confidence/detected_by/summary/document_id`를 가진 JSON 배열로 넣고, 개수 상한은 `BriefingMaxActions`(기본 40) — 초과 시 기한 오름차순(NULL 뒤) 상위만 넣는다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** 고정 입력 헬퍼 `testInput()`(가공 더미 2건: `action:aaaa…`/doc `1111…`, `action:bbbb…`/doc `2222…`)를 만들고 6가지를 검증한다.
+
+```go
+// (1) 화이트리스트 밖 document_id 를 단 문장은 폐기되고 DroppedCount==1
+// (2) document_ids 가 빈 문장은 폐기되고, 전부 폐기되면 Degraded==true
+// (3) degraded 폴백 문장도 DocumentIDs 를 비워두지 않는다
+// (4) 화이트리스트 밖 identity_key 는 제거되지만 문장은 살아남는다
+// (5) 코드 펜스/머리말이 붙은 응답도 디코드된다
+// (6) Generate: LLM 이 에러를 반환해도 err==nil 이고 Degraded 폴백이 나온다
+got, err := Validate(raw, testInput())
+if len(got.Sentences) != 1 { t.Fatalf("sentences = %+v, want only the grounded one", got.Sentences) }
+```
+
+(6)의 스텁은 함수를 `llm.Completer`로 감싸는 어댑터로 만든다.
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/briefing/ -run 'TestValidate|TestGenerate' -v` → FAIL(미정의)
+- [ ] **Step 3: 구현.** `validate.go`: 펜스 제거 → 슬라이싱 → 디코드 → 화이트리스트 검증 → 폐기 집계 → 전부 폐기 시 `fallbackResult(in)`. `generate.go`: 프롬프트 조립 → `CompleteWithMessages` → 에러면 `fallbackResult(in)`(에러를 위로 올리지 않는다) → 성공이면 `Validate`.
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/briefing/ -v` → PASS
+- [ ] **Step 5: 커밋.** `git add internal/briefing/prompt.go internal/briefing/validate.go internal/briefing/generate.go internal/briefing/validate_test.go internal/briefing/generate_test.go && git commit -m "feat(briefing): enforce per-sentence document-id grounding"`
+
+---
+
+## Task 7: 브리핑 API
+
+**Files:** Create `internal/api/briefing.go`, `internal/api/briefing_test.go`; Modify `internal/api/router.go`
+
+**Interfaces**
+- Consumes: Task 2의 `ActionLister`, Task 5–6의 `briefing.Input`/`NewCache`/`Generate`, 기존 `Server.llmClient`.
+- Produces: `func (s *Server) WithBriefing(cache *briefing.Cache, maxActions int) *Server`, `func (s *Server) briefingHandler(...)`; 라우트 `GET /api/v1/briefing`; 응답 `{"sentences":[...],"degraded":bool,"dropped_count":N,"action_count":N,"cached":bool,"generated_at":"RFC3339"}`.
+
+**설계 메모**
+- 흐름: `ListOpenActions`(limit=`maxActions`, sort=`due`) → `briefing.Input` 조립 → `in.CacheKey()` → `cache.Get` 히트면 `cached:true`로 즉시 반환 → 미스면 `briefing.Generate` → `cache.Put`.
+- `LatestDocumentAt`은 조회된 액션들의 `observed_at` 최대값으로 둔다(확정 판단 표 참조).
+- 열린 액션이 0건이면 **LLM을 호출하지 않고** `{"sentences":[],"degraded":false,"action_count":0}`을 반환한다. 빈 목록으로 LLM을 부르면 반드시 환각이 나온다.
+- 요청 컨텍스트에 30초 데드라인. 초과 시 `Generate`가 degraded 폴백으로 떨어진다(500이 아니다).
+- `s.llmClient == nil`이거나 `s.actionLister == nil`이면 라우트를 등록하지 않는다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** 2가지:
+
+```go
+// (1) 열린 액션 0건이면 LLM stub 이 호출되지 않고 200
+// (2) 같은 요청을 두 번 보내면 LLM 호출 횟수가 1이어야 한다(두 번째는 캐시 히트)
+if calls != 1 { t.Fatalf("LLM called %d times, want 1 (second call must hit the cache)", calls) }
+```
+
+(2)의 lister 스텁은 `store.ActionListItem{Action: model.Action{IdentityKey:"action:aaaaaaaaaaaaaaaa", DocumentID: uuid.MustParse("11111111-1111-1111-1111-111111111111"), Kind: model.KindMyCommitment, Summary:"더미 요약", ObservedAt: 고정시각}, State: model.StateOpen}` 하나를 반환하고, LLM 스텁은 그 doc id를 근거로 단 유효 문장 하나를 반환한다.
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/api/ -run TestBriefingHandler -v` → FAIL `WithBriefing undefined`
+- [ ] **Step 3: 구현.**
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/api/ ./internal/briefing/ -v` → PASS; `go build ./...` → 성공
+- [ ] **Step 5: 커밋.** `git add internal/api/briefing.go internal/api/briefing_test.go internal/api/router.go && git commit -m "feat(briefing): add GET /api/v1/briefing with input-hash cache"`
+
+---
+
+## Task 8: 개인정보·로깅 규약
+
+**Files:** Create `internal/briefing/redact.go`, `redact_test.go`, `doc.go`; Modify Task 5–7에서 만든 로그 호출부
+
+**Interfaces**
+- Produces: `func SafeLogFields(in Input, r Result) []any`(개인정보가 제거된 구조화 로그 필드만), `func KeyPrefix(identityKey string) string`(`action:0123` — 앞 4 hex).
+
+**규약 (Task 1–12 전체에 소급 적용)**
+
+| 대상 | 화면 | 로그 | 에러 응답 본문 |
+|---|---|---|---|
+| `actions.summary` | 표시 | **금지** | 금지 |
+| 상대방 이름 | 표시 | **금지** | 금지 |
+| `action_status.note` | 표시 | **금지** | 금지 |
+| **LLM 원본 응답 문자열** | 미표시 | **절대 금지** | 금지 |
+| LLM 프롬프트 | 미표시 | **금지** | 금지 |
+| `identity_key` | DOM data 속성만 | 앞 4 hex까지만 | 허용 |
+| `document_id`(UUID) | 링크로만 | 허용 | 허용 |
+| 캐시 키 해시 | 미표시 | 허용 | 허용 |
+| 건수·소요시간·폐기 문장 수 | 표시 | 허용 | 허용 |
+
+**LLM 원본 응답을 로그에 남기지 않는다 — 이 Task의 핵심이다.** 같은 유형의 결함이 이슈 #194로 이미 등록되어 있다. 파싱 실패한 응답을 통째로 찍고 싶은 유혹이 강한 지점이지만(추출 파이프라인이 실제로 JSON 파싱 실패를 겪는다), 브리핑의 LLM 응답은 **정의상 사용자 대화 요약의 재서술**이므로 원본을 남기면 개인 대화가 컨테이너 로그와 로그 수집기로 유출된다.
+
+파싱 실패 시 남길 수 있는 것: `len(raw)`, 첫 `{`의 인덱스, 마지막 `}`의 인덱스, 그리고 `*json.SyntaxError`의 `Offset`. **`err.Error()`를 그대로 찍지 않는다** — 디코더 에러 메시지에 원본 조각이 섞여 들어온다. 원본이 정말 필요하면 옵트인 환경 변수 `BRIEFING_DEBUG_DUMP=1`로만 켜고 기본값은 off, 프로덕션 `.env.local`에는 넣지 않는다.
+
+**화면 표시 정책**: 사용자 본인의 데이터이므로 실명·연락처를 마스킹하지 않고 그대로 보여준다. 다만 **문서 본문은 목록·브리핑 응답에 절대 싣지 않는다** — `document_id` 링크만 주고 본문은 기존 문서 상세 화면에서 조회한다. 이렇게 하면 응답이 캐시·프록시 계층에 남더라도 노출량이 요약 한 줄로 제한된다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다.** 센티넬 토큰을 심고 로그 필드로 새지 않는지 본다.
+
+```go
+// Summary="SENSITIVE_SUMMARY_TOKEN", CounterpartName="SENSITIVE_NAME_TOKEN",
+// Sentence.Text="SENSITIVE_SENTENCE_TOKEN", IdentityKey="action:0123456789abcdef"
+joined := fmt.Sprint(SafeLogFields(in, res)...)
+for _, banned := range []string{"SENSITIVE_SUMMARY_TOKEN", "SENSITIVE_NAME_TOKEN", "SENSITIVE_SENTENCE_TOKEN"} {
+    if strings.Contains(joined, banned) { t.Fatalf("log fields leaked %q", banned) }
+}
+if !strings.Contains(joined, "action:0123") { t.Fatal("expected truncated key prefix for correlation") }
+if strings.Contains(joined, "0123456789abcdef") { t.Fatal("full identity key must be truncated") }
+```
+
+- [ ] **Step 2: 실패 확인.** Run `go test ./internal/briefing/ -run TestSafeLogFields -v` → FAIL(미정의)
+- [ ] **Step 3: 구현하고 기존 로그 호출부를 감사한다.** `redact.go` 구현 후 Task 5–7의 모든 로그 호출부를 위 표에 맞춰 고친다. 감사 명령:
+
+```bash
+grep -rn "Summary\|CounterpartName\|raw\b" internal/briefing/*.go internal/api/actions.go internal/api/briefing.go | grep -i "log\|print"
+```
+
+- [ ] **Step 4: 통과 확인.** Run `go test ./internal/briefing/ ./internal/api/ -v` → PASS; 위 `grep` → **출력 없음**
+- [ ] **Step 5: 커밋.** `git add internal/briefing/redact.go internal/briefing/redact_test.go internal/briefing/doc.go internal/api/actions.go internal/api/briefing.go && git commit -m "feat(briefing): forbid raw LLM output and PII in logs (#194)"`
+
+---
+
+## Task 9: 웹 BFF 프록시
+
+**Files:** Create `web/src/app/api/actions/route.ts`, `web/src/app/api/actions/[key]/status/route.ts`, `web/src/app/api/briefing/route.ts`; Modify `web/src/lib/types.ts`, `web/src/lib/api.ts`
+
+**Interfaces**
+- Consumes: Task 2·4·7의 백엔드 엔드포인트.
+- Produces:
+  - `interface ActionItem { identity_key: string; document_id: string; thread_key: string; kind: "awaiting_my_reply"|"my_commitment"|"their_commitment"|"scheduled"; summary: string; counterpart_name: string; due_at: string|null; detected_by: "structural"|"llm"|"both"; confidence: number; observed_at: string; state: "open"|"done"|"ignored" }`
+  - `interface BriefingSentence { text: string; document_ids: string[]; identity_keys: string[] }`
+  - `interface BriefingResponse { sentences: BriefingSentence[]; degraded: boolean; dropped_count: number; action_count: number; cached: boolean; generated_at: string }`
+  - `listActions(params)`, `setActionState(identityKey, state, note?)`, `getBriefing()` — `web/src/lib/api.ts`
+
+**설계 메모**
+- 3개 라우트 모두 `web/src/app/api/notes/route.ts`의 패턴을 그대로 복제한다: `BRAIN_API_URL ?? NEXT_PUBLIC_API_URL ?? "http://localhost:9200"`, 서버 보관 `API_KEY`를 `Authorization: Bearer`로 붙임, 업스트림 실패 시 502.
+- 인증은 이미 `web/src/proxy.ts`가 처리한다. **이 라우트들에 인증 코드를 추가하지 않는다.**
+- 목록 라우트는 브라우저의 쿼리스트링을 **화이트리스트로 걸러** 전달한다(`kind`, `counterpart`, `due_before`, `min_confidence`, `sort`, `limit`, `include_archived`). 통째로 포워딩하면 프런트 버그가 백엔드 400으로 새어 나온다.
+- `[key]` 세그먼트는 `action:`의 콜론을 포함하므로 클라이언트에서 `encodeURIComponent`로 감싸 보내고, 라우트 핸들러에서 디코드 후 업스트림 URL을 만들 때 다시 인코딩한다.
+- 502/에러 본문에 업스트림 응답 텍스트를 실어 나르지 않는다(Task 8) — `{ error: "upstream request failed" }` 고정 문구.
+
+- [ ] **Step 1: 타입과 클라이언트 함수를 추가한다.** `types.ts`에 위 3개 인터페이스, `api.ts`에 3개 함수. 기존 `listConversations`/`getConversation`의 fetch·에러 처리 관례를 그대로 따른다.
+- [ ] **Step 2: 3개 라우트 파일을 만든다.**
+- [ ] **Step 3: 타입 체크와 린트로 검증한다.** Run `cd web && bun run lint && bunx tsc --noEmit` → 무오류. (`npm`을 쓰지 않는다.)
+- [ ] **Step 4: 로컬 백엔드로 수동 확인한다.** 백엔드를 로컬에 띄운 상태로 `cd web && bun run dev` 후 `curl -s localhost:3000/api/actions | jq '.actions | length'` — 숫자가 나오면 성공. **응답 본문을 그대로 출력하지 않는다**(개인정보).
+- [ ] **Step 5: 커밋.** `git add web/src/app/api/actions web/src/app/api/briefing web/src/lib/types.ts web/src/lib/api.ts && git commit -m "feat(web): add actions/briefing BFF routes"`
+
+---
+
+## Task 10: 액션 목록 화면
+
+**Files:** Create `web/src/app/actions/page.tsx`, `web/src/app/actions/ActionList.tsx`
+
+**Interfaces**
+- Consumes: Task 9의 `listActions`/`setActionState`, `ActionItem`.
+- Produces: `/actions` 경로의 화면. `ActionList`는 `{ items: ActionItem[]; onResolve: (key: string, state: "done"|"ignored") => void }`를 받는다.
+
+**설계 메모 — `/ask` 페이지와의 일관성**
+- `"use client"` + `useState`/`useCallback`, `@/components/ui`의 `Button`/`Card`/`Badge`/`Spinner` 재사용. 새 UI 원시 컴포넌트를 만들지 않는다.
+- 레이아웃: 상단 브리핑 패널(Task 11) → 필터 바 → 액션 카드 목록.
+- 필터 바: 종류 4개 토글(한국어 라벨 — 응답 대기 / 내 약속 / 상대 약속 / 예정), 상대방 텍스트 입력, 정렬 셀렉트(기한/신뢰도), 신뢰도 하한 슬라이더(0.0에서 시작). 필터 상태는 URL 쿼리스트링에 반영한다(`/ask`가 `useSearchParams`로 하는 것과 같은 방식) — 새로고침해도 유지되고 링크 공유가 된다.
+- 카드 내용: 요약(굵게), 상대방 이름, 종류 배지, `detected_by` 배지, `confidence` 퍼센트, 기한(있으면 "3일 남음"/"2일 지남" 형태의 상대 시간), 근거 문서 링크(`/documents/{document_id}`), **완료 / 무시** 버튼 2개.
+- 조작은 **낙관적 업데이트**: 클릭 즉시 목록에서 제거하고 요청을 보낸다. 실패하면 되돌리고 카드 위에 "처리 실패 — 다시 시도" 인라인 메시지를 띄운다. 상태 변경 API가 멱등이므로(Task 3) 재시도 클릭이 안전하다.
+- 처리 성공 후 브리핑을 다시 요청한다 — 열린 집합이 바뀌어 캐시 키가 자동으로 달라진다(Task 5).
+- 빈 상태: "열린 액션이 없습니다." `truncated`면 하단에 "상위 N건만 표시됨 — 필터를 좁히세요".
+- 목록 조회가 404를 받으면 "액션 기능이 비활성화되어 있습니다"를 표시한다(Task 12의 플래그 off 상태).
+- 모바일 레이아웃 주의: 이 프로젝트는 과거에 저장 버튼이 하단 탭바에 영구히 가리는 버그를 겪었다. 완료/무시 버튼은 카드 안에 두고 화면 하단 고정 요소로 만들지 않는다.
+
+- [ ] **Step 1: `ActionList.tsx`를 만든다.** props 배열을 렌더링하고 버튼 클릭 시 `onResolve(key, state)`를 호출하는 순수 표시 컴포넌트로 시작한다.
+- [ ] **Step 2: `page.tsx`를 만든다.** 마운트 시 `listActions()`, 필터·URL 동기화, 낙관적 업데이트와 롤백, 404 분기를 담당한다.
+- [ ] **Step 3: 타입 체크와 린트.** Run `cd web && bun run lint && bunx tsc --noEmit` → 무오류
+- [ ] **Step 4: 브라우저에서 렌더를 확인한다.** `bun run dev` 후 `http://localhost:3000/actions`에서 (a) 카드가 그려지는지, (b) 콘솔 에러가 없는지, (c) 완료 버튼을 누르면 카드가 사라지고 새로고침 후에도 사라져 있는지 확인한다. **타입 체크 통과만으로 완료를 선언하지 않는다** — 이 프로젝트의 완료 검증 규칙상 UI 변경은 실제 렌더 확인이 필요하다.
+- [ ] **Step 5: 커밋.** `git add web/src/app/actions/page.tsx web/src/app/actions/ActionList.tsx && git commit -m "feat(web): add /actions list with done/ignore"`
+
+---
+
+## Task 11: 브리핑 패널
+
+**Files:** Create `web/src/app/actions/BriefingPanel.tsx`; Modify `web/src/app/actions/page.tsx`
+
+**Interfaces**
+- Consumes: Task 9의 `getBriefing`, `BriefingResponse`.
+- Produces: `<BriefingPanel refreshKey={number} />` — `refreshKey`가 바뀔 때마다 다시 조회한다(Task 10이 완료/무시 성공 시 증가시킨다).
+
+**설계 메모**
+- 문장은 리스트가 아니라 **한 문단으로 이어 붙여** 보여준다. 각 문장 끝에 근거 문서 링크를 위첨자 번호(`[1]`, `[2]`)로 붙이고 번호는 `/documents/{document_id}`로 이동한다. 링크 텍스트에 문서 제목이나 본문을 넣지 않는다 — 번호만이다(Task 8: 본문 미노출).
+- `degraded === true`면 문단 위에 경고 배지 "요약 생성 실패 — 집계만 표시". 사용자가 이 브리핑을 완전한 요약으로 오해하지 않게 하는 것이 이 배지의 유일한 목적이다.
+- `dropped_count > 0`이면 문단 아래에 회색 소문자 주석 "근거 없는 문장 N개 폐기됨". 이건 디버깅 정보가 아니라 **신뢰 신호**다 — 시스템이 검증을 하고 있다는 것을 사용자가 볼 수 있어야 한다.
+- `cached === true`면 "캐시됨" 배지. `action_count === 0`이면 패널을 숨긴다.
+- 로딩 중에는 `Spinner`. 요청 실패는 조용히 삼키고 패널을 숨긴다 — 브리핑 실패가 액션 목록 사용을 막아서는 안 된다.
+
+- [ ] **Step 1: `BriefingPanel.tsx`를 만든다.**
+- [ ] **Step 2: `page.tsx`에 배치하고 `refreshKey`를 배선한다.** 완료/무시 성공 시 `setRefreshKey((n) => n + 1)`.
+- [ ] **Step 3: 타입 체크와 린트.** Run `cd web && bun run lint && bunx tsc --noEmit` → 무오류
+- [ ] **Step 4: 브라우저에서 확인한다.** (a) 문단이 렌더되고 위첨자 링크가 문서 상세로 이동하는지, (b) 액션을 하나 완료 처리하면 브리핑이 갱신되는지, (c) 콘솔 에러 없음.
+- [ ] **Step 5: 커밋.** `git add web/src/app/actions/BriefingPanel.tsx web/src/app/actions/page.tsx && git commit -m "feat(web): add briefing panel with evidence links"`
+
+---
+
+## Task 12: 기능 플래그 배선
+
+**Files:** Modify `internal/config/config.go`, `cmd/server/main.go`, `.env.example`, `web/src/app/dashboard/page.tsx`
+
+**Interfaces**
+- Produces: `Config.ActionsAPIEnabled bool`(env `ACTIONS_API_ENABLED`, 기본 `false`), `Config.BriefingEnabled bool`(env `BRIEFING_ENABLED`, 기본 `false`), `Config.BriefingMaxActions int`(env `BRIEFING_MAX_ACTIONS`, 기본 `40`).
+
+**설계 메모**
+- **`internal/config/config.go`는 다른 에이전트가 동시에 만지고 있을 수 있다.** 필드 3개를 구조체 **맨 끝에** 추가하고 파싱도 기존 블록 맨 끝에 붙인다. 기존 필드의 순서나 서식을 정리하지 않는다(충돌 면적 최소화).
+- 기본값이 `false`인 이유: 배포 후 아무것도 노출되지 않는 상태에서 시작해 백엔드가 정상인지 확인한 뒤 켠다.
+- 플래그가 꺼져 있으면 `WithActions`/`WithBriefing`을 **아예 호출하지 않는다.** 옵션 안에서 분기하지 않는다 — 라우트 미등록이 곧 404이고 그것이 이 플래그의 롤백 의미다.
+
+```go
+if cfg.ActionsAPIEnabled {
+    aq := store.NewActionQueryStore(pg)
+    srv = srv.WithActions(aq, aq)
+    if cfg.BriefingEnabled {
+        srv = srv.WithBriefing(briefing.NewCache(8), cfg.BriefingMaxActions)
+    }
+}
+```
+
+- `BriefingEnabled`는 `ActionsAPIEnabled`에 종속된다(브리핑이 액션 조회를 쓴다). 액션만 켜고 브리핑을 끄는 조합은 유효하고, 그 반대는 무시된다.
+- 대시보드에 `/actions` 링크를 추가한다.
+
+- [ ] **Step 1: config 필드 3개를 추가한다.** 기존 bool/int 파싱 헬퍼가 있으면 그것을 쓴다.
+- [ ] **Step 2: `cmd/server/main.go`를 배선한다.**
+- [ ] **Step 3: `.env.example`에 3개 변수를 주석과 함께 추가한다.** `BRIEFING_DEBUG_DUMP`는 넣지 않는다(Task 8).
+- [ ] **Step 4: 검증.** Run `go build ./... && go test ./...` → 성공. 플래그를 끈 채 로컬 서버를 띄우고 `curl -s -o /dev/null -w '%{http_code}' localhost:9200/api/v1/actions` → `404`. 켠 상태로 → `200`(또는 인증 미들웨어의 `401`).
+- [ ] **Step 5: 커밋.** `git add internal/config/config.go cmd/server/main.go .env.example web/src/app/dashboard/page.tsx && git commit -m "feat(actions): gate actions/briefing behind feature flags"`
+
+---
+
+## 배포 (마지막, 별도 절)
+
+구현·검증이 전부 끝난 뒤에만 진행한다. **이 계획서를 작성한 에이전트는 배포를 수행하지 않는다** — SSH·컨테이너 조작·프로덕션 DB 접속은 범위 밖이다. 아래는 배포 담당자를 위한 절차다.
+
+- [ ] **Step 1: CI 그린 확인.** 백엔드 `go test ./...`, 프런트 lint + 빌드가 모두 통과했는지 확인한다. **CI 그린이 곧 배포 가능은 아니다** — 이 프로젝트는 CI가 통과했는데 compose 설정 때문에 배포가 깨진 전례가 있다.
+- [ ] **Step 2: compose 설정을 정적으로 검증한다.** `docker compose -f docker-compose.local.yml --env-file .env.local config`로 렌더 결과를 확인한다. `--env-file`을 빼고 실행하지 않는다 — 볼륨 경로가 기본값으로 떨어져 컨테이너가 죽는다.
+- [ ] **Step 3: 플래그를 끈 채로 배포한다.** `.env.local`에 `ACTIONS_API_ENABLED=false`, `BRIEFING_ENABLED=false`를 넣고 server + web 이미지를 올린다. 기존 기능이 그대로 동작하는지 먼저 확인한다.
+- [ ] **Step 4: 액션 API만 켠다.** `ACTIONS_API_ENABLED=true` → server 재기동 → 컨테이너 **내부** 서비스명으로 200을 확인한다. Cloudflare Access가 앞단에 있으면 외부에서 302가 돌아와 실제 상태를 가리므로 도커 네트워크 내부에서 검증해야 한다.
+- [ ] **Step 5: 브리핑을 켠다.** `BRIEFING_ENABLED=true` → 재기동 → 첫 요청의 지연과 두 번째 요청의 `cached:true`를 확인한다. **응답 본문을 그대로 출력하지 않는다** — `jq '{degraded, dropped_count, action_count, cached}'`로 메타데이터만 본다.
+- [ ] **Step 6: 로그를 감사한다.** 배포 직후 server 컨테이너 로그에서 요약·이름·LLM 원본이 새지 않았는지 확인한다. 액션 요약 문구가 보이면 즉시 플래그를 끄고 Task 8로 돌아간다.
+- [ ] **Step 7: 화면을 연다.** 실제 브라우저로 `/actions`를 열어 목록·브리핑·완료 처리를 확인한다.
+
+---
+
+## 롤백
+
+세 단계로 되돌릴 수 있고 위로 갈수록 빠르다.
+
+| 상황 | 조치 | 소요 |
+|---|---|---|
+| 브리핑 품질 문제(환각·빈 결과·비용) | `.env.local`에서 `BRIEFING_ENABLED=false` → server 재기동. 액션 목록은 계속 동작한다. | 1분 |
+| 액션 API 자체 문제(쿼리 지연, 오탐 노출) | `ACTIONS_API_ENABLED=false` → server 재기동. 두 라우트가 모두 미등록되어 404. 프런트는 "기능 비활성화" 안내를 표시한다. | 1분 |
+| 코드 결함 | 이전 이미지 태그로 롤백. | 5분 |
+
+**데이터 롤백은 필요 없다.** Part C는 신규 마이그레이션을 만들지 않고 쓰기는 `action_status` upsert 하나뿐이다. 그 행은 사용자가 명시적으로 누른 판단이므로 되돌릴 대상이 아니다 — 오히려 코드를 롤백해도 **살아남아야 하는** 데이터다(§5.5 불변식).
+
+한 가지 예외: 프런트 버그로 대량의 액션이 잘못 `ignored` 처리된 경우. 이때는 특정 시간대의 `resolved_at`을 가진 행을 `state='open'`으로 되돌리는 일회성 UPDATE가 필요하다. **`resolved_at`이 상태 전이 시각을 정확히 보존하는 것(Task 3의 멱등 구현)이 이 복구를 가능하게 한다** — `now()`로 매번 덮어썼다면 어떤 행이 사고에 포함됐는지 구분할 수 없다.
+
+---
+
+## Self-Review
+
+**스펙 커버리지**: §7.1 구조 신호(Part A 소유 — Part C는 산출물을 읽기만 함, Task 1) · §7.2 병합 결과의 `detected_by` 노출(Task 2 응답, Task 10 배지) · §7.3 온디맨드 + 입력 해시 캐시(Task 5, 7) · §7.3 문장별 근거 강제와 폐기(Task 6) · §7.4 "무시" 영속화(Task 3, 4) · §7.4 LLM 환각 방어(`detected_by`/`confidence` 노출, Task 10) · §7.4 90일 누적 방어(Task 1 조회 필터) · §11 프라이버시(Task 8). §7.4의 "인증문자 오탐 제외"는 Part A 구조 신호 워커의 책임이므로 Part C에 태스크가 없다 — 의도된 공백이다.
+
+**미해결 위험 (구현자가 알아야 할 것)**
+
+1. **`counterpart_entity_id`가 대부분 NULL일 가능성.** 구조 신호 경로는 상대방을 문자열로 계산하고(`internal/action/identity.go`의 `CounterpartIdentity`), 그 값을 `entities`에 넣는지는 Part A 워커 구현에 달려 있다. NULL이 많으면 `counterpart_name`이 빈 문자열이 되어 상대방 필터가 무용해지고 화면도 빈약해진다. Task 1 구현 시 **실제 데이터의 NULL 비율을 먼저 확인**하고, 높으면 `thread_key`에서 표시명을 파생하는 폴백(`sms:{이름}` → 이름, 해시면 "알 수 없는 번호")을 Task 1에 추가한다.
+2. **`awaiting_my_reply`의 요약이 Go 생성 템플릿이라 브리핑 문장이 단조로울 수 있다.** `NormalizeSummary`가 이 종류에 대해 빈 문자열을 반환하는 데서 보듯 요약 텍스트에 정보가 적다. 품질이 낮으면 프롬프트에 `thread_key`와 `observed_at`을 더 실어 보내는 것을 먼저 시도한다(프롬프트만 바꾸므로 `PromptVersion` 증가로 캐시가 자동 무효화된다).
+3. **브리핑 비용이 측정되지 않았다.** 액션 40건을 프롬프트에 실으면 입력 토큰이 상당하다. thinking은 비활성화되어 있지만 입력 자체의 비용은 남는다. 배포 후 첫 주에 호출 횟수를 관측하고 잦으면 `BriefingMaxActions`를 낮춘다.
+4. **`entities` 조인이 조회를 느리게 만들 수 있다.** `idx_actions_counterpart`는 있지만 `entities` 쪽 인덱스는 확인하지 않았다. 액션이 수천 건으로 늘면 재측정이 필요하다. 스키마 변경 금지 제약 때문에 인덱스 추가는 별도 승인이 필요하다.
+5. **동시 편집 충돌.** `internal/api/router.go`, `cmd/server/main.go`, `internal/config/config.go`는 다른 작업 흐름도 건드릴 가능성이 높다. 각 Task 착수 전에 `git fetch` 후 ahead/behind를 확인한다 — 이 프로젝트는 스테일 베이스 위에 작업을 쌓아 전량 재작업한 전례가 두 번 있다.

--- a/docs/superpowers/plans/2026-08-18-feedback-loop.md
+++ b/docs/superpowers/plans/2026-08-18-feedback-loop.md
@@ -1,0 +1,707 @@
+# Part D — 피드백 루프 (`/ask` 통합) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/ask` 답변의 각 근거 문서에 좋아요/싫어요를 붙여 `(query, document_id, thumbs)` 검색 레이블을 축적하고, 그 레이블로 검색 변경이 개선인지 악화인지 **판정할 수 있게** 만든다.
+
+**Architecture:** 근거 카드 단위 피드백 → `feedback` 테이블(기존, additive 확장) → 질의 해시 기반 고정 분할(train/holdout) → `SearchWeights` 좌표 탐색 최적화기(train 전용) → holdout 게이트 통과 시 승격, 이력 저장, 즉시 롤백. holdout 데이터는 **패키지 경계 밖으로 나가지 않는 폐쇄형 평가 인터페이스**로만 접근된다.
+
+**Tech Stack:** Go 1.23+ (backend, `cmd/tune` 배치 바이너리), PostgreSQL(pgvector), Next.js 16 + React 19 + **bun**(web), Langfuse(관측), Cloudflare Access JWT(`web/src/proxy.ts`).
+
+**Spec:** `docs/superpowers/specs/2026-08-17-knowledge-graph-actions-feedback-design.md` §8 (Part D). 전제 명세: `docs/superpowers/specs/2026-08-17-ask-pipeline-design.md` §5.1(SSE `sources` 이벤트).
+
+## Global Constraints
+
+- **LLM은 원격 API 호출만.** 로컬 추론/파인튜닝 금지 (spec §9).
+- **기존 `feedback` 50행을 파괴하지 않는다.** 모든 마이그레이션은 additive only — 컬럼 삭제·타입 변경·기존 컬럼 NOT NULL 승격 금지.
+- **`internal/config/config.go`는 이 계획에서 수정하지 않는다** (동시 작업 중). 신규 플래그는 `os.Getenv`로 읽는다 — 기존 선례: `internal/model/document.go:133`의 `SUMMARY_VEC_COVERAGE_THRESHOLD`, `ENTITY_EXTRACTION_ENABLED`.
+- **동시 작업 중이라 이 계획이 건드리지 않는 파일:** `internal/graph/**`, `internal/worker/graph_projection_worker*.go`, `internal/store/graph_source*.go`, `internal/model/projection.go`, `cmd/collector/main.go`, `internal/llm/client.go`, `internal/config/config.go`, `internal/store/document.go`, `internal/api/ask_retrieval.go`. Task 10은 이 중 `ask_retrieval.go`를 **건드리지 않는 경로**(서버 조립 지점)로 설계되어 있다.
+- **네트워크 제약(실측 확인):** macmini 컨테이너는 ubuntu1의 Tailscale IP에 도달하지 못하고, 역방향도 막혀 있다. 따라서 `cmd/tune`은 **Postgres와 같은 호스트에서 실행**한다(§배포). 리랭커 HTTP 서비스에 의존하지 않는다.
+- **개인 데이터 취급:** 질의 원문(`feedback.query`)에 개인정보가 포함될 수 있다. 로그·Langfuse에 질의 원문을 그대로 싣지 않는다 — `md5(query)` 앞 8자(`query_hash`)만 식별자로 쓴다.
+- **패키지 매니저는 bun.** `npm install` 금지 — `package-lock.json`이 생기면 CI(`bun --frozen-lockfile`)가 깨진다.
+- 기능 플래그 2개 모두 기본 off. off 상태에서 시스템 동작은 오늘과 **완전히 동일**해야 한다.
+
+---
+
+## 1. 왜 지금 이것을 만드는가 — 판정 불가 상태의 종료
+
+오늘 검색 품질을 기준선과 비교했더니 **평균 overlap@10이 4.68/10**이었다. 즉 후보 집합의 절반 이상이 갈렸다. 그런데 그 변화가 개선인지 악화인지 **판정할 수단이 없다.** 정답 레이블이 없기 때문이다.
+
+이 계획의 1차 목표는 "가중치를 자동 튜닝한다"가 아니라 **"변경이 나아진 것인지 답할 수 있게 만든다"** 이다. 자동 튜닝은 판정 능력이 생긴 뒤에 따라오는 2차 결과물이며, 그래서 Task 1~5(레이블 축적)가 Task 6~10(최적화·승격)보다 먼저 오고, 승격은 표본이 30 질의에 도달하기 전까지 **제안만** 한다.
+
+현재 자산 실측:
+
+| 자산 | 상태 | 위치 |
+|---|---|---|
+| `feedback` 테이블 | 존재, 약 50행 | `migrations/005_feedback.sql` |
+| `POST /api/v1/feedback` | 존재 (범용 핸들러) | `internal/api/feedback.go`, `router.go:287` |
+| `FeedbackStore.Record` / `.Upsert` | 존재 | `internal/store/feedback.go:47,74` |
+| 레이블→평가쌍 변환 | 존재 (`BuildFromFeedback`) | `internal/store/eval.go:50` |
+| 측정 함수 (NDCG/MRR/FP penalty) | 존재 | `internal/search/tune.go` |
+| 가중치 주입 경로 | 존재 (`WithWeights`) | `internal/search/search.go:82` |
+| `/ask` 근거 카드 UI | 존재 (`SourceCard`) | `web/src/app/ask/page.tsx:39` |
+| 대화 세션 보존 | 존재 (`ask_sessions`) | `migrations/024_ask_sessions.sql` |
+| **가중치 최적화기** | **없음** | — |
+| **train/holdout 분할** | **없음** | — |
+| **가중치 변경 이력·롤백** | **없음** | — |
+
+빠진 것은 넷이다: (1) 근거 단위 수집 경로, (2) 오염되지 않은 분할, (3) 탐색기, (4) 승격·롤백 이력.
+
+---
+
+## 2. 확정된 설계 판단 (실행자는 이 절을 근거로 삼는다)
+
+### 2.1 `feedback` 테이블은 그대로 쓸 수 있는가 — **쓸 수 있다. 단 두 가지 additive 보강이 필요하다.**
+
+현재 스키마(`migrations/005_feedback.sql`):
+
+```
+id, query, document_id, chunk_id, source, session_id, user_id,
+thumbs, comment, metadata, created_at    -- CHECK (thumbs BETWEEN -1 AND 1)
+```
+
+`(query, document_id, thumbs)`라는 레이블 삼중항이 이미 1급 컬럼으로 존재한다. 새 테이블을 만들 이유가 없다. 다만 두 가지가 없다:
+
+**(a) 멱등성 보장이 없다.** `Record`는 항상 INSERT다. 기존 `Upsert`(`internal/store/feedback.go:74`)는 `(user_id, session_id, source)` 튜플의 **모든 행을 DELETE**한 뒤 하나를 INSERT한다 — Discord 리액션 토글용 설계다. 이걸 근거 카드에 그대로 쓰면 **같은 대화에서 앞서 매긴 다른 문서의 레이블이 전부 지워진다.** 근거 단위 피드백에는 `(session_id, query, document_id)` 단위 멱등 경로가 따로 필요하다.
+
+**(b) 분할 컬럼이 없다.** train/holdout을 매번 계산하면 재현성이 규약에 의존한다. 컬럼으로 못박아 저장해야 알고리즘이 나중에 바뀌어도 과거 행의 분할이 고정된다.
+
+**보강 방식 (additive only):**
+
+| 변경 | 안전한 이유 |
+|---|---|
+| `ALTER TABLE feedback ADD COLUMN split TEXT` (nullable, 기본 NULL) | 기존 50행에 영향 없음. NOT NULL 승격 안 함 |
+| 결정적 backfill `UPDATE ... WHERE split IS NULL AND query IS NOT NULL` | 값 추가만. 행 삭제·컬럼 변경 없음 |
+| **부분** UNIQUE 인덱스 `WHERE source = 'ask_evidence'` | 기존 50행의 `source`는 `'search'`/`'discord_bot'`/`'api'`이므로 **인덱스 대상이 0행** → 중복 충돌로 마이그레이션이 실패할 수 없다 |
+
+전역 UNIQUE 인덱스를 걸지 않는 이유가 핵심이다. 시드 50행에 `(query, document_id)` 중복이 있으면 전역 인덱스 생성이 **마이그레이션 시점에 실패**한다. 신규 소스 값 `'ask_evidence'`로 대상을 좁히면 그 실패 가능성이 구조적으로 0이다.
+
+### 2.2 분할은 질의 단위로, 결정적으로
+
+행 단위가 아니라 **정규화된 질의 문자열 단위**로 분할한다. 행 단위로 나누면 같은 질의가 양쪽 분할에 동시에 등장해 holdout이 곧바로 오염된다.
+
+- 정규화: `lower(btrim(query))`
+- 해시: `md5('sbfeedback:v1:' || normalized)` 의 앞 4바이트를 big-endian uint32로 읽고 `% 100`
+- `< 70` → `train`, 아니면 `holdout` (70/30)
+- 시드 문자열 `sbfeedback:v1:`은 상수. 바꾸면 과거 분할이 흔들리므로 **절대 변경 금지**(변경이 필요하면 `v2` 접두사와 새 컬럼으로).
+
+md5를 쓰는 이유: Go(`crypto/md5`)와 PostgreSQL(`md5()`)이 **동일한 값**을 내므로, backfill(SQL)과 신규 삽입(Go)이 같은 결과를 낸다. `hashtext()`는 PostgreSQL 내부 함수라 버전 간 안정성이 보장되지 않으므로 쓰지 않는다.
+
+### 2.3 검증셋 격리는 규약이 아니라 **타입과 패키지 경계**로 강제한다
+
+"노출하지 않기로 한다"는 문장은 코드가 아니다. 다음 세 겹으로 막는다.
+
+1. **분리 로더.** `dataset.Load(ctx, src)`가 `(TrainSet, HoldoutSet, error)`를 돌려준다. `WHERE split='train'`과 `WHERE split='holdout'`을 **각각 별도 쿼리**로 읽는다. "전부 읽기" 함수는 존재하지 않는다.
+2. **폐쇄형 평가 인터페이스.** `HoldoutSet`은 내부 필드가 전부 unexported이고, 평가쌍을 밖으로 내보내는 exported 접근자가 **하나도 없다**. 유일한 exported 메서드는
+
+   ```go
+   func (h *HoldoutSet) Evaluate(run RunFunc) (Metrics, error)
+   ```
+
+   호출자는 *검색 함수를 넣고* *집계 스칼라만* 받는다. 최적화기는 holdout의 질의 문자열도, 문서 ID도 손에 넣을 수 없다. (`TrainSet`은 반대로 `Pairs() []store.EvalPair`를 노출한다 — 좌표 탐색은 원본이 필요하다.)
+3. **평가 예산.** `HoldoutSet`은 잔여 호출 카운터를 갖고, 기본 예산 2회(baseline 1 + candidate 1)를 넘기면 `ErrHoldoutBudgetExhausted`를 반환한다. holdout을 반복 프로빙해 사실상 학습셋처럼 쓰는 우회를 막는다.
+
+추가로 리플렉션 기반 API 표면 테스트가 `HoldoutSet`의 exported 메서드 집합이 `{Evaluate, Queries}`(`Queries()`는 개수만 반환하는 `int`)임을 고정한다. 누군가 나중에 `Pairs()`를 추가하면 테스트가 깨진다.
+
+### 2.4 최적화기 목적 함수와 배치 위치
+
+- **목적 함수:** `objective = NDCG@10 − 0.5 × FPPenalty@10` (둘 다 `internal/search/tune.go`의 기존 함수. 새 지표를 만들지 않는다 — spec §8.3)
+- **탐색 공간:** `FTSWeight, VecWeight, BigmWeight ∈ [0.25, 2.0] step 0.25`; `SummaryVec ∈ [0.05, 1.5] step 0.25`; `EntityWeight ∈ [0.05, 1.5] step 0.25`; `RRFK ∈ {20, 40, 60, 80, 120}`
+  - `SummaryVec`의 하한이 0이 아니라 0.05인 이유: `SearchWeights.Defaults()`에서 **0은 "미설정 → 커버리지 게이트에 위임"** 이라는 별도 의미를 갖는다(`internal/model/document.go:99`). 최적화기가 0을 후보로 내면 의도와 다른 동작이 된다. 레인을 끄고 싶으면 `DisableSummaryVec=true`를 별도 후보로 평가한다.
+- **탐색 방식:** 좌표 탐색. 한 좌표씩 전 구간을 훑어 최선값 고정 → 다음 좌표. 개선폭 `< 1e-4`이거나 **최대 3 sweep**에서 종료(무한 루프 방지).
+- **과적합 방지:** (a) 탐색은 train만 사용, (b) holdout에서 baseline 대비 **NDCG@10 +0.01 이상** 개선 **그리고** FPPenalty@10 악화 `≤ 0.02`일 때만 승격, (c) train↔holdout objective 격차를 이력에 기록해 사후 감시, (d) holdout 평가 예산 2회.
+- **배치 위치:** `cmd/tune`은 **Postgres와 같은 호스트에서 실행**한다. macmini↔ubuntu1 상호 도달이 막혀 있으므로 배치를 DB 반대편에 두면 아예 동작하지 않는다. Postgres가 ubuntu1로 이전되면(`docs/superpowers/plans/2026-08-18-postgres-migration-to-ubuntu1.md`) 최적화기도 ubuntu1로 따라간다. 이전 전에는 macmini에서 일회성으로 돌린다.
+- **리랭커 미사용:** 배치 계층에서 리랭커 HTTP 서비스 도달성을 보장할 수 없다. `UseRerank=false`로 고정한다. RRF 가중치는 리랭킹 **이전** 융합 단계의 파라미터이고, 후보와 baseline을 **동일 조건**에서 비교하므로 상대 비교의 타당성은 유지된다. 이 사실을 이력 행 `metadata.rerank=false`에 남긴다.
+- **주기:** 수동 실행 + 주 1회 cron. 레이블 증가 속도가 느리므로 야간 매일 실행은 낭비다.
+
+### 2.5 승격·롤백
+
+- 신규 테이블 `search_weights_history` (migration 026). `status ∈ {proposed, active, rolled_back, superseded}`.
+- **`active`는 최대 1행** — 부분 UNIQUE 인덱스 `WHERE status='active'`가 DB 레벨에서 강제한다.
+- **30 질의 게이트:** holdout의 **distinct 질의 수 < 30**이면 승격 경로를 타지 않고 `proposed`로만 기록한다. 이것은 조건문 하나가 아니라 `promote()` 진입 전의 별도 함수 `gate.Eligible(holdoutQueries int) (bool, string)`로 분리해 단위 테스트한다.
+- **롤백:** `cmd/tune -rollback` → 현재 `active`를 `rolled_back`으로 바꾸고 직전 `active`였던(=`superseded`) 행을 다시 `active`로 올린다. 되돌릴 행이 없으면 `active` 없음 상태(= 코드 기본값)로 복귀. 플래그를 끄는 것만으로도 즉시 기본값으로 되돌아간다.
+
+---
+
+
+## 3. 파일 구조
+
+```
+migrations/
+  025_feedback_evidence.sql        # NEW — feedback additive 보강 (split, 부분 UNIQUE)
+  026_search_weights_history.sql   # NEW — 가중치 이력·승격 상태
+
+internal/store/
+  feedback.go                      # EDIT — UpsertEvidence + ListEvidenceSplitStats 추가 (기존 함수 불변)
+  feedback_evidence_test.go        # NEW — 실 DB 테스트
+  weights_history.go               # NEW — SearchWeightsHistoryStore
+  weights_history_test.go          # NEW
+
+internal/api/
+  feedback_evidence.go             # NEW — POST /api/v1/feedback/evidence 핸들러
+  feedback_evidence_test.go        # NEW
+  server.go                        # EDIT — 라우트 1줄 + 필드 1개 (router.go는 건드리지 않는다)
+
+internal/dataset/                  # NEW 패키지 — 분할·격리의 경계
+  dataset.go                       # Load → (TrainSet, HoldoutSet); HoldoutSet은 폐쇄형
+  split.go                         # SplitOf(query) — Go/SQL 동일 md5 규칙
+  runner.go                        # RunFunc 타입 + 평가 루프
+  dataset_test.go, split_test.go, api_surface_test.go
+
+internal/tune/                     # NEW 패키지 — 좌표 탐색
+  coordinate.go                    # Search(train, base) → 후보 가중치
+  gate.go                          # Eligible(holdoutQueries) — 30 질의 게이트
+  coordinate_test.go, gate_test.go
+
+cmd/tune/
+  main.go                          # NEW — -propose / -promote / -rollback / -dry-run
+
+cmd/server/
+  main.go                          # 건드리지 않는다 (동시 작업) — Task 10은 internal/api/server.go에서 조립
+
+web/src/
+  lib/types.ts                     # EDIT — AskSourceItem에 선택 필드 없음; FeedbackVote 타입 추가
+  lib/api.ts                       # EDIT — sendEvidenceFeedback()
+  app/ask/page.tsx                 # EDIT — SourceCard에 좋아요/싫어요 + 낙관적 토글
+  app/ask/page.test.tsx            # NEW 또는 EDIT
+```
+
+**마이그레이션 번호 주의:** 현재 최신은 `024_ask_sessions.sql`이다. 동시 작업(그래프 계열)이 `025`를 먼저 점유했을 수 있으므로, 착수 시점에 `ls migrations`로 확인하고 **비어 있는 두 개의 연속 번호**를 쓴다. 순서(feedback 보강 → weights history)만 유지하면 번호 자체는 무관하다.
+
+
+
+## 4. 작업 목록
+
+> Task 1~5는 **판정 능력**(레이블 수집 + 오염 없는 분할)을 만든다. Task 6~10은 그 위에서 최적화·승격을 얹는다. Task 5까지 끝나면 최적화기 없이도 "이 변경이 나아졌는가"에 답할 수 있어야 한다 — 그것이 이 계획의 1차 목표다(§1).
+
+---
+
+## Task 1: `feedback` additive 보강 마이그레이션
+
+**Files:**
+- Create: `migrations/025_feedback_evidence.sql`
+
+**설계 메모**
+
+기존 50행을 건드리지 않는다. 이 마이그레이션이 하는 일은 셋뿐이다: 컬럼 1개 추가, 값 backfill, 부분 인덱스 2개 생성. `DROP`·`ALTER TYPE`·`SET NOT NULL`은 **하나도 없다**.
+
+- `split TEXT` — nullable. `CHECK`는 붙이되 `NOT VALID`로 걸어 기존 행 재검사를 피한다(기존 행은 어차피 backfill로 유효값이 들어가지만, 순서 의존을 없앤다).
+- backfill의 해시 규칙은 §2.2 그대로: `md5('sbfeedback:v1:' || lower(btrim(query)))`의 앞 8 hex를 `bit(32)`로 캐스팅해 정수로 읽고 `% 100 < 70` → `train`.
+  - PostgreSQL에서 hex→int는 `('x' || substr(md5(...),1,8))::bit(32)::bigint`가 관용구다. 결과는 부호 있는 값이 될 수 있으므로 `abs(...)`로 감싼다(Go 쪽도 uint32로 읽어 동일 결과가 되도록 Task 2에서 맞춘다 — **부호 처리 규칙을 양쪽이 반드시 동일하게** 한다).
+- `query IS NULL` 또는 빈 문자열인 행은 분할 대상이 아니다. `split`을 NULL로 남긴다. 분할 로더는 NULL을 무시한다.
+- 부분 UNIQUE 인덱스는 `WHERE source = 'ask_evidence'` 로 제한한다. 시드 50행의 `source`는 `'search'`/`'discord_bot'`/`'api'` 뿐이므로 대상 행이 0이고, 따라서 **중복 충돌로 이 마이그레이션이 실패할 수 없다**(§2.1).
+- 멱등 키는 `(session_id, md5(normalized query), document_id)`다. 세션이 다르면 별개 레이블이다 — 같은 질문을 다른 대화에서 다시 물어봤다면 그건 독립 신호다.
+
+```sql
+ALTER TABLE feedback ADD COLUMN IF NOT EXISTS split TEXT;
+ALTER TABLE feedback ADD CONSTRAINT feedback_split_chk
+  CHECK (split IS NULL OR split IN ('train','holdout')) NOT VALID;
+
+UPDATE feedback SET split = CASE
+    WHEN abs(('x' || substr(md5('sbfeedback:v1:' || lower(btrim(query))),1,8))::bit(32)::bigint) % 100 < 70
+    THEN 'train' ELSE 'holdout' END
+WHERE split IS NULL AND query IS NOT NULL AND btrim(query) <> '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_feedback_ask_evidence
+  ON feedback (session_id, md5(lower(btrim(query))), document_id)
+  WHERE source = 'ask_evidence';
+
+CREATE INDEX IF NOT EXISTS idx_feedback_split
+  ON feedback (split, thumbs) WHERE source = 'ask_evidence';
+```
+
+- [ ] **Step 1: 마이그레이션 파일 작성** — 위 SQL. 파일 상단에 "additive only" 주석과 근거(§2.1) 링크.
+- [ ] **Step 2: 로컬 DB에서 dry-run**
+
+Run: `psql "$TEST_DATABASE_URL" -1 -v ON_ERROR_STOP=1 -f migrations/025_feedback_evidence.sql`
+Expected: 에러 없이 완료. `ALTER TABLE`/`UPDATE`/`CREATE INDEX` 4개 모두 성공.
+
+- [ ] **Step 3: 파괴성 없음을 증명한다**
+
+Run:
+```bash
+psql "$TEST_DATABASE_URL" -Atc "SELECT count(*) FROM feedback;"                  # 마이그레이션 전후 동일
+psql "$TEST_DATABASE_URL" -Atc "SELECT split, count(*) FROM feedback GROUP BY 1;" # NULL 없음(query 있는 행 한정)
+psql "$TEST_DATABASE_URL" -Atc "SELECT count(*) FROM feedback WHERE source='ask_evidence';" # 0
+```
+Expected: 행 수 불변, `train`/`holdout` 두 값만 등장(그리고 `query IS NULL` 행만 NULL), `ask_evidence` 0행.
+
+- [ ] **Step 4: 재실행 멱등성** — 같은 파일을 두 번 적용해도 실패하지 않고 `split` 값이 바뀌지 않는지 확인한다.
+- [ ] **Step 5: 커밋** — `git commit -m "feat(feedback): additive split column and evidence uniqueness index"`
+
+---
+
+## Task 2: 근거 단위 멱등 저장 (`UpsertEvidence`)
+
+**Files:**
+- Edit: `internal/store/feedback.go` (추가만 — 기존 `Record`/`Upsert`/`ListRecent`/`Stats`는 한 줄도 바꾸지 않는다)
+- Create: `internal/store/feedback_evidence_test.go`
+
+**Interfaces:**
+- `type EvidenceVote struct { SessionID, Query, DocumentID string; Thumbs int16; UserID *string; Metadata map[string]any }`
+- `func (s *FeedbackStore) UpsertEvidence(ctx context.Context, v EvidenceVote) (id int64, err error)`
+- `func SplitOf(query string) string` (`internal/dataset/split.go`, Task 5에서 정의 — 여기서는 store가 그 패키지를 import한다)
+
+**설계 메모**
+
+- **기존 `Upsert`를 재사용하면 안 된다.** 그 함수는 `(user_id, session_id, source)`의 모든 행을 DELETE한다. 근거 카드에 쓰면 같은 대화에서 앞서 매긴 다른 문서의 레이블이 전부 지워진다(§2.1(a)). 새 함수를 만든다.
+- 멱등은 DELETE가 아니라 `ON CONFLICT ... DO UPDATE`로 한다. 충돌 타깃은 Task 1의 부분 UNIQUE 인덱스와 **정확히 같은 식**이어야 한다:
+  `ON CONFLICT (session_id, md5(lower(btrim(query))), document_id) WHERE source = 'ask_evidence'`
+- **재클릭 토글:** 같은 값을 다시 보내면 `thumbs`를 0으로 되돌린다. 이 판단은 SQL에서 한다 — `DO UPDATE SET thumbs = CASE WHEN feedback.thumbs = EXCLUDED.thumbs THEN 0 ELSE EXCLUDED.thumbs END`. 왕복 조회 없이 원자적으로 처리된다.
+- **`RETURNING`에서 `EXCLUDED`를 참조하지 않는다.** 과거에 이 프로젝트가 정확히 이 함정에 빠졌다. `RETURNING id, thumbs`만 쓴다(둘 다 대상 행의 컬럼).
+- `split`은 INSERT 시 Go에서 계산해 넣는다. 갱신 시에는 건드리지 않는다 — 질의가 같으면 split도 같으므로 재계산이 무의미하고, 재계산하면 규칙 변경 시 과거 행이 흔들린다(§2.2).
+- `thumbs = 0` 행은 남겨둔다. 삭제하지 않는다. "본 적 있으나 판단 보류"와 "본 적 없음"은 다른 정보이고, `BuildFromFeedback`은 `thumbs >= 1` / `= -1`만 보므로 0행은 자연히 무시된다.
+- `metadata`에는 `{"rank": <카드 순위>, "layer": "<note|observed|insight>"}`를 넣는다. 나중에 위치 편향 보정을 하려면 순위가 필요하다. **질의 원문은 metadata에 중복 저장하지 않는다**(이미 `query` 컬럼에 있다).
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`internal/store/feedback_evidence_test.go`. SQL은 스텁으로 검증할 수 없다 — 실 DB(`TEST_DATABASE_URL`, 미설정 시 `t.Skip`)에 넣고 `t.Cleanup`에서 지운다. 기존 store 테스트의 연결 헬퍼를 재사용한다.
+
+```go
+func TestUpsertEvidence_SecondDocInSameSessionIsNotDeleted(t *testing.T)
+// 같은 session/query로 docA(+1), docB(-1) 저장 → 두 행 모두 남아 있어야 한다.
+// 기존 Upsert 였다면 docA 행이 사라진다. 이 테스트가 §2.1(a)의 회귀 가드다.
+
+func TestUpsertEvidence_RepeatSameVoteTogglesToZero(t *testing.T)
+// docA에 +1 두 번 → 행은 1개, thumbs = 0.
+
+func TestUpsertEvidence_OppositeVoteOverwrites(t *testing.T)
+// docA에 +1 후 -1 → 행은 1개, thumbs = -1.
+
+func TestUpsertEvidence_DoesNotTouchLegacyRows(t *testing.T)
+// source='search' 시드 행을 넣고 evidence upsert 수행 → 시드 행 count 불변.
+
+func TestUpsertEvidence_SplitMatchesSQLBackfill(t *testing.T)
+// Go SplitOf(q) 와 Task 1 backfill SQL 식의 결과가 같은 질의 20개에 대해 일치.
+// 이것이 Go/SQL 해시 규칙 동치성의 유일한 방어선이다.
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/store/ -run TestUpsertEvidence -v` → FAIL (`undefined: UpsertEvidence`).
+- [ ] **Step 3: 구현** — `UpsertEvidence` 추가. `source`는 상수 `SourceAskEvidence = "ask_evidence"`로 고정하고 호출자가 바꿀 수 없게 한다(부분 인덱스가 이 값에 의존한다).
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/store/ -run TestUpsertEvidence -v` → PASS. 이어서 `go test ./internal/store/` 전체로 기존 feedback 테스트 회귀 없음 확인.
+- [ ] **Step 5: 커밋** — `git commit -m "feat(feedback): idempotent per-evidence upsert with deterministic split"`
+
+---
+
+## Task 3: 피드백 수집 API — `POST /api/v1/feedback/evidence`
+
+**Files:**
+- Create: `internal/api/feedback_evidence.go`, `internal/api/feedback_evidence_test.go`
+- Edit: `internal/api/server.go` (필드 1개 + 라우트 1줄). **`internal/api/router.go`는 동시 작업 중이므로 열지 않는다** — 라우트 등록 지점이 `router.go`에만 있다면 그 파일을 수정하는 대신, `server.go`에 `RegisterFeedbackEvidenceRoutes(mux)` 형태의 등록 함수를 두고 착수 시점에 동시 작업이 끝난 뒤 한 줄로 연결한다.
+
+**Interfaces:**
+- 요청: `{ "conversation_id": string, "query": string, "document_id": string, "thumbs": -1|0|1, "rank": int, "layer": string }`
+- 응답 `200`: `{ "thumbs": -1|0|1 }` — **서버가 판정한 최종 상태**를 돌려준다. 클라이언트가 토글 결과를 추측하지 않게 하기 위함이다.
+- `type EvidenceVoter interface { UpsertEvidence(ctx, store.EvidenceVote) (int64, error) }` — 스텁 주입용.
+
+**설계 메모**
+
+- **기존 `POST /api/v1/feedback`은 그대로 둔다.** 그 핸들러는 `Record`(항상 INSERT)를 호출하는 범용 경로이고 Discord 봇/검색 UI가 쓰고 있다. 근거 단위 경로는 요구사항(멱등, 질의 필수, source 고정)이 다르므로 별도 엔드포인트가 맞다. 기존 핸들러에 분기를 심으면 `source` 값에 따라 멱등성이 달라지는 숨은 계약이 생긴다.
+- **인증은 새로 만들지 않는다.** `web/src/proxy.ts`의 Cloudflare Access JWT 검증이 `/api/*`를 이미 감싼다. 핸들러는 인증을 가정한다.
+- **`user_id`는 서버가 채우지 않는다.** Access가 넘겨주는 신원을 굳이 레이블에 붙일 이유가 없다(단일 사용자 시스템). NULL로 둔다 — 개인 데이터 최소화.
+- **검증:** `conversation_id`/`query`/`document_id` 빈 값 → 400. `thumbs` 범위 밖 → 400. `document_id`가 UUID 형식이 아니면 → 400(DB FK 에러를 500으로 흘리지 않는다).
+- **기능 플래그:** `FEEDBACK_EVIDENCE_ENABLED`(기본 off). off일 때 이 엔드포인트는 **404**를 반환한다(501이 아니라 404 — 존재를 드러내지 않는다). `os.Getenv`로 읽는다(`internal/config/config.go`는 동시 작업 중이라 수정 금지, Global Constraints).
+- **관측:** 핸들러에서 OTel 스팬 `feedback.evidence`를 연다(`internal/telemetry` 재사용). 속성은 `query_hash`(md5 앞 8자), `thumbs`, `rank`, `layer`, `split`. **질의 원문·문서 제목은 스팬에 넣지 않는다**(Global Constraints, 개인 데이터).
+- 저장 실패는 500이되 로그에도 질의 원문을 남기지 않는다 — `query_hash`만.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`internal/api/feedback_evidence_test.go`. 스텁 `EvidenceVoter`로 DB 없이 검증한다(여기서 검증하는 것은 HTTP 계약이지 SQL이 아니다 — SQL은 Task 2가 실 DB로 검증했다).
+
+```go
+func TestEvidenceHandler_DisabledReturns404(t *testing.T)   // 플래그 off → 404, 스텁 호출 0회
+func TestEvidenceHandler_RejectsBadThumbs(t *testing.T)     // thumbs=2 → 400
+func TestEvidenceHandler_RejectsNonUUIDDocument(t *testing.T)
+func TestEvidenceHandler_RejectsEmptyQuery(t *testing.T)
+func TestEvidenceHandler_PassesRankAndLayerToMetadata(t *testing.T) // 스텁이 받은 Metadata에 rank/layer 존재
+func TestEvidenceHandler_ReturnsServerResolvedThumbs(t *testing.T)  // 스텁이 0을 리턴하면 응답도 0
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/api/ -run TestEvidenceHandler -v` → FAIL.
+- [ ] **Step 3: 구현** — 핸들러 + 등록 함수. 플래그 체크를 핸들러 **최상단**에 둔다(디코딩보다 먼저).
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/api/ -v -run TestEvidenceHandler` → PASS. 이어서 `go build ./...`.
+- [ ] **Step 5: 수동 계약 확인 (로컬 서버)**
+
+Run:
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -XPOST localhost:8080/api/v1/feedback/evidence -d '{}'   # 플래그 off → 404
+FEEDBACK_EVIDENCE_ENABLED=1 <서버 재기동 후>
+curl -s -XPOST localhost:8080/api/v1/feedback/evidence \
+  -H 'content-type: application/json' \
+  -d '{"conversation_id":"c1","query":"테스트 질의","document_id":"<유효 UUID>","thumbs":1,"rank":1,"layer":"observed"}'
+# → {"thumbs":1}  같은 요청 재전송 → {"thumbs":0}
+```
+
+- [ ] **Step 6: 커밋** — `git commit -m "feat(api): per-evidence feedback endpoint behind FEEDBACK_EVIDENCE_ENABLED"`
+
+---
+
+## Task 4: `/ask` 근거 카드 좋아요/싫어요 UI
+
+**Files:**
+- Edit: `web/src/lib/types.ts` (`EvidenceVote`, `EvidenceFeedbackRequest` 타입)
+- Edit: `web/src/lib/api.ts` (`sendEvidenceFeedback`)
+- Edit: `web/src/app/ask/page.tsx` (`SourceCard`, `SourceLayerGroup`, `AssistantBubble` 프롭 배선)
+- Create: `web/src/app/ask/evidenceFeedback.test.ts`
+
+**설계 메모**
+
+- **문서 단위여야 한다.** 답변 단위 좋아요는 `(query, thumbs)`뿐이라 어떤 문서가 좋았는지 알 수 없고, 레이블로 쓸 수 없다. 버튼은 반드시 `SourceCard` 안에 있어야 한다(요구사항 1).
+- `SourceCard`는 현재 `{ source }`만 받는다. `{ source, rank, conversationId, query, vote, onVote }`로 확장한다. `rank`는 **레이어 필터링 전 원본 `turn.sources` 배열의 인덱스**여야 한다 — 레이어별로 나눈 뒤의 인덱스를 쓰면 실제 노출 순위와 어긋난다. `AssistantBubble`에서 `sourcesByLayer`를 만들기 전에 `turn.sources`에 대해 `rank` 맵을 먼저 만든다.
+- **`query`는 그 턴의 질문**(`turn.question`)이지 현재 입력창 값이 아니다. 과거 턴의 카드에 나중에 투표할 수 있으므로 반드시 턴에서 읽는다.
+- **투표 상태는 턴 로컬 state**로 둔다: `Record<string /*docId*/, -1|0|1>`을 `Turn`에 추가하거나 `page.tsx` 상단에 `Map<turnIndex, Record<docId, vote>>`로 둔다. 서버에서 기존 투표를 되읽어오지 않는다 — 대화 재로드 시 투표 표시가 비는 것은 v1에서 허용한다(요구사항은 수집이지 표시 복원이 아니다). 이 절충을 코드 주석에 남긴다.
+- **낙관적 갱신 + 서버 판정 반영:** 클릭 즉시 로컬 상태를 바꾸되, 응답의 `thumbs`로 **덮어쓴다**. 토글 판정의 단일 진실 공급원은 서버다(Task 3). 실패 시 이전 값으로 되돌리고 카드에 조용한 에러 틴트만 준다 — 토스트를 띄우지 않는다(대화 흐름을 끊는다).
+- **접근성:** `aria-pressed`로 현재 투표 상태를 노출하고 `aria-label`은 `"이 근거가 도움이 됐어요"` / `"도움이 안 됐어요"`. 아이콘만 두지 않는다.
+- **비활성화 시 렌더링:** `NEXT_PUBLIC_FEEDBACK_EVIDENCE_ENABLED !== "1"`이면 버튼을 아예 렌더링하지 않는다. 서버 플래그와 별개로 UI 쪽 게이트가 있어야 백엔드 배포 전에 프런트가 404를 때리지 않는다.
+- **패키지 매니저는 bun.** `npm install` 금지 — `package-lock.json`이 생기면 CI(`bun --frozen-lockfile`)가 깨진다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`web/src/app/ask/evidenceFeedback.test.ts`. DOM 렌더링 전체가 아니라 **순수 함수 두 개**를 뽑아 검증한다 — 그래야 테스트가 값싸고 회귀에 강하다.
+
+```ts
+// page.tsx에서 export 하는 순수 헬퍼
+export function buildRankMap(sources: AskSourceItem[]): Record<string, number>
+export function nextVote(current: -1|0|1|undefined, clicked: 1|-1): -1|0|1  // 낙관적 예측값
+
+describe("buildRankMap", () => {
+  it("레이어와 무관하게 원본 배열 순서로 0-based rank를 매긴다");
+  it("중복 문서 ID가 있으면 첫 등장 순위를 유지한다");
+});
+describe("nextVote", () => {
+  it("같은 방향 재클릭은 0으로 토글한다");
+  it("반대 방향 클릭은 그 값으로 덮어쓴다");
+  it("undefined에서 클릭하면 클릭 값이 된다");
+});
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `cd web && bun test evidenceFeedback` → FAIL.
+- [ ] **Step 3: 구현** — 헬퍼 → `sendEvidenceFeedback` → `SourceCard` 버튼 → 프롭 배선 순서로.
+- [ ] **Step 4: 통과 확인**
+
+Run: `cd web && bun test evidenceFeedback && bunx tsc --noEmit && bun run lint`
+Expected: 전부 통과. **`bun.lockb` 외의 lockfile이 생기지 않았는지 `git status`로 확인한다.**
+
+- [ ] **Step 5: 브라우저 렌더 검증 (R020 — 타입체크만으로는 완료가 아니다)**
+
+Run: `cd web && bun run dev` → `/ask`에서 질문 1건 → 근거 그룹 펼침 → 카드에 버튼 2개 보임 → 좋아요 클릭 시 상태 반영, 재클릭 시 해제. 콘솔 에러 0. 플래그를 끈 상태에서 버튼이 사라지는 것도 함께 확인한다.
+
+- [ ] **Step 6: 커밋** — `git commit -m "feat(ask): per-evidence thumbs on source cards"`
+
+---
+
+## Task 5: `internal/dataset` — 고정 분할과 **구조적** 검증셋 격리
+
+**Files:**
+- Create: `internal/dataset/split.go`, `dataset.go`, `runner.go`
+- Create: `internal/dataset/split_test.go`, `dataset_test.go`, `api_surface_test.go`
+
+**Interfaces:**
+
+```go
+func SplitOf(query string) string            // "train" | "holdout"; 빈 질의는 ""
+func Normalize(query string) string          // strings.ToLower(strings.TrimSpace(q))
+
+type Source interface {                       // store.EvalStore가 만족
+    EvalPairsBySplit(ctx context.Context, split string) ([]store.EvalPair, error)
+}
+func Load(ctx context.Context, src Source) (*TrainSet, *HoldoutSet, error)
+
+func (t *TrainSet) Pairs() []store.EvalPair   // 좌표 탐색은 원본이 필요하다 — 노출한다
+func (t *TrainSet) Queries() int
+
+type RunFunc func(ctx context.Context, query string, k int) ([]string, error)
+type Metrics struct { NDCG10, MRR10, FPPenalty10, Objective float64; Pairs, Queries int }
+
+func (h *HoldoutSet) Evaluate(ctx context.Context, run RunFunc) (Metrics, error)
+func (h *HoldoutSet) Queries() int             // 개수만. 질의 문자열이 아니다.
+var ErrHoldoutBudgetExhausted = errors.New(...)
+```
+
+**격리를 코드가 어떻게 막는가 — 네 겹 (§2.3)**
+
+1. **분리 로더.** `Load`가 `WHERE split='train'`과 `WHERE split='holdout'`을 **별개 쿼리 두 번**으로 읽는다. "전부 읽어 나중에 나눈다"는 경로가 존재하지 않으므로, 실수로 전체를 최적화기에 넘길 방법이 없다. `Source` 인터페이스 자체가 split 인자를 요구한다.
+2. **필드 unexported + 접근자 부재.** `HoldoutSet{ pairs []store.EvalPair; budget int }` — 전부 소문자. exported 메서드는 `Evaluate`와 `Queries` **둘뿐**이고 어느 쪽도 `EvalPair`·질의 문자열·문서 ID를 반환하지 않는다. `internal/tune`은 다른 패키지이므로 Go 컴파일러가 접근을 **차단한다**. 규약이 아니라 타입 시스템이 막는 것이다.
+3. **평가 예산.** `budget` 기본 2(baseline 1 + candidate 1). `Evaluate`가 호출될 때마다 감소하고 0에서 `ErrHoldoutBudgetExhausted`를 반환한다. holdout을 반복 프로빙해 사실상 학습셋으로 쓰는 우회를 막는다. 예산은 생성자에서만 정해지고 exported setter가 없다.
+4. **API 표면 고정 테스트.** 리플렉션으로 `HoldoutSet`의 exported 메서드 집합이 정확히 `{Evaluate, Queries}`임을 단언한다. 누군가 나중에 편의상 `Pairs()`를 추가하면 **테스트가 깨지고** 그 순간 격리가 무너졌음이 드러난다.
+
+`Metrics.Objective = NDCG10 − 0.5 × FPPenalty10`(§2.4). 계산은 `internal/search`의 기존 `NDCGK`/`MRRK`/`FalsePositivePenalty`를 호출한다 — 새 지표를 만들지 않는다.
+
+`EvalPairsBySplit`은 `store.EvalStore`에 추가한다. 기존 `BuildFromFeedback`을 복제하지 말고 **split 필터를 인자로 받는 내부 쿼리로 리팩터**하되, `BuildFromFeedback()`은 시그니처를 유지한 얇은 래퍼로 남긴다(호출자 회귀 방지).
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+```go
+// split_test.go
+func TestSplitOf_Deterministic(t *testing.T)          // 같은 질의 1000회 → 같은 값
+func TestSplitOf_NormalizationInsensitive(t *testing.T) // " Foo "와 "foo"가 같은 split
+func TestSplitOf_RoughlySeventyThirty(t *testing.T)   // 10k 랜덤 질의 → train 비율 0.65~0.75
+func TestSplitOf_KnownVectors(t *testing.T)           // 하드코딩 5쌍 — 규칙이 바뀌면 즉시 깨진다
+
+// dataset_test.go
+func TestLoad_QueriesEachSplitSeparately(t *testing.T) // 스텁 Source가 받은 split 인자 = ["train","holdout"]
+func TestLoad_NoQueryAppearsInBothSets(t *testing.T)   // TrainSet.Pairs()의 질의 ∩ holdout 질의 = ∅
+                                                       // (스텁 Source 쪽에서 대조 — HoldoutSet은 안 열린다)
+func TestHoldout_BudgetExhausted(t *testing.T)         // 3번째 Evaluate → ErrHoldoutBudgetExhausted
+func TestHoldout_EvaluateReturnsScalarsOnly(t *testing.T)
+
+// api_surface_test.go
+func TestHoldoutSet_ExportedSurfaceIsFrozen(t *testing.T) {
+    got := exportedMethodNames(reflect.TypeOf(&HoldoutSet{}))
+    want := []string{"Evaluate", "Queries"}
+    // 불일치 시: "HoldoutSet의 공개 표면이 바뀌었다. 검증셋 격리(§2.3)가 깨졌을 수 있다."
+}
+```
+
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/dataset/ -v` → FAIL (패키지 없음).
+- [ ] **Step 3: 구현** — `split.go`(md5 → uint32 → %100, **Task 1 SQL과 부호 처리 동일**) → `dataset.go` → `runner.go` 순.
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/dataset/ ./internal/store/ -v` → PASS.
+- [ ] **Step 5: 격리를 컴파일러로 증명한다**
+
+Run: 임시 파일 `internal/tune/leak_check.go`에 `_ = h.pairs` 및 `_ = h.Pairs()`를 써 넣고 `go build ./internal/tune/`.
+Expected: **컴파일 실패** (`h.pairs undefined (cannot refer to unexported field)`, `h.Pairs undefined`). 확인 후 파일 삭제. 이 단계를 건너뛰면 §2.3은 주장에 머문다.
+
+- [ ] **Step 6: 커밋** — `git commit -m "feat(dataset): deterministic split with closed-form holdout isolation"`
+
+---
+
+## Task 6: 가중치 후보 평가 하네스 (`RunFunc` 어댑터)
+
+**Files:**
+- Create: `internal/tune/harness.go`, `internal/tune/harness_test.go`
+
+**Interfaces:**
+- `type Searcher interface { WithWeights(model.SearchWeights) *search.Service; Search(ctx, search.Query) (search.Results, error) }` — 실제 타입에 맞춰 착수 시 조정한다.
+- `func RunnerFor(svc *search.Service, w model.SearchWeights) dataset.RunFunc`
+- `func Objective(m dataset.Metrics) float64` — `m.NDCG10 - 0.5*m.FPPenalty10`
+
+**설계 메모**
+
+- 이것이 "변경이 나아졌는가"에 답하는 실제 기계다. Task 5가 자로 눈금을 새겼다면 이 Task는 자를 대상에 대는 손이다.
+- `WithWeights`는 `*Service`를 **뮤테이트하고 자기 자신을 반환**한다(`internal/search/search.go`). 후보마다 같은 인스턴스를 재사용하면 이전 후보의 가중치가 남는 오염이 생긴다. **후보마다 서비스 인스턴스를 새로 조립**하거나, 최소한 매 호출 직전에 `WithWeights`를 다시 적용한다. 어느 쪽을 택했는지 주석에 남긴다.
+- **`UseRerank=false` 고정**(§2.4). 배치 계층에서 리랭커 HTTP 도달성을 보장할 수 없다. baseline과 candidate를 동일 조건에서 재므로 상대 비교의 타당성은 유지된다.
+- **HyDE도 끈다.** LLM 호출이 들어가면 같은 질의가 실행마다 다른 결과를 내 재현성이 사라지고, 수백 회 탐색에 원격 API 비용이 붙는다.
+- `k`는 10 고정(NDCG@10/FP@10과 맞춘다). 검색은 상위 10개 문서 ID만 순서대로 뽑아 반환한다.
+- **동시성:** 질의별 평가를 `errgroup`으로 최대 4 병렬. Postgres 커넥션 풀 크기를 넘지 않게 상한을 상수로 둔다. 결과 순서는 인덱스로 복원한다(맵 순회 순서에 의존하지 않는다 — 결정성).
+- 검색 에러는 삼키지 않는다. 한 질의라도 실패하면 `Evaluate` 전체를 에러로 끝낸다. 부분 실패를 0점으로 처리하면 "가중치가 나쁘다"와 "DB가 흔들렸다"가 구분되지 않는다.
+
+- [ ] **Step 1: 실패하는 테스트** — 스텁 `Searcher`로:
+  - `TestRunnerFor_AppliesWeightsPerCandidate` — 서로 다른 가중치 2개를 연속 실행하면 스텁이 받은 weights가 각각 다르다(오염 없음).
+  - `TestRunnerFor_ForcesRerankAndHyDEOff` — 스텁이 받은 Query의 `UseRerank`/`UseHyDE`가 false.
+  - `TestObjective_PenalisesFalsePositives` — FP가 커질수록 objective가 단조 감소.
+  - `TestRunnerFor_PropagatesSearchError` — 스텁 에러 → 에러 전파.
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/tune/ -v` → FAIL.
+- [ ] **Step 3: 구현.**
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/tune/ ./internal/dataset/ -v` → PASS.
+- [ ] **Step 5: 커밋** — `git commit -m "feat(tune): deterministic search harness for weight evaluation"`
+
+---
+
+## Task 7: 가중치 이력 테이블과 스토어
+
+**Files:**
+- Create: `migrations/026_search_weights_history.sql`
+- Create: `internal/store/weights_history.go`, `internal/store/weights_history_test.go`
+
+**Interfaces:**
+- `func (s *WeightsHistoryStore) Insert(ctx, rec WeightsRecord) (int64, error)`
+- `func (s *WeightsHistoryStore) Active(ctx) (*WeightsRecord, error)` — 없으면 `(nil, nil)`
+- `func (s *WeightsHistoryStore) Promote(ctx, id int64) error` — 기존 active를 `superseded`로, 대상을 `active`로 **한 트랜잭션 안에서**
+- `func (s *WeightsHistoryStore) Rollback(ctx) (*WeightsRecord, error)` — 현재 active를 `rolled_back`, 직전 `superseded`를 `active`로
+
+**스키마 (migration 026)**
+
+```sql
+CREATE TABLE IF NOT EXISTS search_weights_history (
+    id              BIGSERIAL PRIMARY KEY,
+    weights         JSONB       NOT NULL,          -- model.SearchWeights 직렬화
+    status          TEXT        NOT NULL,          -- proposed|active|rolled_back|superseded
+    train_objective DOUBLE PRECISION,
+    holdout_ndcg10  DOUBLE PRECISION,
+    holdout_fp10    DOUBLE PRECISION,
+    baseline_ndcg10 DOUBLE PRECISION,
+    baseline_fp10   DOUBLE PRECISION,
+    holdout_queries INTEGER     NOT NULL DEFAULT 0,
+    gate_reason     TEXT,                          -- 승격 거부 사유 (사람이 읽는다)
+    metadata        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    promoted_at     TIMESTAMPTZ,
+    CHECK (status IN ('proposed','active','rolled_back','superseded'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_search_weights_active
+  ON search_weights_history ((status)) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_search_weights_created
+  ON search_weights_history (created_at DESC);
+```
+
+**설계 메모**
+
+- **`active`가 둘일 수 없음을 DB가 강제한다**(부분 UNIQUE 인덱스). 애플리케이션 조건문에 맡기면 동시 실행 두 번에 깨진다.
+- `Promote`는 반드시 하나의 트랜잭션. 순서는 (1) 기존 active → `superseded`, (2) 대상 → `active` + `promoted_at=now()`. 순서를 뒤집으면 부분 UNIQUE 인덱스가 중간 상태에서 터진다.
+- `metadata`에 `{"rerank": false, "train_holdout_gap": <float>, "sweeps": <int>, "tool_version": "..."}`를 남긴다. `train_holdout_gap`은 과적합 사후 감시용이다(§2.4(c)).
+- 승격되지 못한 후보도 **반드시 `proposed`로 기록**한다. 기록하지 않으면 "왜 안 올라갔는가"를 나중에 물을 수 없다. `gate_reason`에 사람이 읽을 문장을 넣는다(예: `"holdout distinct queries 12 < 30"`).
+- 개인 데이터 금지: 질의 원문·문서 ID를 이 테이블에 넣지 않는다. 집계 스칼라만.
+
+- [ ] **Step 1: 실패하는 테스트** (실 DB, `t.Cleanup`으로 정리):
+  - `TestPromote_LeavesExactlyOneActive` — 3회 연속 promote 후 `status='active'` 행이 정확히 1개.
+  - `TestPromote_IsAtomicUnderDuplicateActive` — 수동으로 active 2행을 넣으려 하면 **DB가 거부**한다.
+  - `TestRollback_RestoresPreviousActive` — promote A → promote B → rollback → active == A, B는 `rolled_back`.
+  - `TestRollback_NoPreviousReturnsNilNoError` — 되돌릴 행 없으면 active 없음 상태로 복귀.
+  - `TestActive_ReturnsNilWhenEmpty`.
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/store/ -run TestPromote -run TestRollback -v` → FAIL.
+- [ ] **Step 3: 마이그레이션 적용 + 구현** — Run: `psql "$TEST_DATABASE_URL" -1 -v ON_ERROR_STOP=1 -f migrations/026_search_weights_history.sql`
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/store/ -v` → PASS.
+- [ ] **Step 5: 커밋** — `git commit -m "feat(store): search weights history with single-active invariant"`
+
+---
+
+## Task 8: 좌표 탐색 최적화기 + 승격 게이트
+
+**Files:**
+- Create: `internal/tune/coordinate.go`, `internal/tune/gate.go`
+- Create: `internal/tune/coordinate_test.go`, `internal/tune/gate_test.go`
+
+**Interfaces:**
+
+```go
+type SearchSpace struct{ FTS, Vec, Bigm, SummaryVec, Entity []float64; RRFK []float64 }
+func DefaultSpace() SearchSpace
+type Result struct { Best model.SearchWeights; BestObjective float64; Sweeps, Evals int; Trace []string }
+func Coordinate(ctx context.Context, train *dataset.TrainSet,
+    base model.SearchWeights, space SearchSpace,
+    eval func(context.Context, model.SearchWeights) (dataset.Metrics, error)) (Result, error)
+
+func Eligible(holdoutQueries int) (bool, string)
+type GateInput struct{ BaseNDCG10, CandNDCG10, BaseFP10, CandFP10 float64; HoldoutQueries int }
+func PassesPromotion(in GateInput) (bool, string)
+```
+
+**설계 메모**
+
+- **탐색 공간**(§2.4): `FTS/Vec/Bigm ∈ [0.25, 2.0] step 0.25`, `SummaryVec ∈ [0.05, 1.5] step 0.25`, `Entity ∈ [0.05, 1.5] step 0.25`, `RRFK ∈ {20,40,60,80,120}`. 좌표 6개, sweep당 약 45회 평가.
+- **`SummaryVec`의 하한이 0이 아니라 0.05인 것이 핵심이다.** `SearchWeights.Defaults()`에서 0은 "미설정 → 커버리지 게이트에 위임"이라는 **별도 의미**를 갖는다(`internal/model/document.go`). 최적화기가 0을 후보로 내면 의도와 다른 동작이 되고, 그 결과를 "최적 가중치"라 부르면 거짓말이 된다. 레인을 끄고 싶으면 `DisableSummaryVec=true`를 **별도 후보 1개**로 따로 평가한다. `Entity`도 음수가 "명시적 비활성"이므로 하한을 양수로 둔다.
+- **종료 조건:** 한 sweep의 개선폭이 `< 1e-4`이거나 sweep 3회. 둘 다 상수로 두고 exported 하지 않는다 — 늘리고 싶은 유혹이 곧 과적합이다.
+- **탐색은 train만 본다.** `Coordinate`의 시그니처에 `*dataset.HoldoutSet`이 **없다**. holdout을 넣을 자리가 아예 없으므로 실수로 넘길 수 없다.
+- **결정성:** 좌표 순회 순서와 후보 값 순서를 고정한다. 동점이면 **먼저 나온 값**을 유지한다(맵 순회·부동소수 비교로 결과가 흔들리지 않게).
+- **승격 게이트**(§2.5): `PassesPromotion`은 (a) `Eligible(HoldoutQueries)`, (b) `CandNDCG10 - BaseNDCG10 >= 0.01`, (c) `CandFP10 - BaseFP10 <= 0.02` 셋을 모두 요구한다. **거부 사유 문자열을 반드시 반환**한다 — 이력의 `gate_reason`에 그대로 들어간다.
+- `Eligible`을 별도 함수로 뽑는 이유: 30 질의 게이트는 `if`문 하나로 두면 나중에 "이번만"이라며 우회된다. 독립 함수 + 독립 테스트로 못박는다.
+
+- [ ] **Step 1: 실패하는 테스트**
+  - `TestCoordinate_FindsKnownOptimum` — 합성 objective(예: `-(fts-1.5)²-(vec-0.5)²`)를 주면 격자 위 최적점에 수렴.
+  - `TestCoordinate_NeverProposesZeroSummaryVec` — 전 탐색 궤적에서 `SummaryVec == 0`인 후보가 나오지 않는다.
+  - `TestCoordinate_TerminatesWithinThreeSweeps` — 개선이 없는 평평한 objective에서도 유한 종료(`Sweeps <= 3`).
+  - `TestCoordinate_IsDeterministic` — 같은 입력 5회 → 같은 `Best`.
+  - `TestEligible_Under30Rejects` / `TestEligible_At30Accepts` — 경계값 29/30.
+  - `TestPassesPromotion_RejectsSmallGain`(+0.005), `_RejectsFPRegression`(+0.03), `_AcceptsClearWin`, `_ReasonIsNonEmptyOnReject`.
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/tune/ -run 'TestCoordinate|TestEligible|TestPasses' -v` → FAIL.
+- [ ] **Step 3: 구현.**
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/tune/ -v` → PASS.
+- [ ] **Step 5: holdout 미접근을 컴파일러로 재확인** — `Coordinate` 시그니처에 `HoldoutSet`이 없고, `internal/tune` 어디에서도 `dataset.HoldoutSet`의 unexported 필드를 참조하지 않음을 `grep -rn "HoldoutSet" internal/tune/`로 확인한다. `cmd/tune`(Task 9)의 `Evaluate` 호출 외에는 등장하지 않아야 한다.
+- [ ] **Step 6: 커밋** — `git commit -m "feat(tune): coordinate search with explicit promotion gate"`
+
+---
+
+## Task 9: 관측 (Langfuse 계측)
+
+**Files:**
+- New: `internal/telemetry/feedback_attrs.go` — 신규 span 이름·속성 키 상수
+- New: `internal/telemetry/feedback_attrs_test.go` — 속성 키 허용목록 고정 테스트
+- Edit: `internal/api/feedback_evidence.go`(Task 5 산출물) — 근거 카드 피드백 기록 시 span 1개
+- Edit: `internal/api/feedback_evidence_test.go`(Task 5 산출물) — span 방출 테스트 추가
+- **호출 계약만 명시**(파일이 아직 없어 이 Task의 편집 대상이 아님): `cmd/tune/main.go`가 구현될 때 아래 세 지점에 반드시 넣는다 — `dataset.Load` 직후, `tune.Coordinate` 반환 직후, `gate.PassesPromotion` 판정 직후. `internal/store/weights_history.go`의 promote/rollback 처리 끝에도 한 지점 필요.
+
+**Interfaces:**
+
+```go
+// internal/telemetry/feedback_attrs.go
+const (
+    SpanFeedbackEvidence  = "feedback.evidence.recorded"
+    SpanTuneDatasetLoaded = "tune.dataset.loaded"
+    SpanTuneCoordinate    = "tune.coordinate.completed"
+    SpanTunePromotion     = "tune.promotion.decision"
+    SpanWeightsAction     = "weights.action.applied"
+)
+
+const (
+    AttrFeedbackDocumentID = "feedback.document_id" // doc UUID, PII 아님
+    AttrFeedbackThumbs     = "feedback.thumbs"       // -1 | 1
+    AttrFeedbackSplit      = "feedback.split"        // "train" | "holdout"
+    AttrTuneTrainQueries   = "tune.train_queries"
+    AttrTuneHoldoutQueries = "tune.holdout_queries"
+    AttrTuneTotalRows      = "tune.total_feedback_rows"
+    AttrTuneSweeps         = "tune.sweeps"
+    AttrTuneEvals          = "tune.evals"
+    AttrTuneBaseObjective  = "tune.base_objective"
+    AttrTuneBestObjective  = "tune.best_objective"
+    AttrTuneGatePassed     = "tune.gate_passed"
+    AttrTuneGateReason     = "tune.gate_reason"      // gate.go/coordinate.go 고정 enum만
+    AttrTuneNDCGGain       = "tune.ndcg_gain"
+    AttrTuneFPDelta        = "tune.fp_delta"
+    AttrWeightsHistoryID   = "weights.history_id"    // int64 PK
+    AttrWeightsAction      = "weights.action"        // "propose"|"promote"|"rollback"
+    AttrWeightsPreviousID  = "weights.previous_history_id"
+)
+```
+
+**설계 메모**
+
+- **왜 span 속성이지 별도 메트릭 시스템이 아닌가.** `internal/telemetry`는 이미 OTel 트레이스만 Langfuse OTLP(`/v1/traces`)로 내보낸다(`otel.go`) — 메트릭 익스포터는 없다. 새 파이프라인 대신 기존 `tracer()` 패턴(`internal/llm/client.go:36,48`)을 재사용한다. 승격 이벤트마다 `tune.ndcg_gain`을 span 속성으로 실으면, Langfuse 트레이스 타임라인 자체가 "검증셋 점수 추이" 그래프가 된다 — 별도 대시보드가 필요 없다.
+- **PII 회피가 이 Task의 존재 이유다.** Global Constraints(§0)는 로그·Langfuse에 `query_hash`(md5 앞 8자)까지는 허용하지만, **이 Task는 그보다 보수적으로 간다.** Langfuse는 외부 호스팅 서비스이고 보존 기간이 로컬 로그보다 길다 — 트레이스 속성에는 `query_hash`조차 싣지 않는다. `feedback.document_id`(문서 UUID)와 집계 스칼라만 싣는다. 재현이 필요하면 DB의 `feedback.split` 컬럼과 `search_weights_history`만으로 충분하다.
+- **`tune.gate_reason`은 자유 텍스트가 아니라 `gate.go`/`coordinate.go`(Task 8)가 반환하는 고정 enum 문자열이다.** 자유 텍스트를 속성에 실으면 어딘가에서 사용자 입력이 우연히 섞여 들어갈 경로가 열린다 — enum 고정으로 그 경로를 원천 차단한다.
+- **속성 키 허용목록 테스트.** `feedback_attrs_test.go`는 `go/parser`로 이 파일의 `const` 블록을 읽어 문자열 값 전체 집합이 하드코딩된 `attributeKeyAllowlist`와 **정확히 일치**하는지 검사한다(§2.3 리플렉션 기반 API 표면 테스트와 동일 패턴). 새 속성을 추가하려는 사람은 테스트와 allowlist를 함께 고쳐야 하므로 "일단 문서 제목도 넣자" 같은 실수가 CI에서 걸린다.
+- `feedback.thumbs ∈ {-1,1}`, `feedback.split ∈ {"train","holdout"}` — 둘 다 §2.1/§2.2에서 이미 확정된 닫힌 도메인이라 새로운 노출면이 아니다.
+
+- [ ] **Step 1: 실패하는 테스트**
+  - `TestAttrKeys_MatchAllowlist` — `internal/telemetry`의 `const` 블록 파싱 결과가 하드코딩 allowlist와 정확히 일치.
+  - `TestFeedbackEvidence_EmitsSpan` — 근거 카드 피드백 핸들러 호출 후, 테스트 전용 in-memory span recorder(`sdktrace.NewTracerProvider` + `tracetest.NewInMemoryExporter`)에 `SpanFeedbackEvidence` 1개, 속성 3개(`document_id`/`thumbs`/`split`)만 존재.
+  - `TestFeedbackEvidence_SpanHasNoQueryAttribute` — 방출된 span의 속성 키 중 `"query"`를 부분 문자열로 포함하는 키가 **없다**.
+- [ ] **Step 2: 실패 확인** — Run: `go test ./internal/telemetry/... ./internal/api/... -run 'TestAttrKeys|TestFeedbackEvidence_Emits|TestFeedbackEvidence_SpanHasNo' -v` → FAIL.
+- [ ] **Step 3: 구현.** `internal/telemetry/feedback_attrs.go` 상수 정의 + `internal/api/feedback_evidence.go`에 `tracer().Start(ctx, telemetry.SpanFeedbackEvidence, oteltrace.WithAttributes(...))` 삽입(기존 `tracerName`/`tracer()` 패턴 재사용, `internal/api` 전용 tracerName 신설, 요청 실패 시 span을 만들지 않는다 — 실패는 HTTP 계층 로그로 충분).
+- [ ] **Step 4: 통과 확인** — Run: `go test ./internal/telemetry/... ./internal/api/... -v` → PASS.
+- [ ] **Step 5: 계약 남기기** — `cmd/tune`가 구현될 때 넣어야 할 세 호출 지점은 이미 위 "Files"·"설계 메모"에 기술돼 있다. 이 Task는 그 파일을 새로 만들지 않는다 — 존재하지 않는 파일을 편집 대상으로 넣지 않기 위함(§금지 사항).
+- [ ] **Step 6: 커밋** — `git commit -m "feat(telemetry): PII-free spans for feedback evidence and tune events"`
+
+---
+
+## 배포
+
+프로덕션은 macmini의 `docker compose -f docker-compose.local.yml --env-file .env.local`이다(k8s 아님). **`--env-file .env.local`을 절대 빼지 않는다** — 빼면 `${VAR}` 치환이 기본값으로 떨어져 볼륨 마운트가 어긋나고 컨테이너가 죽는다([[feedback_macmini_compose_envfile_flag]] 전례).
+
+**마이그레이션:** `cmd/server/main.go`가 기동 시 `pg.RunMigrations`로 `migrations/` 디렉토리를 자동 적용한다 — 수동 `psql` 실행이 필요 없다. 순서는 파일명 사전순으로 고정되므로 §3 "번호 주의"대로 착수 시점에 `ls migrations`로 실제 번호를 확인해 feedback 보강이 weights history보다 먼저 오게만 해 두면 나머지는 자동이다.
+
+- [ ] 적용 전: `docker compose ... exec postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT count(*) FROM feedback;"` — 배포 전 행 수 기록(약 50 + 그간 누적분).
+- [ ] `docker compose -f docker-compose.local.yml --env-file .env.local up -d --no-deps --build server` — `postgres`·`web`은 대상에서 제외해 무손상 유지.
+- [ ] 적용 후: 같은 count 쿼리가 **감소 없이** 배포 전과 같거나 큰지 확인. `SELECT count(*) FROM feedback WHERE split IS NOT NULL;`이 backfill 대상 행 수와 일치하는지 확인.
+- [ ] `\d feedback`에 `split` 컬럼과 `WHERE source = 'ask_evidence'` 부분 UNIQUE 인덱스가 보이는지, `\d search_weights_history`에 `WHERE status='active'` 부분 UNIQUE 인덱스가 보이는지 확인.
+- [ ] 플래그 off 상태 회귀 확인: `curl -s -o /dev/null -w '%{http_code}\n' localhost:9200/api/v1/feedback/evidence` → 404. 기존 `/api/v1/feedback`, `/api/v1/ask`는 200대 그대로.
+- [ ] **플래그는 배포와 분리된 별도 조작, 한 번에 하나씩.** `.env.local`에 `FEEDBACK_EVIDENCE_ENABLED=true` → `up -d --no-deps server` → `POST /api/v1/feedback/evidence` 200/201 확인 + Langfuse에서 `feedback.evidence.recorded` span이 `document_id`/`thumbs`/`split` 세 속성만 갖고 나타나는지 육안 확인(질의 텍스트 없음).
+- [ ] 이어서 `NEXT_PUBLIC_FEEDBACK_EVIDENCE_ENABLED=true` → `up -d --no-deps --build web` → `/ask` 근거 카드 좋아요/싫어요 렌더·낙관적 토글 확인.
+- [ ] `cmd/tune`을 postgres와 같은 macmini 호스트에서 1회 수동 실행(§2.4 배치 위치) → Langfuse에 `tune.dataset.loaded`/`tune.coordinate.completed`/`tune.promotion.decision` span이 잡히는지, 표본 30 미만이면 `gate_reason`이 그 사실을 보고하는지 확인.
+
+> 이 절의 명령은 **운영자가 실행한다.** 에이전트는 macmini에 SSH하거나 컨테이너를 조작하지 않는다.
+
+---
+
+## 롤백
+
+- [ ] **1단계(즉시, 플래그만):** `.env.local`에서 `FEEDBACK_EVIDENCE_ENABLED=false`(및 `NEXT_PUBLIC_FEEDBACK_EVIDENCE_ENABLED=false`) → `up -d --no-deps server`(또는 `web`). 엔드포인트가 다시 404가 되고 UI 버튼이 사라진다. 기존 `/ask`·`/api/v1/feedback`은 영향 없음.
+- [ ] **2단계(가중치가 이미 승격된 경우, 즉시 롤백 경로):** `cmd/tune -rollback` 실행 → `search_weights_history`에서 현재 `active` 행이 `rolled_back`으로, 직전 `superseded` 행이 다시 `active`로 전이된다(§2.5). 되돌릴 `superseded` 행이 없으면 `active` 없음 상태(=`SearchWeights.Defaults()`)로 복귀 — 코드 기본값과 동일하므로 **서버 재기동 없이도 다음 검색 요청부터 기본 가중치로 돌아간다**(검색 경로가 매 요청 `active` 행을 조회하는 설계일 때. Task 10에서 캐싱을 도입한다면 캐시 무효화 훅이 반드시 필요하다 — 이 문장을 Task 10 담당자에게 그대로 전달할 것).
+- [ ] **3단계(이미지 회귀, 위 두 단계로 부족할 때만):** 직전 태그로 `up -d --no-deps --build server web`. `feedback`·`search_weights_history` 데이터는 그대로 남는다.
+- [ ] **마이그레이션은 되돌리지 않는다.** 025/026(§3, 실제 번호는 착수 시점 확인)은 전부 additive(nullable 컬럼 추가, 신규 테이블, 부분 인덱스)이므로 앱 코드가 롤백돼도 스키마는 무해하게 남는다 — `DROP COLUMN`/`DROP TABLE`이 이 계획의 어떤 마이그레이션에도 없다.
+- [ ] 하지 말 것: `feedback` 또는 `search_weights_history` 행 삭제. 사용자가 이미 매긴 평가와 승격 이력이며 재수집으로 복구되지 않는다.
+
+---
+
+## Self-Review
+
+구현 완료 후 아래를 직접 확인한다. 하나라도 아니면 완료가 아니다.
+
+- [ ] 기존 `feedback` 50행이 파괴되지 않았다: 이번 브랜치에서 추가된 마이그레이션만 대상으로 `git diff --name-only main...HEAD -- migrations/ | xargs grep -in 'drop column\|alter column .* type\|set not null'` → 신규 컬럼의 최초 정의 라인 외 출력 없음.
+- [ ] **검증셋 격리가 코드로(규약이 아니라) 강제된다:** `internal/dataset`의 리플렉션 기반 `api_surface_test.go`가 `HoldoutSet`의 exported 메서드 집합을 `{Evaluate, Queries}`로 고정하는지 확인, `grep -rn "HoldoutSet" internal/tune/`이 `Evaluate` 호출 외에 등장하지 않는지 확인(§Task 8 Step 5), `tune.Coordinate` 시그니처에 `*dataset.HoldoutSet` 파라미터가 없는지 확인.
+- [ ] 질의 30개 미만에서 자동 승격이 차단된다: `TestEligible_Under30Rejects`/`TestEligible_At30Accepts` 통과, `gate.Eligible`이 `promote()` 진입 **전** 독립 호출인지(인라인 `if` 아님) 확인.
+- [ ] 모든 기능 플래그 기본값이 off다: 환경변수를 지운 상태에서 `FEEDBACK_EVIDENCE_ENABLED`/`NEXT_PUBLIC_FEEDBACK_EVIDENCE_ENABLED` 관련 테스트가 off를 강제.
+- [ ] 로그·트레이스에 질의 텍스트·문서 본문·실명이 없다: `TestFeedbackEvidence_SpanHasNoQueryAttribute` 통과, `TestAttrKeys_MatchAllowlist` 통과, `grep -rn "Attr(Feedback|Tune|Weights)" internal/telemetry/feedback_attrs.go | grep -iw query` → 출력 없음.
+- [ ] `web/package-lock.json`이 생기지 않았다: `git status --porcelain web/package-lock.json` → 출력 없음. bun만 사용.
+- [ ] `go test ./... && go vet ./...` 통과, `cd web && bun run lint && bun run build` 통과.
+- [ ] 동시 작업 파일(§Global Constraints 목록, `internal/graph/**`·`internal/api/graph.go`·`internal/api/router.go`·`internal/store/graph_source.go`·`internal/worker/graph_projection_worker.go`·`internal/llm/client.go`·`internal/config/config.go`·`internal/worker/extraction_worker.go`·`cmd/server/main.go`·`cmd/collector/main.go` 등)을 건드리지 않았다: `git diff --name-only main...HEAD`로 확인.
+- [ ] `internal/config/config.go`를 수정하지 않았다: 신규 플래그는 전부 `os.Getenv` 직접 호출.

--- a/docs/superpowers/plans/2026-08-18-graph-projection-view.md
+++ b/docs/superpowers/plans/2026-08-18-graph-projection-view.md
@@ -1,0 +1,997 @@
+# 지식 그래프 투영·탐색 화면 구현 계획 (Part B)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PostgreSQL의 `entity_relations`/`document_entities`를 Neo4j로 멱등 투영하고, 진입점 선택 → 1홉 확장 방식의 그래프 탐색 화면을 웹에 붙인다.
+
+**Architecture:** PostgreSQL이 진실의 원천이고 Neo4j는 언제든 버리고 다시 만들 수 있는 파생 투영이다. collector 안의 `GraphProjectionWorker`가 기존 `ExtractionWorker`와 같은 패턴(ticker + 직렬 배치 + env 플래그 게이팅)으로 Postgres를 읽어 Cypher `MERGE`로 반영한다. server는 **코드에 박힌 파라미터화 고정 쿼리 카탈로그**만 노출하고, 프런트는 그 4개 엔드포인트만 호출한다. 투영 워커가 Neo4j의 유일한 writer다.
+
+**Tech Stack:** Go 1.26 / `neo4j-go-driver/v5` / Neo4j 5.26 Community (docker-compose) / PostgreSQL 16 / Next.js 16 + React 19 + Tailwind 4 / bun
+
+**Spec:** `docs/superpowers/specs/2026-08-17-knowledge-graph-actions-feedback-design.md` — §6(Part B)가 대상이고 §5.3 닫힌 어휘 8종, §5.4 스키마, §11 프라이버시가 전제다.
+
+---
+
+## 설계 문서 대비 변경 사항
+
+### 변경 1 — Neo4j는 ubuntu1이 아니라 macmini에 배치한다
+
+설계 문서 §6.1은 "ubuntu1 호스트에 배치"라고 적었고 §10-1이 그 전제로 "PostgreSQL → ubuntu1 이전 선행"을 들었다. **그 선행 조건이 아직 실행되지 않았다** — `docs/superpowers/plans/2026-08-18-postgres-migration-to-ubuntu1.md`가 존재하지만 그 문서 스스로 "planning-only, 어떤 작업도 실행되지 않았음"을 명시하고 실행 전 별도 go/no-go를 요구한다. 즉 Part B는 postgres가 macmini에 있는 상태를 전제로 착수해야 하고, 그 상태에서는 다음 실측 때문에 ubuntu1 배치가 성립하지 않는다.
+
+| 경로 | 결과 |
+|---|---|
+| macmini **호스트** → ubuntu1 (100.68.237.99) | 도달 가능 |
+| macmini **컨테이너** → ubuntu1 | **도달 불가** — macOS Docker Desktop VM에 호스트 Tailscale 라우트가 없다 |
+| ubuntu1 → macmini의 5432 / 8080 / 3000 | **전부 closed** — 서비스가 127.0.0.1 바인딩이다 |
+
+양방향이 막혀 있다. ubuntu1에 두려면 Tailscale 사이드카나 SSH 포워딩 배관이 필요한데, **사용자는 postgres 이전 논의에서 동일한 배관을 SPOF라는 이유로 이미 거부했다.** 투영 워커(collector)와 읽기 API(server)가 둘 다 macmini 컨테이너이므로 그 배관은 그래프 기능 전체의 단일 실패점이 된다. 반대 방향의 비용은 없다 — 문서 1,213건에서 나오는 관계 수천 개 규모라 heap 512MB / pagecache 256MB면 충분하다. **결정: macmini의 `docker-compose.local.yml`에 서비스로 추가한다.**
+
+### 변경 2 — 설계 문서가 구현 단계로 미룬 항목(§13) 확정
+
+| 항목 | 확정값 | 근거 |
+|---|---|---|
+| 렌더링 라이브러리 | `react-force-graph-2d` + `next/dynamic({ssr:false})` | 우산 패키지 `react-force-graph`는 three.js를 끌어온다. Task 11에 **실측 게이트** — `/graph` First Load JS 증가분이 250KB(gzip)를 넘으면 d3-force + SVG로 되돌린다 |
+| 진입점 N | 기본 **20**, 최대 50 | 라벨 붙은 force graph가 한 화면에 읽히는 상한. 그 이상은 hairball이고 설계 의도(진입점 → 1홉 확장)에 어긋난다 |
+| `confidence` 스케일 / 화면 기본 하한 | 0–1 연속값 / **0.5** | 마이그레이션 021이 `NUMERIC(3,2) CHECK 0..1`로 이미 확정. 0.5는 슬라이더로 0까지 내릴 수 있다 |
+
+### 변경 3 — 설계 문서에 없던 결정 3가지
+
+1. **투영 워터마크를 Postgres가 아니라 Neo4j 안(`(:ProjectionState {id:'singleton'})`)에 둔다.** Postgres에 두면 Neo4j 볼륨만 지웠을 때 워터마크가 살아남아 재구축이 조용히 깨진다. **이 계획은 마이그레이션 파일을 하나도 추가하지 않는다** — 진실의 원천에 되돌릴 것이 남지 않아야 롤백이 §롤백대로 끝난다.
+2. **엔티티 노드를 별도 패스로 투영하지 않는다.** 관계 쿼리가 양 끝 엔티티를 JOIN해 가져오고 Cypher가 `MERGE`로 함께 만든다. 별도 패스는 "관계는 왔는데 노드가 아직 없음" 순서 의존을 만들고, 그 관계를 건너뛴 채 워터마크가 전진하면 영구 유실이 된다. 어떤 관계에도 참여하지 않는 고립 엔티티는 화면에서 의미가 없다.
+3. **`server`/`collector`에 `depends_on: neo4j`를 걸지 않는다.** Neo4j가 죽어도 수집·검색·`/ask`는 돌아야 한다. 워커는 다음 tick에 재시도하고 API는 503을 반환한다. 이 결정이 §롤백의 "컨테이너 제거만으로 끝"을 성립시킨다.
+
+---
+
+## Global Constraints
+
+- **프로덕션은 macmini의 `docker compose -f docker-compose.local.yml --env-file .env.local ...`이다.** k8s가 아니다. `--env-file` 생략 불가 — 생략하면 `${VAR}` 치환이 기본값으로 떨어져 마운트가 어긋난 전례가 있다.
+- **PostgreSQL이 진실의 원천, Neo4j는 재구축 가능한 파생 투영이다.** Neo4j 백업은 요구사항이 아니다. 애플리케이션 경로에서 Neo4j에 직접 쓰지 않는다.
+- **관계 타입은 닫힌 어휘 8종**(`communicated_with`, `requested_of`, `committed_to`, `mentions`, `belongs_to`, `scheduled_with`, `about_topic`, `related_to`) — `internal/model/relation.go`에 상수로 존재하며 어휘 밖 값은 `related_to`로 강등된다.
+- **엔티티 타입은 4종**: `PERSON`, `ORG`, `CONCEPT`, `OTHER` (`internal/model/entity.go`).
+- **LLM은 원격 API만 사용한다(로컬 추론 금지). 이 범위는 LLM을 전혀 호출하지 않는다.** 자연어→Cypher는 범위 밖이다(§프라이버시 6).
+- **웹 인증은 `web/src/proxy.ts`의 Cloudflare Access JWT 검증이 처리한다.** 새 인증을 만들지 않는다.
+- **웹 패키지 매니저는 bun.** `npm install`은 `package-lock.json`을 만들어 CI(`bun --frozen-lockfile`)를 깬다.
+- **Go 1.26.6**, 모듈 `github.com/baekenough/second-brain`. 커밋은 Conventional Commits, 브랜치는 `main`에서 딴 `feature/*`.
+- **개인정보**: 테스트 픽스처·커밋 메시지·로그에 실제 개인 데이터를 넣지 않는다. 가공된 더미(`더미갑`, `더미을`)만 쓴다.
+
+---
+
+## 파일 구조
+
+**신규 (Go)**: `internal/graph/client.go`(드라이버 수명주기·세션 헬퍼) · `schema.go`(제약·인덱스 보증) · `reltypes.go`(Cypher 타입 리터럴 화이트리스트) · `projector.go`(MERGE 배치·워터마크·wipe) · `queries.go`(읽기 전용 고정 쿼리 + 상한) / `internal/store/graph_source.go`(투영용 Postgres 읽기) / `internal/model/projection.go`(투영 행 타입) / `internal/worker/graph_projection_worker.go` / `internal/api/graph.go`
+
+**수정 (Go)**: `cmd/collector/main.go`(312행 근처, 워커 배선 + 플래그) · `cmd/server/main.go`(`WithGraph` 호출) · `internal/api/router.go`(옵셔널 필드 + 라우트) · `docker-compose.local.yml` · `.env.local.example` · `go.mod`/`go.sum`
+
+**신규 (웹)**: `web/src/app/graph/page.tsx`(필터 + 진입점) · `GraphCanvas.tsx`(force-graph 래퍼, client-only) · `EvidencePanel.tsx` · `mask.ts` / `web/src/app/api/graph/{entry,expand,evidence,entities}/route.ts`(프록시 4개)
+
+**수정 (웹)**: `web/src/lib/api.ts`, `web/src/lib/types.ts`, `web/package.json`
+
+**마이그레이션 파일 없음.** 의도된 제약이다(변경 3-1).
+
+---
+
+## 그래프 데이터 모델
+
+### 노드
+
+```
+(:Entity:Person)  (:Entity:Org)  (:Entity:Topic)  (:Entity:Other)   (:Document)   (:ProjectionState)
+```
+
+`entities.type`을 **보조 라벨**로 매핑한다(`CONCEPT` → `Topic`). 설계 문서 §6.2의 근거대로 라벨은 플래너가 직접 쓰는 1급 시민이라 속성 필터보다 저렴하고, 타입이 유한한 닫힌 집합이라 라벨 폭증 위험이 없다. `type` 속성도 **함께** 저장한다 — API 응답에서 라벨 목록을 역산하는 것보다 속성 1개 읽기가 단순하고, 두 값은 같은 소스에서 동시에 쓰여 어긋날 수 없다.
+
+| 노드 | 속성 |
+|---|---|
+| `:Entity` | `pgId`(int, **UNIQUE**), `name`, `normalizedName`(인덱스), `type` |
+| `:Document` | `pgId`(string UUID, **UNIQUE**), `sourceType`, `occurredAt`(nullable). **`title`·`content` 저장 금지** (§프라이버시 1) |
+| `:ProjectionState` | `id`(항상 `'singleton'`, **UNIQUE**), `lastRelationId`, `resetToken`, `updatedAt` |
+
+문서를 **노드**로 두는 이유: 한 문서가 여러 관계의 근거이므로(N:M) 관계 속성으로 복제하면 같은 메타데이터가 수천 번 중복된다. 반대로 엔티티 이름은 **속성**으로 둔다 — 이름으로 조인·필터하는 질의가 없고(항상 `pgId`로 진입한다) 노드로 승격하면 홉만 늘어난다.
+
+### 관계
+
+8종을 대문자 스네이크로 매핑하고 `document_entities` 투영인 `MENTIONED_IN` 하나를 더해 9종이다.
+
+```
+(:Entity)-[:COMMUNICATED_WITH|REQUESTED_OF|COMMITTED_TO|MENTIONS|BELONGS_TO|SCHEDULED_WITH|ABOUT_TOPIC|RELATED_TO]->(:Entity)
+(:Entity)-[:MENTIONED_IN]->(:Document)
+```
+
+엔티티 간 8종은 `pgId`(= `entity_relations.id`), `evidencePgId`, `confidence`, `observedAt`을 갖고, `MENTIONED_IN`은 `evidencePgId`만 갖는다.
+
+**Postgres 1행 = 관계 1개.** 같은 쌍·같은 타입이 근거 문서 3개에서 관찰되면 병렬 엣지 3개다. 집계("12번 연락했다")는 질의 시점에 `count(r)`로 한다. 대안(엣지 1개 + 카운터 증가)을 버린 이유는 (1) 카운터 증가는 멱등하지 않아 재실행 시 값이 부풀고, (2) 엣지 1개가 Postgres 1행에 1:1 대응해야 "모든 노드·관계가 Postgres 행으로 역추적된다"는 재구축 보증이 성립하기 때문이다. 병렬 엣지는 이 규모에서 비용이 아니다.
+
+**방향**: 저장은 `from_entity_id → to_entity_id`를 그대로 따라 단방향이다. 탐색은 방향 무관(`-[r]-`)으로 매치하고 응답에 `direction`을 실어 UI가 화살표를 그린다. 양방향 이중 저장을 하지 않는다.
+
+### 제약과 인덱스
+
+```cypher
+CREATE CONSTRAINT entity_pg_id       IF NOT EXISTS FOR (e:Entity)          REQUIRE e.pgId IS UNIQUE;
+CREATE CONSTRAINT document_pg_id     IF NOT EXISTS FOR (d:Document)        REQUIRE d.pgId IS UNIQUE;
+CREATE CONSTRAINT projection_state_id IF NOT EXISTS FOR (p:ProjectionState) REQUIRE p.id  IS UNIQUE;
+CREATE INDEX entity_normalized_name  IF NOT EXISTS FOR (e:Entity)          ON (e.normalizedName);
+```
+
+유니크 제약은 **`MERGE`의 안전판**이다 — 없으면 동시 `MERGE`가 중복 노드를 만든다. 제약이 백킹 인덱스를 만들므로 `pgId`에 별도 인덱스를 만들지 않는다.
+
+**관계 속성 인덱스는 만들지 않는다.** (1) Community 에디션은 **관계 유니크/존재 제약을 지원하지 않으므로**(Enterprise 기능) 관계 중복 방지를 제약이 아니라 "투영 워커가 유일한 직렬 writer"라는 구조로 보장한다 — 동시 writer가 없으면 `MERGE` 경합 자체가 없다. (2) 모든 조회가 `pgId`로 노드에 진입한 뒤 1홉 확장이라 관계를 전역 스캔하는 질의가 없다. 진입점 쿼리만 예외인데, 관계 수천 개에서는 인덱스보다 스캔이 빠르다. **임계**: 관계 50만 개 초과 또는 기간 전역 질의 도입 시 `observedAt` 관계 인덱스를 추가한다(§미해결 위험).
+
+**슈퍼노드 주의**: 사용자 본인 엔티티와 상용 토픽은 팬아웃이 커진다. 현 규모에서는 문제가 아니지만 **확장 질의는 반드시 `ORDER BY` + `LIMIT`으로 자른다**. 무제한 확장 질의를 만들지 않는다. 가변 길이 경로(`*`)도 쓰지 않는다.
+
+---
+
+## 프라이버시 처리 방침
+
+Part B는 LLM을 호출하지 않으므로 **이 범위에서 개인 데이터가 원격으로 나가는 경로는 없다.**
+
+1. **Neo4j에 원문을 넣지 않는다.** `:Document`는 `pgId`+`sourceType`+`occurredAt`만 갖는다. 근거 열람은 UI가 기존 `/documents/{id}`로 링크하며 그 페이지는 이미 Access + Bearer 인증 뒤에 있다. 결과적으로 **Neo4j 볼륨이 통째로 유출되어도 노출되는 것은 이름과 관계 구조이지 대화 원문이 아니다.**
+2. **포트를 공개하지 않는다.** bolt(7687)·browser(7474) 모두 `127.0.0.1` 바인딩. Browser는 인증만 통과하면 그래프 전체를 조회하므로 **cloudflared ingress에 7474 호스트명을 추가하지 않는다.** 필요하면 SSH 로컬 포워딩으로만 접근한다.
+3. **화면 표시.** `/graph`는 `proxy.ts`의 Access 검증 뒤에 놓인다(새 인증 코드 없음). 노드 라벨에 실명이 그대로 나오는 것이 이 화면의 목적이다. 다만 화면 공유용 **마스킹 토글**을 둔다 — 켜면 클라이언트에서만 `김민수` → `김**`로 렌더링한다. 서버 응답은 바뀌지 않는다(서버 측 마스킹은 근거 대조를 불가능하게 만든다). 기본 off, 선택은 `localStorage`에 저장.
+4. **로그.** 엔티티 `name`/`normalizedName`, 문서 제목·본문, Cypher 파라미터 맵 전체를 **절대 로그에 남기지 않는다.** 허용: `pgId`, 건수, 소요시간, 오류 종류. Task 12에 강제 가드 테스트를 둔다.
+5. **Neo4j 자체 로그.** `NEO4J_server_logs_query_enabled: "OFF"` — 켜져 있으면 파라미터의 실명이 `/logs/query.log`에 남는다. Task 1에서 더미 이름으로 실증한다. `/logs`는 볼륨으로 내보내지 않아 컨테이너와 함께 사라진다.
+6. **자연어→Cypher는 범위 밖이다.** 향후 붙인다면 읽기 전용 세션, 파라미터화 강제(리터럴 삽입 거부), 실행 전 `EXPLAIN` 게이트, 파괴적 절(`CREATE`/`MERGE`/`SET`/`DELETE`/`REMOVE`/`CALL {...} IN TRANSACTIONS`/`LOAD CSV`/`apoc.*` 쓰기) 정적 차단, 경로 상한·기본 `LIMIT`·트랜잭션 타임아웃이 **전부** 필요하다. 덧붙여 **Community에는 RBAC이 없어 "reader 롤 전용 사용자"라는 방어선을 쓸 수 없다** — 그때는 Enterprise 전환이나 읽기 복제본을 함께 판단해야 한다. 지금은 이 문제를 만들지 않는 쪽을 택했다.
+
+---
+
+## 작업 목록
+
+작업 1–8은 백엔드, 9–12는 프런트다. 각 작업은 독립 검증·리뷰·커밋 가능하다. 배포는 §배포에서 따로 다룬다.
+
+### Task 1: Neo4j 컨테이너 정의
+
+**Files:** Modify `docker-compose.local.yml`(services 마지막 블록 뒤), `.env.local.example`
+**Produces:** compose 네트워크 내부 엔드포인트 `bolt://neo4j:7687`, 사용자 `neo4j`, 비밀번호는 `NEO4J_PASSWORD`
+
+- [ ] **Step 1: compose에 서비스와 볼륨 추가**
+
+```yaml
+  # neo4j — 지식 그래프 파생 투영. PostgreSQL이 진실의 원천이므로 이 볼륨은
+  #   버려도 된다(백업 요구사항 없음, 재구축은 §배포 D6).
+  #   포트는 127.0.0.1 에만 바인딩한다 — Browser(7474)는 인증만 통과하면
+  #   그래프 전체를 조회하므로 cloudflared ingress에 호스트명을 두지 않는다.
+  neo4j:
+    image: neo4j:5.26-community
+    ports:
+      - "127.0.0.1:7687:7687"
+      - "127.0.0.1:7474:7474"
+    environment:
+      # ${VAR} 치환은 env_file이 아니라 --env-file/셸에서 온다. 그래서
+      # --env-file 없이 기동하면 아래 :? 가 조용한 오작동 대신 즉시 실패시킨다.
+      NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+      NEO4J_PASSWORD: "${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+      NEO4J_server_memory_heap_initial__size: "512m"   # 관계 수천 개 규모.
+      NEO4J_server_memory_heap_max__size: "512m"       # 과할당은 다른 컨테이너를
+      NEO4J_server_memory_pagecache_size: "256m"       # 밀어낼 뿐이다.
+      NEO4J_server_logs_query_enabled: "OFF"           # 파라미터의 실명 유출 방지
+    volumes:
+      - neo4jdata:/data                                # /logs 는 내보내지 않는다
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"$${NEO4J_PASSWORD}\" 'RETURN 1' >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 40s
+    restart: unless-stopped
+```
+
+`volumes:` 블록에 `neo4jdata:` 추가(주석: 파생 투영 전용, 삭제해도 재구축된다).
+
+- [ ] **Step 2: `.env.local.example`에 변수 추가** — 값은 비운다.
+
+```
+NEO4J_PASSWORD=
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USERNAME=neo4j
+GRAPH_PROJECTION_ENABLED=false
+GRAPH_PROJECTION_INTERVAL=5m
+GRAPH_PROJECTION_BATCH_SIZE=500
+GRAPH_PROJECTION_RESET_TOKEN=
+```
+
+- [ ] **Step 3: compose 문법 검증**
+Run: `docker compose -f docker-compose.local.yml --env-file .env.local config >/dev/null && echo OK` → `OK`.
+`--env-file`을 뺀 동일 명령이 `NEO4J_PASSWORD is required`로 실패하는 것도 확인한다.
+
+- [ ] **Step 4: 기동과 헬스체크**
+Run: `docker compose -f docker-compose.local.yml --env-file .env.local up -d neo4j` → `... ps neo4j`가 60초 내 `healthy`.
+
+- [ ] **Step 5: 포트 바인딩 확인**
+Run: `... port neo4j 7687` → `127.0.0.1:7687`. `0.0.0.0`이면 실패로 간주하고 compose를 고친다.
+
+- [ ] **Step 6: 쿼리 로그에 파라미터가 남지 않음을 실증** (더미 이름 사용)
+
+```bash
+docker compose -f docker-compose.local.yml --env-file .env.local exec neo4j \
+  cypher-shell -u neo4j -p "$NEO4J_PASSWORD" 'CREATE (:Probe {name: $n})' -P 'n => "ZZTESTNAME"'
+docker compose -f docker-compose.local.yml --env-file .env.local exec neo4j \
+  sh -c 'grep -rl ZZTESTNAME /logs || echo NO_MATCH'   # Expected: NO_MATCH
+```
+
+- [ ] **Step 7: 프로브 삭제 후 커밋**
+`... exec neo4j cypher-shell -u neo4j -p "$NEO4J_PASSWORD" 'MATCH (p:Probe) DETACH DELETE p'` 실행 후
+`git add docker-compose.local.yml .env.local.example && git commit -m "feat(graph): add neo4j container for derived graph projection"`
+
+### Task 2: Neo4j 클라이언트와 스키마 보증
+
+**Files:** Create `internal/graph/client.go`, `internal/graph/schema.go`, `internal/graph/client_test.go`, `internal/graph/schema_integration_test.go`; Modify `go.mod`/`go.sum`
+**Produces:**
+
+```go
+type Config struct { URI, Username, Password string; MaxPoolSize int; Timeout time.Duration }
+func New(ctx context.Context, cfg Config) (*Client, error)
+func (c *Client) Close(ctx context.Context) error
+func (c *Client) EnsureSchema(ctx context.Context) error
+func (c *Client) Read(ctx context.Context, work func(tx neo4j.ManagedTransaction) (any, error)) (any, error)
+func (c *Client) Write(ctx context.Context, work func(tx neo4j.ManagedTransaction) (any, error)) (any, error)
+```
+
+- [ ] **Step 1: 의존성 추가** — `go get github.com/neo4j/neo4j-go-driver/v5@latest && go mod tidy`
+
+- [ ] **Step 2: 실패하는 테스트 작성** (`client_test.go`)
+
+```go
+func TestNew_RejectsEmptyURI(t *testing.T) {
+	if _, err := New(context.Background(), Config{Username: "neo4j", Password: "x"}); err == nil {
+		t.Fatal("New with empty URI: want error, got nil")
+	}
+}
+func TestNew_RejectsEmptyPassword(t *testing.T) {
+	if _, err := New(context.Background(), Config{URI: "bolt://localhost:7687", Username: "neo4j"}); err == nil {
+		t.Fatal("New with empty password: want error, got nil")
+	}
+}
+```
+Run: `go test ./internal/graph/ -run TestNew -v` → FAIL (`undefined: New`)
+
+- [ ] **Step 3: 클라이언트 구현**
+
+프로세스당 드라이버 1개, 작업 단위마다 짧은 세션, **관리 트랜잭션만** 사용한다(리더 전환·교착 재시도를 드라이버가 처리한다). 세션을 고루틴 간 공유하지 않는다.
+
+```go
+const (defaultGraphTimeout = 10 * time.Second; defaultMaxPoolSize = 10; defaultTxTimeout = 5 * time.Second)
+
+func New(ctx context.Context, cfg Config) (*Client, error) {
+	if cfg.URI == "" { return nil, errors.New("graph: URI must not be empty") }
+	if cfg.Password == "" { return nil, errors.New("graph: password must not be empty") }
+	cfg = withDefaults(cfg) // 빈 Username→"neo4j", Timeout<=0→10s, MaxPoolSize<=0→10
+	d, err := neo4j.NewDriverWithContext(cfg.URI, neo4j.BasicAuth(cfg.Username, cfg.Password, ""),
+		func(c *neo4j.Config) { c.MaxConnectionPoolSize = cfg.MaxPoolSize; c.ConnectionAcquisitionTimeout = cfg.Timeout })
+	if err != nil { return nil, fmt.Errorf("graph: driver: %w", err) }
+	vctx, cancel := context.WithTimeout(ctx, cfg.Timeout); defer cancel()
+	if err := d.VerifyConnectivity(vctx); err != nil {   // 실패 시 드라이버를 닫고 에러 반환
+		_ = d.Close(ctx); return nil, fmt.Errorf("graph: connect: %w", err)
+	}
+	return &Client{driver: d, timeout: cfg.Timeout}, nil
+}
+```
+
+`Read`/`Write`는 각각 `AccessModeRead`/`AccessModeWrite` 세션을 열고 `neo4j.WithTxTimeout(defaultTxTimeout)`으로 `ExecuteRead`/`ExecuteWrite`를 호출한 뒤 `defer session.Close(ctx)` 한다. **`Read`가 쓰기 모드 세션을 절대 쓰지 않는 것**이 §프라이버시 6의 방어선 중 하나다.
+
+- [ ] **Step 4: 스키마 보증 구현** (`schema.go`)
+§그래프 데이터 모델의 DDL 4문을 상수 슬라이스에 담고 `EnsureSchema`가 `Write`로 하나씩 실행한다. 전부 `IF NOT EXISTS`라 반복 실행이 안전하다. Neo4j는 한 트랜잭션에 스키마 변경과 데이터 변경을 섞지 못하므로 **DDL마다 별도 트랜잭션**이다.
+
+- [ ] **Step 5: 단위 테스트 통과 확인** — `go test ./internal/graph/ -run TestNew -v` → PASS
+
+- [ ] **Step 6: 통합 테스트 작성·실행**
+`NEO4J_TEST_URI`가 없으면 `t.Skip`한다(CI는 Neo4j 없이 돈다). 있으면 `EnsureSchema`를 **두 번** 호출해 두 번째도 무오류인지, `SHOW CONSTRAINTS`가 3건인지 확인한다.
+Run: `NEO4J_TEST_URI=bolt://localhost:7687 NEO4J_TEST_PASSWORD="$NEO4J_PASSWORD" go test ./internal/graph/ -run Integration -v` → PASS. 환경변수 없이는 SKIP.
+
+- [ ] **Step 7: 커밋** — `git add go.mod go.sum internal/graph/ && git commit -m "feat(graph): add neo4j client and schema bootstrap"`
+
+### Task 3: 관계 타입 화이트리스트
+
+**Files:** Create `internal/graph/reltypes.go`, `internal/graph/reltypes_test.go`
+**Consumes:** `model.RelationType` 상수 8종
+**Produces:** `func CypherRelType(t model.RelationType) (string, bool)`, `func AllCypherRelTypes() []string`(8종), `const MentionedInRelType = "MENTIONED_IN"`
+
+**이 파일이 따로 존재하는 이유**: Cypher에서 관계 타입은 **파라미터화할 수 없다**(`-[r:$type]-`은 문법 오류). 즉 타입만은 쿼리 문자열에 리터럴로 박히고, 그 값이 DB에서 읽은 문자열이면 그 지점이 유일한 Cypher 인젝션 경로가 된다. 이 파일이 "DB 문자열 → 코드 상수" 매핑을 강제해 그 경로를 닫는다.
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```go
+func TestCypherRelType(t *testing.T) {
+	cases := map[model.RelationType]string{
+		model.RelationCommunicatedWith: "COMMUNICATED_WITH", model.RelationRequestedOf: "REQUESTED_OF",
+		model.RelationCommittedTo: "COMMITTED_TO", model.RelationMentions: "MENTIONS", model.RelationBelongsTo: "BELONGS_TO",
+		model.RelationScheduledWith: "SCHEDULED_WITH", model.RelationAboutTopic: "ABOUT_TOPIC", model.RelationRelatedTo: "RELATED_TO"}
+	for in, want := range cases {
+		if got, ok := CypherRelType(in); !ok || got != want {
+			t.Errorf("CypherRelType(%q) = %q,%v; want %q,true", in, got, ok, want)
+		}
+	}
+}
+func TestCypherRelType_RejectsUnknown(t *testing.T) {
+	for _, raw := range []string{"", "drop_all", "RELATED_TO", "MENTIONS`]->() DETACH DELETE n //"} {
+		if got, ok := CypherRelType(model.RelationType(raw)); ok {
+			t.Errorf("CypherRelType(%q) = %q,true; want ok=false", raw, got)
+		}
+	}
+}
+func TestAllCypherRelTypes_HasEightEntries(t *testing.T) {
+	if n := len(AllCypherRelTypes()); n != 8 { t.Errorf("length = %d, want 8", n) }
+}
+```
+
+대문자 `"RELATED_TO"`가 거부되어야 하는 이유: 입력은 항상 Postgres에 저장된 소문자 어휘이므로, 대문자가 들어왔다는 것은 어딘가에서 이미 변환된 값이라는 뜻이고 그 경로를 통과시키면 안 된다.
+
+- [ ] **Step 2: 테스트 실패 확인** — `go test ./internal/graph/ -run TestCypherRelType -v` → FAIL
+
+- [ ] **Step 3: 구현** — `map[model.RelationType]string` 리터럴 하나, 조회 함수, 정렬된 값 슬라이스 반환 함수. 맵 밖의 어떤 문자열도 통과시키지 않는다.
+
+- [ ] **Step 4: 통과 확인 후 커밋** — `go test ./internal/graph/ -v` → PASS. `git add internal/graph/reltypes*.go && git commit -m "feat(graph): whitelist cypher relationship type literals"`
+
+### Task 4: 투영용 Postgres 읽기 쿼리
+
+**Files:** Create `internal/model/projection.go`, `internal/store/graph_source.go`, `internal/store/graph_source_test.go`
+**Produces:**
+
+```go
+// internal/model/projection.go
+type ProjectionRelation struct { ID int64; FromEntityID int64; FromName, FromType string
+	ToEntityID int64; ToName, ToType string; Type RelationType
+	EvidenceDocumentID string /* UUID 문자열 */; Confidence float64; ObservedAt time.Time }
+type ProjectionMention struct { DocumentID, SourceType string; OccurredAt *time.Time
+	EntityID int64; EntityName, EntityType string }
+type GraphProjectionState struct { LastRelationID int64; ResetToken string }
+
+// internal/store/graph_source.go
+func NewGraphSource(pg *Postgres) *GraphSource
+func (s *GraphSource) ListRelationsAfter(ctx context.Context, afterID int64, limit int) ([]model.ProjectionRelation, error)
+func (s *GraphSource) ListMentionsAfter(ctx context.Context, afterDocumentID string, afterEntityID int64, limit int) ([]model.ProjectionMention, error)
+```
+
+- [ ] **Step 1: 실패하는 단위 테스트 작성**
+
+이 저장소의 `internal/store` 테스트는 순수 함수만 다룬다(DB를 띄우지 않는다). 그래서 여기서는 인자 검증과 커서 절 구성만 단위 테스트하고, SQL 자체는 Step 4에서 실제 DB로 검증한다.
+
+```go
+func TestListRelationsAfter_RejectsNonPositiveLimit(t *testing.T) {
+	if _, err := (&GraphSource{}).ListRelationsAfter(context.Background(), 0, 0); err == nil {
+		t.Fatal("limit=0: want error, got nil")
+	}
+}
+func TestMentionCursorClause(t *testing.T) {
+	if got := mentionCursorClause(""); got != "" { t.Errorf("empty cursor = %q, want %q", got, "") }
+	if got := mentionCursorClause("some-uuid"); got == "" { t.Error("non-empty cursor: want WHERE clause") }
+}
+```
+Run: `go test ./internal/store/ -run "TestListRelationsAfter|TestMentionCursor" -v` → FAIL
+
+- [ ] **Step 2: 관계 쿼리 구현** — 관계와 양 끝 엔티티를 **한 번에** 가져온다(변경 3-2).
+
+```sql
+SELECT r.id, fe.id, fe.name, fe.type, te.id, te.name, te.type,
+       r.type, r.evidence_document_id, r.confidence, r.observed_at
+  FROM entity_relations r
+  JOIN entities fe ON fe.id = r.from_entity_id
+  JOIN entities te ON te.id = r.to_entity_id
+ WHERE r.id > $1 ORDER BY r.id LIMIT $2
+```
+
+`entity_relations`는 `ON CONFLICT DO NOTHING`으로만 삽입되는 **append-only** 테이블이라(`internal/store/relations.go`) `id` 워터마크가 정확히 맞는다. 단 `BIGSERIAL`은 커밋 순서와 id 순서가 어긋날 수 있어(A가 100을 잡고 B의 101보다 늦게 커밋) 워터마크가 앞질러 나갈 수 있다. **투영이 멱등하므로 겹쳐 읽는 비용이 없다** — 워커가 매번 `watermark - overlap`부터 다시 읽어 이 틈을 메운다(Task 6).
+
+- [ ] **Step 3: 멘션 쿼리 구현**
+
+```sql
+SELECT d.id, d.source_type, d.occurred_at, e.id, e.name, e.type
+  FROM document_entities de
+  JOIN documents d ON d.id = de.document_id
+  JOIN entities  e ON e.id = de.entity_id
+ WHERE d.status = 'active'
+   AND ($1 = '' OR (de.document_id, de.entity_id) > ($1::uuid, $2))
+ ORDER BY de.document_id, de.entity_id LIMIT $3
+```
+
+`document_entities`에는 단조 증가 키가 없다(PK가 복합이고 문서 id는 랜덤 UUID다). keyset 커서로 페이지를 넘기되 **매 사이클 커서 0부터 다시 시작하는 전량 스윕**을 한다 — 랜덤 UUID 특성상 커서보다 "작은" 위치에 새 행이 끼어들어 증분 커서만으로는 누락이 생기기 때문이다. 현재 1,402행이고 이를 만드는 EntityWorker는 사실상 휴면(46,539건 중 142건 처리)이라 전량 스윕이 저렴하다. **임계**: 10만 행 초과 시 `created_at` 컬럼 추가 + 시간 워터마크로 전환(§미해결 위험).
+
+- [ ] **Step 4: 실제 DB로 SQL 검증(읽기 전용)** — 단위 테스트는 SQL 유효성을 증명하지 못한다. **프로덕션(macmini)에 붙지 않는다.**
+
+```bash
+docker compose -f docker-compose.local.yml --env-file .env.local up -d postgres server
+docker compose -f docker-compose.local.yml --env-file .env.local exec postgres psql -U brain -d second_brain \
+  -c "EXPLAIN SELECT r.id, fe.id, fe.name, fe.type, te.id, te.name, te.type, r.type, r.evidence_document_id, r.confidence, r.observed_at FROM entity_relations r JOIN entities fe ON fe.id=r.from_entity_id JOIN entities te ON te.id=r.to_entity_id WHERE r.id > 0 ORDER BY r.id LIMIT 10;"
+```
+Expected: 계획이 출력되고 에러가 없다. 멘션 쿼리도 동일하게 `EXPLAIN`한다. 두 쿼리 모두 PK/인덱스를 타는지 확인한다.
+
+- [ ] **Step 5: 통과 확인 후 커밋** — `go test ./internal/store/ ./internal/model/ -v` → PASS.
+`git add internal/model/projection.go internal/store/graph_source*.go && git commit -m "feat(graph): add postgres read queries for graph projection"`
+
+### Task 5: 투영기 — 멱등 MERGE, 워터마크, 전량 재구축
+
+**Files:** Create `internal/graph/projector.go`, `internal/graph/projector_integration_test.go`
+**Consumes:** Task 2의 `*Client`, Task 3의 `CypherRelType`, Task 4의 model 타입
+**Produces:** `NewProjector(c *Client) *Projector` 와 메서드 `EnsureSchema` / `State(ctx) (model.GraphProjectionState, error)` / `UpsertRelations(ctx, []model.ProjectionRelation) error` / `UpsertMentions(ctx, []model.ProjectionMention) error` / `SetLastRelationID(ctx, int64) error` / `SetResetToken(ctx, string) error` / `Wipe(ctx) error`
+
+- [ ] **Step 1: 실패하는 통합 테스트 작성** (`NEO4J_TEST_URI` 없으면 skip) — 멱등성이 이 작업의 전부다.
+
+```go
+func TestProjector_UpsertRelations_Idempotent(t *testing.T) {
+	p := newTestProjector(t) // NEO4J_TEST_URI 없으면 t.Skip
+	ctx := context.Background()
+	if err := p.Wipe(ctx); err != nil { t.Fatal(err) }
+	if err := p.EnsureSchema(ctx); err != nil { t.Fatal(err) }
+	rows := []model.ProjectionRelation{{
+		ID: 1, FromEntityID: 11, FromName: "더미갑", FromType: "PERSON",
+		ToEntityID: 22, ToName: "더미을", ToType: "PERSON",
+		Type: model.RelationCommunicatedWith,
+		EvidenceDocumentID: "00000000-0000-0000-0000-0000000000aa",
+		Confidence: 0.9, ObservedAt: time.Now().UTC(),
+	}}
+	for i := 0; i < 2; i++ {
+		if err := p.UpsertRelations(ctx, rows); err != nil { t.Fatal(err) }
+	}
+	if got := countRels(t, p); got != 1 { t.Fatalf("rel count after 2 identical upserts = %d, want 1", got) }
+	if got := countNodes(t, p, "Entity"); got != 2 { t.Fatalf("Entity count = %d, want 2", got) }
+}
+
+func TestProjector_State_RoundTrip(t *testing.T) {
+	p := newTestProjector(t); ctx := context.Background()
+	if err := p.Wipe(ctx); err != nil { t.Fatal(err) }
+	if err := p.SetLastRelationID(ctx, 42); err != nil { t.Fatal(err) }
+	st, err := p.State(ctx); if err != nil { t.Fatal(err) }
+	if st.LastRelationID != 42 { t.Fatalf("LastRelationID = %d, want 42", st.LastRelationID) }
+}
+```
+
+픽스처 이름은 반드시 가공된 더미다.
+Run: `NEO4J_TEST_URI=... NEO4J_TEST_PASSWORD=... go test ./internal/graph/ -run TestProjector -v` → FAIL
+
+- [ ] **Step 2: 관계 업서트 구현** — 행을 **관계 타입별로 묶고**, 묶음마다 `CypherRelType`으로 얻은 리터럴로 `UNWIND` 문 하나를 만든다. 화이트리스트 밖 타입은 건너뛰고 카운트만 로그한다.
+
+```cypher
+UNWIND $rows AS row   // row.from/row.to = {name, normalizedName, type} 맵
+MERGE (a:Entity {pgId: row.fromId}) ON CREATE SET a += row.from ON MATCH SET a += row.from
+MERGE (b:Entity {pgId: row.toId})   ON CREATE SET b += row.to   ON MATCH SET b += row.to
+MERGE (a)-[r:COMMUNICATED_WITH {pgId: row.pgId}]->(b)
+  ON CREATE SET r.evidencePgId=row.evidencePgId, r.confidence=row.confidence, r.observedAt=datetime(row.observedAt)
+```
+
+`COMMUNICATED_WITH` 자리에만 화이트리스트 리터럴이 들어가고 **나머지는 전부 `$rows` 파라미터**다. 관계 `MERGE` 키가 `pgId`이므로 몇 번을 돌려도 엣지가 하나다. 관계에 `ON MATCH`를 걸지 않는 이유는 `entity_relations`가 append-only라 기존 행 속성이 바뀌지 않기 때문이고, 엔티티 이름은 정규화 규칙 변화에 따라 갱신되어야 하므로 `ON MATCH SET`을 건다.
+
+보조 라벨(`:Person`/`:Org`/`:Topic`/`:Other`)은 타입별로 행을 한 번 더 묶어 `MATCH (e:Entity {pgId: row.pgId}) SET e:Person` 형태의 **별도 문**으로 붙인다 — 라벨도 파라미터화가 불가능하므로 엔티티 타입 4종 역시 코드 상수 매핑을 거친다.
+
+배치 하나(기본 500행)가 트랜잭션 하나다. `Eager` 연산자를 피하려고 한 문장에 읽기와 쓰기를 섞지 않는다.
+
+- [ ] **Step 3: 멘션 업서트 구현**
+
+```cypher
+UNWIND $rows AS row   // row.doc = {sourceType, occurredAt}, row.entity = {name, normalizedName, type}
+MERGE (d:Document {pgId: row.documentId}) ON CREATE SET d += row.doc ON MATCH SET d += row.doc
+MERGE (e:Entity {pgId: row.entityId})     ON CREATE SET e += row.entity
+MERGE (e)-[m:MENTIONED_IN]->(d) ON CREATE SET m.evidencePgId=row.documentId
+```
+
+`occurredAt`이 null일 수 있으므로 Go에서 `nil`을 그대로 넘긴다. **`:Document`에 제목·본문을 절대 넣지 않는다**(§프라이버시 1).
+
+- [ ] **Step 4: 상태·와이프 구현**
+
+```cypher
+MERGE (p:ProjectionState {id: 'singleton'})
+  ON CREATE SET p.lastRelationId=0, p.resetToken='', p.updatedAt=datetime()
+RETURN p.lastRelationId AS lastRelationId, coalesce(p.resetToken,'') AS resetToken
+```
+
+`Wipe`는 반환 카운트가 0이 될 때까지 `MATCH (n) WITH n LIMIT 10000 DETACH DELETE n RETURN count(*)`를 반복한다. `CALL {...} IN TRANSACTIONS`는 관리 트랜잭션 안에서 쓸 수 없으므로 사용하지 않는다. `Wipe`는 `:ProjectionState`까지 지운다 — 그래야 다음 사이클이 워터마크 0에서 시작한다.
+
+- [ ] **Step 5: 통합 테스트 통과 확인** — 위 Run 명령 → PASS(관계 1개, 엔티티 2개, 워터마크 42)
+
+- [ ] **Step 6: 쿼리 계획 확인**
+```bash
+docker compose -f docker-compose.local.yml --env-file .env.local exec neo4j cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
+  "PROFILE MATCH (a:Entity {pgId: 11})-[r]-(b:Entity) RETURN count(r)"
+```
+Expected: 계획에 `NodeUniqueIndexSeek`가 있고 `AllNodesScan`이 없다.
+
+- [ ] **Step 7: 커밋** — `git add internal/graph/projector*.go && git commit -m "feat(graph): add idempotent projector with watermark and rebuild"`
+
+### Task 6: 투영 워커와 collector 배선
+
+**Files:** Create `internal/worker/graph_projection_worker.go`, `internal/worker/graph_projection_worker_test.go`; Modify `cmd/collector/main.go`(312행 근처)
+**Consumes:** Task 4의 `GraphSource`, Task 5의 `Projector`
+**Produces:**
+
+```go
+type GraphProjectionSource interface {
+	ListRelationsAfter(ctx context.Context, afterID int64, limit int) ([]model.ProjectionRelation, error)
+	ListMentionsAfter(ctx context.Context, afterDocumentID string, afterEntityID int64, limit int) ([]model.ProjectionMention, error)
+}
+// GraphProjector: Task 5 Projector의 7개 메서드(EnsureSchema/State/UpsertRelations/
+// UpsertMentions/SetLastRelationID/SetResetToken/Wipe)를 동일 시그니처로 선언한 인터페이스.
+// 테스트가 fake를 끼울 수 있도록 worker 패키지에 둔다.
+type GraphProjectionWorkerConfig struct {
+	Source GraphProjectionSource; Projector GraphProjector
+	Interval time.Duration // 기본 5m
+	BatchSize int          // 기본 500
+	Overlap  int64         // 기본 1000
+	ResetToken string
+}
+func NewGraphProjectionWorker(cfg GraphProjectionWorkerConfig) *GraphProjectionWorker
+func (w *GraphProjectionWorker) Run(ctx context.Context)
+```
+
+**패턴**: `ExtractionWorker`를 그대로 따른다 — `Run`이 ticker를 돌리고 `tick`이 배치를 **직렬로** 처리하며 개별 실패가 워커를 죽이지 않는다. LLM을 부르지 않으므로 3중 데드라인이 필요 없고 tick당 `context.WithTimeout` 하나(기본 2분)면 충분하다.
+
+**한 tick의 순서**: (1) 첫 성공 연결에서 `EnsureSchema` 1회(성공 여부를 필드에 기억) → (2) `State()` 조회, `st.ResetToken != cfg.ResetToken`이면 `Wipe()` → `SetResetToken` → 워터마크 0에서 시작 → (3) 관계: `from := max(0, st.LastRelationID - cfg.Overlap)`부터 `ListRelationsAfter` → `UpsertRelations` → 배치 최대 id로 `SetLastRelationID`, 빈 배치까지 반복하되 tick당 최대 20배치 → (4) 멘션: 커서 빈 값부터 페이지 단위 전량 스윕 → (5) 건수·소요시간만 로그(이름 금지, §프라이버시 4).
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```go
+func TestGraphProjectionWorker_TickAdvancesWatermark(t *testing.T) {
+	src := &fakeGraphSource{relations: []model.ProjectionRelation{{ID: 7}, {ID: 9}}}
+	proj := &fakeProjector{}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{Source: src, Projector: proj, BatchSize: 10, Overlap: 1000}).
+		tick(context.Background())
+	if proj.lastRelationID != 9 { t.Fatalf("lastRelationID = %d, want 9", proj.lastRelationID) }
+}
+
+func TestGraphProjectionWorker_ResetTokenTriggersWipe(t *testing.T) {
+	proj := &fakeProjector{state: model.GraphProjectionState{LastRelationID: 100, ResetToken: "old"}}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{Source: &fakeGraphSource{}, Projector: proj, ResetToken: "new"}).
+		tick(context.Background())
+	if !proj.wiped { t.Fatal("reset token changed: want Wipe() called") }
+	if proj.resetToken != "new" { t.Fatalf("resetToken = %q, want %q", proj.resetToken, "new") }
+}
+func TestGraphProjectionWorker_SurvivesProjectorError(t *testing.T) {
+	proj := &fakeProjector{upsertErr: errors.New("neo4j down")}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{
+		Source: &fakeGraphSource{relations: []model.ProjectionRelation{{ID: 1}}}, Projector: proj,
+	}).tick(context.Background()) // panic 하지 않아야 한다
+	if proj.lastRelationID != 0 {
+		t.Fatalf("watermark advanced past a failed batch: %d, want 0", proj.lastRelationID)
+	}
+}
+```
+
+세 번째가 핵심 안전 속성이다 — **실패한 배치를 건너뛰고 워터마크가 전진하면 데이터가 영구 유실된다.**
+Run: `go test ./internal/worker/ -run TestGraphProjectionWorker -v` → FAIL
+
+- [ ] **Step 2: 워커 구현** — 위 tick 순서대로. `Run`은 `ExtractionWorker.Run`처럼 즉시 1회 tick 후 ticker 루프, `ctx.Done()`에서 반환.
+
+- [ ] **Step 3: 테스트 통과 확인** — 위 Run → PASS
+
+- [ ] **Step 4: collector 배선** — structural signal worker 배선(312행) 바로 뒤. `EXTRACTION_ENABLED`와 **별개 플래그**를 쓴다 — 추출은 LLM 비용이 걸린 결정이고 투영은 아니므로, 한 스위치로 묶으면 한쪽만 끌 방법이 없다.
+
+```go
+// --- Graph projection (Part B) ---
+// Neo4j는 파생 투영이므로 연결 실패가 collector를 죽이면 안 된다.
+gv := os.Getenv("GRAPH_PROJECTION_ENABLED")
+graphEnabled := gv == "true" || gv == "1"
+wg.Add(1)
+go func() {
+	defer wg.Done()
+	if !graphEnabled { // WaitGroup 균형을 위해 종료까지 대기 (기존 워커들과 동일 패턴)
+		slog.Info("graph projection disabled (set GRAPH_PROJECTION_ENABLED=true to enable)")
+		<-ctx.Done(); return
+	}
+	gc, err := graph.New(ctx, graph.Config{URI: os.Getenv("NEO4J_URI"),
+		Username: os.Getenv("NEO4J_USERNAME"), Password: os.Getenv("NEO4J_PASSWORD")})
+	if err != nil {
+		slog.Error("graph projection disabled — neo4j unavailable", "err", err)
+		<-ctx.Done(); return
+	}
+	defer func() { _ = gc.Close(context.Background()) }()
+	worker.NewGraphProjectionWorker(worker.GraphProjectionWorkerConfig{
+		Source: store.NewGraphSource(pg), Projector: graph.NewProjector(gc),
+		Interval:  envDuration("GRAPH_PROJECTION_INTERVAL", 5*time.Minute),
+		BatchSize: envInt("GRAPH_PROJECTION_BATCH_SIZE", 500),
+		ResetToken: os.Getenv("GRAPH_PROJECTION_RESET_TOKEN"),
+	}).Run(ctx)
+}()
+```
+
+기동 시 접속 실패를 영구 비활성으로 처리하는 것은 의도된 단순화다 — 나중에 Neo4j를 띄우면 collector를 재시작하면 된다. `depends_on`을 걸지 않기로 한 결정(변경 3-3)과 짝을 이룬다.
+
+- [ ] **Step 5: 빌드·전체 테스트 후 커밋** — `go build ./... && go test ./... 2>&1 | tail -20` → 실패 없음.
+`git add internal/worker/graph_projection_worker*.go cmd/collector/main.go && git commit -m "feat(graph): wire graph projection worker into collector"`
+
+### Task 7: 읽기 쿼리 카탈로그
+
+**Files:** Create `internal/graph/queries.go`, `queries_test.go`, `queries_integration_test.go`
+**Produces:**
+
+```go
+type EntryFilter  struct { Since time.Time; MinConfidence float64; EntityTypes []string; Limit int }
+type ExpandFilter struct { EntityPgID int64; Since time.Time; MinConfidence float64; RelTypes []string; Limit int }
+type EntryNode struct { PgID int64 `json:"entity_id"`; Name string `json:"name"`; Type string `json:"type"`; Degree int64 `json:"degree"` }
+type Neighbor  struct { PgID int64 `json:"entity_id"`; Name string `json:"name"`; Type string `json:"type"`
+                        RelType string `json:"rel_type"`; Direction string `json:"direction"` // "out"|"in"
+                        Weight int64 `json:"weight"`; LastSeen time.Time `json:"last_seen"` }
+type EvidenceRef struct { DocumentID string `json:"document_id"`; SourceType string `json:"source_type"`
+                        OccurredAt *time.Time `json:"occurred_at"`
+                        Confidence float64 `json:"confidence"`; ObservedAt time.Time `json:"observed_at"` }
+type EntityHit  struct { PgID int64 `json:"entity_id"`; Name string `json:"name"`; Type string `json:"type"` }
+func NewReader(c *Client) *Reader
+func (r *Reader) EntryPoints(ctx context.Context, f EntryFilter) ([]EntryNode, error)
+func (r *Reader) Expand(ctx context.Context, f ExpandFilter) ([]Neighbor, error)
+func (r *Reader) Evidence(ctx context.Context, fromPgID, toPgID int64, relType string, limit int) ([]EvidenceRef, error)
+func (r *Reader) SearchEntities(ctx context.Context, prefix string, limit int) ([]EntityHit, error)
+```
+
+**상한** (전부 서버에서 clamp): 진입점 20/최대 50, 확장 50/최대 200, 근거 20/최대 100, 검색 10/최대 50, 트랜잭션 타임아웃 5초.
+
+- [ ] **Step 1: clamp·화이트리스트 테스트 작성**
+
+```go
+func TestClampLimit(t *testing.T) {
+	for _, c := range []struct{ in, def, max, want int }{{0,20,50,20},{-5,20,50,20},{10,20,50,10},{999,20,50,50}} {
+		if got := clampLimit(c.in, c.def, c.max); got != c.want {
+			t.Errorf("clampLimit(%d,%d,%d) = %d, want %d", c.in, c.def, c.max, got, c.want)
+		}
+	}
+}
+func TestSanitizeRelTypes_DropsUnknown(t *testing.T) {
+	if got := sanitizeRelTypes([]string{"COMMUNICATED_WITH", "DROP_EVERYTHING", "MENTIONS"}); len(got) != 2 {
+		t.Fatalf("kept %d entries, want 2 (%v)", len(got), got)
+	}
+}
+```
+
+`sanitizeRelTypes`는 Task 3의 `AllCypherRelTypes()` 집합만 통과시킨다. 관계 타입은 파라미터로 넘길 수 있는 자리(`type(r) IN $relTypes`)에서만 쓰지만 화이트리스트를 한 번 더 거쳐 오타·탐색 시도를 조기에 잘라낸다.
+Run: `go test ./internal/graph/ -run "TestClampLimit|TestSanitizeRelTypes" -v` → FAIL
+
+- [ ] **Step 2: 진입점 쿼리 구현**
+
+```cypher
+MATCH (e:Entity)-[r]-(:Entity)
+WHERE r.observedAt >= datetime($since) AND r.confidence >= $minConfidence
+  AND (size($types) = 0 OR e.type IN $types)
+WITH e, count(r) AS degree
+ORDER BY degree DESC, e.pgId ASC LIMIT $limit
+RETURN e.pgId AS pgId, e.name AS name, e.type AS type, degree
+```
+
+이 쿼리만 전역 관계 스캔을 한다(관계 수천 개에서 수 밀리초). `e.pgId ASC` 2차 정렬은 동점 시 순서가 흔들려 화면이 매번 달라지는 것을 막는다.
+
+- [ ] **Step 3: 확장 쿼리 구현**
+
+```cypher
+MATCH (e:Entity {pgId: $pgId})-[r]-(n:Entity)
+WHERE r.observedAt >= datetime($since) AND r.confidence >= $minConfidence
+  AND (size($relTypes) = 0 OR type(r) IN $relTypes)
+WITH n, type(r) AS relType,
+     CASE WHEN startNode(r) = e THEN 'out' ELSE 'in' END AS direction,
+     count(r) AS weight, max(r.observedAt) AS lastSeen
+ORDER BY weight DESC, lastSeen DESC, n.pgId ASC LIMIT $limit
+RETURN n.pgId AS pgId, n.name AS name, n.type AS type, relType, direction, weight, lastSeen
+```
+
+`e`가 유니크 제약 인덱스로 seek되므로 슈퍼노드여도 확장 범위가 그 노드의 이웃으로 한정되고 `LIMIT`이 결과를 자른다. 가변 길이 경로를 쓰지 않는다 — 화면은 항상 1홉씩만 확장한다.
+
+- [ ] **Step 4: 근거·검색 쿼리 구현**
+
+```cypher
+MATCH (a:Entity {pgId: $from})-[r]-(b:Entity {pgId: $to}) WHERE type(r) = $relType
+MATCH (d:Document {pgId: r.evidencePgId})
+RETURN d.pgId AS documentId, d.sourceType AS sourceType, d.occurredAt AS occurredAt,
+       r.confidence AS confidence, r.observedAt AS observedAt
+ORDER BY r.observedAt DESC LIMIT $limit
+```
+```cypher
+MATCH (e:Entity) WHERE e.normalizedName STARTS WITH $prefix
+RETURN e.pgId AS pgId, e.name AS name, e.type AS type ORDER BY e.normalizedName ASC LIMIT $limit
+```
+
+`CONTAINS`가 아니라 `STARTS WITH`를 쓰는 이유: range 인덱스는 접두 매치를 가속하지만 부분 문자열은 가속하지 못한다. 부분 검색이 필요해지면 text/full-text 인덱스를 추가한다(범위 밖).
+
+모든 쿼리는 `Client.Read`(읽기 모드 세션 + 5초 트랜잭션 타임아웃)로만 실행한다. **문자열 연결로 Cypher를 만들지 않는다** — 위 4개 문자열은 전부 상수이고 값은 전부 `$param`이다.
+
+- [ ] **Step 5: 단위 테스트 통과 확인** — `go test ./internal/graph/ -v` → PASS
+
+- [ ] **Step 6: 통합 테스트로 계획 검증** — 더미 그래프(엔티티 3개, 관계 4개)를 만들고 4개 쿼리의 결과 개수·정렬을 확인한 뒤, `EXPLAIN`으로 진입점 쿼리 외에는 `AllNodesScan`이 없음을 확인한다.
+Run: `NEO4J_TEST_URI=bolt://localhost:7687 NEO4J_TEST_PASSWORD="$NEO4J_PASSWORD" go test ./internal/graph/ -run Integration -v` → PASS
+
+- [ ] **Step 7: 커밋** — `git add internal/graph/queries*.go && git commit -m "feat(graph): add fixed read-only cypher query catalogue"`
+
+### Task 8: 읽기 API 엔드포인트
+
+**Files:** Create `internal/api/graph.go`, `internal/api/graph_test.go`; Modify `internal/api/router.go`, `cmd/server/main.go`
+**Produces:** `type GraphReader interface`(Task 7 `Reader`의 4개 메서드와 동일 시그니처, 테스트용 fake를 위해 선언), `func (s *Server) WithGraph(g GraphReader) *Server`
+
+**라우트** (기존 Bearer 인증 그룹 안, `s.graph != nil`일 때만 등록):
+
+| 메서드 · 경로 | 파라미터 |
+|---|---|
+| `GET /api/v1/graph/entry` | `days`(기본 30), `min_confidence`(기본 0.5), `types`(CSV), `limit` |
+| `GET /api/v1/graph/expand` | `entity_id`(필수), `days`, `min_confidence`, `rel_types`(CSV), `limit` |
+| `GET /api/v1/graph/evidence` | `from`, `to`, `rel_type`(전부 필수), `limit` |
+| `GET /api/v1/graph/entities` | `q`(1자 이상 필수), `limit` |
+
+**GET만 노출한다.** 쓰기 라우트를 아예 만들지 않는 것이 이 API가 그래프를 변경할 수 없다는 가장 단순한 보증이다.
+
+- [ ] **Step 1: 실패하는 핸들러 테스트 작성**
+
+```go
+func TestGraphEntryHandler_ClampsLimit(t *testing.T) {
+	fake := &fakeGraphReader{}
+	srv := newTestServer(t).WithGraph(fake)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/graph/entry?limit=9999", nil)
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder(); srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK { t.Fatalf("status = %d, want 200", rr.Code) }
+	if fake.lastEntryFilter.Limit != 50 { t.Fatalf("Limit = %d, want clamped to 50", fake.lastEntryFilter.Limit) }
+}
+
+func TestGraphExpandHandler_RequiresEntityID(t *testing.T) {
+	// entity_id 없는 요청 → 400, reader 호출 없음
+}
+
+func TestGraphRoutes_NotRegisteredWithoutWithGraph(t *testing.T) {
+	srv := newTestServer(t) // WithGraph 미호출
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/graph/entry", nil)
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder(); srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound { t.Fatalf("status = %d, want 404 when graph is not wired", rr.Code) }
+}
+```
+
+세 번째 테스트가 §롤백의 "플래그 off만으로 기능이 사라진다"를 코드로 고정한다.
+Run: `go test ./internal/api/ -run TestGraph -v` → FAIL(`WithGraph` 미정의)
+
+- [ ] **Step 2: 라우터 배선** — `Server`에 `graph GraphReader` 필드와 `WithGraph`를 추가하고, `buildHandler`의 Bearer 그룹 안(`/api/v1/notes` 등록부 근처)에 `if s.graph != nil { r.Get(...) × 4 }`를 넣는다. 기존 `WithNotes`/`WithCollectStatus`와 완전히 같은 모양이다.
+
+- [ ] **Step 3: 핸들러 구현** — (1) 파라미터 파싱 + clamp, (2) `days` → `time.Now().AddDate(0,0,-days)`, (3) reader 호출, (4) `{"nodes":[...]}` / `{"neighbors":[...]}` / `{"evidence":[...]}` / `{"entities":[...]}` 반환. reader 에러는 **503**으로 매핑한다 — Neo4j가 죽었을 때 500이 아니라 503이어야 프런트가 "그래프 일시 사용 불가"를 정확히 구분한다. 에러 로그에는 오류 문자열과 엔드포인트명만 남기고 파라미터 값을 남기지 않는다.
+
+- [ ] **Step 4: server 배선** — `NEO4J_URI`와 `NEO4J_PASSWORD`가 **둘 다** 있을 때만 `graph.New`를 호출하고 성공 시 `srv = srv.WithGraph(graph.NewReader(gc))`. 실패하면 경고 로그만 남기고 그래프 라우트 없이 계속 기동한다 — 그래프 때문에 API 서버가 죽으면 안 된다.
+
+- [ ] **Step 5: 통과 확인 후 커밋** — `go test ./internal/api/ -run TestGraph -v && go build ./...` → PASS.
+`git add internal/api/graph*.go internal/api/router.go cmd/server/main.go && git commit -m "feat(graph): expose read-only graph query endpoints"`
+
+### Task 9: 웹 프록시 라우트와 API 클라이언트
+
+**Files:** Create `web/src/app/api/graph/{entry,expand,evidence,entities}/route.ts`; Modify `web/src/lib/types.ts`, `web/src/lib/api.ts`
+**Produces:**
+
+```ts
+export interface GraphNode { entity_id: number; name: string; type: string; degree: number }
+export interface GraphNeighbor { entity_id: number; name: string; type: string;
+  rel_type: string; direction: "out" | "in"; weight: number; last_seen: string }
+export interface GraphEvidence { document_id: string; source_type: string;
+  occurred_at: string | null; confidence: number; observed_at: string }
+export interface GraphEntityHit { entity_id: number; name: string; type: string }
+export interface GraphFilters { days: number; minConfidence: number; entityTypes: string[]; relTypes: string[] }
+
+export async function getGraphEntry(f: GraphFilters, limit?: number): Promise<GraphNode[]>
+export async function expandGraphNode(entityId: number, f: GraphFilters, limit?: number): Promise<GraphNeighbor[]>
+export async function getGraphEvidence(from: number, to: number, relType: string): Promise<GraphEvidence[]>
+export async function searchGraphEntities(q: string): Promise<GraphEntityHit[]>
+```
+
+- [ ] **Step 1: 프록시 라우트 4개 작성** — `web/src/app/api/documents/recent/route.ts`를 **글자 그대로 본떠서** 만든다(`BRAIN_API_URL` + `authHeaders()` + 쿼리스트링 전달 + 502 폴백). 새 인증을 붙이지 않는다(Access는 `proxy.ts`가 처리한다).
+
+```ts
+/** GET /api/graph/entry → proxies to GET /api/v1/graph/entry */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const qs = request.nextUrl.searchParams.toString();
+    const upstream = await fetch(`${BRAIN_API_URL}/api/v1/graph/entry${qs ? `?${qs}` : ""}`, {
+      headers: authHeaders(),
+    });
+    const data: unknown = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (err) {
+    console.error("[api/graph/entry] upstream error:", err);   // 본문을 찍지 않는다
+    return NextResponse.json({ error: "upstream error" }, { status: 502 });
+  }
+}
+```
+
+`console.error`에 응답 본문을 찍지 않는다 — 엔티티 이름이 로그로 새는 경로다(§프라이버시 4).
+
+- [ ] **Step 2: 타입과 클라이언트 함수 추가** — 기존 `listRecentByKind` 등과 같은 형태(`fetch` → `res.ok` 검사 → JSON). 503이면 `GraphUnavailableError`를 던져 페이지가 "그래프 일시 사용 불가"를 구분 표시하게 한다.
+
+- [ ] **Step 3: 타입 체크·린트 후 커밋** — `cd web && bun install && bun run type-check && bun run lint` → 오류 없음. **`npm`을 쓰지 않는다.**
+`git add web/src/app/api/graph web/src/lib/api.ts web/src/lib/types.ts && git commit -m "feat(web): add graph API proxy routes and client"`
+
+### Task 10: 그래프 페이지 셸 (필터 + 진입점)
+
+**Files:** Create `web/src/app/graph/page.tsx`; Modify 기존 내비게이션(`web/src/app/page.tsx`)
+**Consumes:** Task 9의 `getGraphEntry`, `searchGraphEntities`, `GraphFilters`
+**Produces:** `GraphFilters` 상태와 선택된 진입점 `entity_id` — Task 11의 캔버스에 그대로 넘어간다
+
+**캔버스 없이 먼저 만드는 이유**: 데이터 경로 전체(브라우저 → Next 프록시 → Go → Neo4j)를 시각화 라이브러리 없이 검증할 수 있어야 한다. 렌더링에서 문제가 생겨도 이 산출물은 그대로 쓸모가 있다.
+
+- [ ] **Step 1: 페이지 작성** — `"use client"`. 상단 필터 4종, 하단 진입점 목록(이름 / 타입 배지 / 연결 수). 기존 관례를 따른다: `@/components/ui`의 `Button`·`Badge`·`Card`·`Spinner`, Tailwind 유틸리티, 실패는 붉은 배너.
+
+| 필터 | UI | 기본값 |
+|---|---|---|
+| 기간 | 7 / 30 / 90일 세그먼트 버튼 | 30일 |
+| 엔티티 타입 | `PERSON`/`ORG`/`CONCEPT`/`OTHER` 토글 배지 | 전체 켬 |
+| 관계 타입 | 8종 토글 배지 | 전체 켬 |
+| 최소 신뢰도 | 0–1 슬라이더(0.05 단위) | 0.5 |
+
+필터 상태는 URL 쿼리스트링에 반영해 새로고침·공유가 되게 한다(`ask/page.tsx`의 `useSearchParams` 방식과 동일).
+
+- [ ] **Step 2: 진입점 로드** — 마운트·필터 변경 시 `getGraphEntry(filters)`. 결과가 비면 "이 조건에 해당하는 엔티티가 없습니다 — 기간을 넓히거나 신뢰도를 낮춰보세요"를 표시한다(추출 전 흔한 상태다).
+
+- [ ] **Step 3: 엔티티 검색 상자** — 2자 이상에서 300ms 디바운스로 `searchGraphEntities(q)`, 선택 시 그 엔티티를 진입점으로 고정.
+
+- [ ] **Step 4: 내비게이션 링크 추가** — 기존 목록(`/ask`, `/documents`, `/capture`, `/dashboard`, `/governance`)과 같은 위치에 `/graph` 추가.
+
+- [ ] **Step 5: 브라우저 렌더 확인** — `cd web && bun run dev` 후 `http://localhost:3000/graph`.
+Expected: 필터가 보이고 진입점 목록 또는 빈 상태 메시지가 나오며 콘솔 에러가 없다. 필터를 바꾸면 URL이 바뀌고 목록이 재로드된다. **타입 체크 통과만으로 완료로 보지 않는다 — 실제 렌더를 확인한다.**
+
+- [ ] **Step 6: 타입 체크·린트 후 커밋** — `cd web && bun run type-check && bun run lint`.
+`git add web/src/app/graph web/src/app/page.tsx && git commit -m "feat(web): add graph page shell with filters and entry points"`
+
+### Task 11: 캔버스 렌더링과 1홉 확장
+
+**Files:** Create `web/src/app/graph/GraphCanvas.tsx`; Modify `web/src/app/graph/page.tsx`, `web/package.json`
+**Produces:** `GraphCanvas` props — `{ nodes, links, onNodeClick, onLinkClick, maskNames }`
+
+- [ ] **Step 1: 기준 번들 크기 측정** (설치 **전에**) — `cd web && bun run build`. 출력 표의 공유 First Load JS와 라우트별 값을 기록한다. Step 5 게이트의 기준선이다.
+
+- [ ] **Step 2: 라이브러리 설치** — `cd web && bun add react-force-graph-2d`.
+우산 패키지 `react-force-graph`가 아니라 **2d 전용**이다(우산 패키지는 three.js를 함께 끌어온다).
+
+- [ ] **Step 3: 캔버스 컴포넌트 작성** — `"use client"`이며 `react-force-graph-2d`를 직접 import한다. 페이지는 **동적으로만** 불러온다.
+
+```tsx
+const GraphCanvas = dynamic(() => import("./GraphCanvas"), { ssr: false, loading: () => <Spinner /> });
+```
+
+`ssr: false`가 필수다 — force-graph는 `window`/`canvas`에 접근하므로 서버 렌더에서 터진다. 동시에 이 지연 로드가 라이브러리를 초기 번들 밖으로 밀어낸다. 노드 색은 타입별 4색, 링크 굵기는 `weight`의 로그 스케일, 링크 라벨은 관계 타입. `maskNames`가 참이면 마스킹된 문자열을 그린다(Task 12).
+
+- [ ] **Step 4: 1홉 확장 배선** — 노드 클릭 → `expandGraphNode(entity_id, filters)` → 이웃을 기존 노드/링크 집합에 **병합**(중복 `entity_id`는 갱신). 이미 확장한 노드는 `expanded: Set<number>`로 기억해 재요청하지 않는다. 전체 그래프를 한 번에 그리지 않는다(hairball 방지, 설계 §6.3). 화면 노드가 300개를 넘으면 확장을 멈추고 "노드가 너무 많습니다 — 필터를 좁히거나 초기화하세요" 배너 + 초기화 버튼을 띄운다(서버 상한과 별개인 **클라이언트 가독성 상한**).
+
+- [ ] **Step 5: 브라우저 확인 + 번들 게이트**
+Expected(렌더): 진입점 20개가 그려지고 노드 클릭 시 이웃이 추가되며 콘솔 에러가 없다. 필터 변경 시 캔버스가 초기화된다.
+Run: `cd web && bun run build`
+Expected(게이트): `/graph` 라우트의 First Load JS가 Step 1 대비 **250KB(gzip) 이내** 증가. 초과하면 `react-force-graph-2d`를 제거하고 `d3-force` + SVG로 전환한다(props 인터페이스가 같으므로 `GraphCanvas.tsx`만 교체하면 된다). 측정값을 커밋 메시지 본문에 기록한다.
+
+- [ ] **Step 6: 타입 체크·린트 후 커밋** — `cd web && bun run type-check && bun run lint`.
+`git add web/package.json web/bun.lock web/src/app/graph && git commit -m "feat(web): render graph canvas with one-hop expansion"`
+
+### Task 12: 근거 패널, 이름 마스킹, 로그 가드
+
+**Files:** Create `web/src/app/graph/EvidencePanel.tsx`, `web/src/app/graph/mask.ts`, `web/src/app/graph/mask.test.ts`, `internal/api/graph_logging_test.go`; Modify `page.tsx`, `GraphCanvas.tsx`
+
+- [ ] **Step 1: 마스킹 테스트 작성** (vitest)
+
+```ts
+describe("maskName", () => {
+  it("keeps the first character and masks the rest", () => {
+    expect(maskName("더미갑")).toBe("더**");
+    expect(maskName("Acme Corp")).toBe("A********");
+  });
+  it("handles short and empty input", () => {
+    expect(maskName("A")).toBe("A"); expect(maskName("")).toBe("");
+  });
+});
+```
+Run: `cd web && bun run test -- mask` → FAIL(`maskName` 미정의)
+
+- [ ] **Step 2: `mask.ts` 구현과 토글 배선** — 토글은 페이지 헤더 체크박스, 상태는 `localStorage`(`graph.maskNames`). 마스킹은 **클라이언트 렌더링 단계에서만** 적용한다(서버 응답·API는 불변). 근거 패널의 이름에도 같은 함수를 적용한다.
+
+- [ ] **Step 3: 근거 패널 구현** — 링크 클릭 → `getGraphEvidence(from, to, rel_type)` → 우측 패널에 문서 목록. 각 항목은 **소스 타입 배지 + 발생 시각 + 신뢰도**만 보여주고 제목·본문은 보여주지 않는다(Neo4j에 애초에 없다). 각 항목은 기존 `/documents/{id}`로 링크한다 — 원문 열람은 그 페이지의 책임이다.
+
+- [ ] **Step 4: 로그 가드 테스트 작성** — 핸들러가 엔티티 이름을 로그에 남기지 않음을 고정한다.
+
+```go
+func TestGraphHandlers_DoNotLogEntityNames(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+	// fake reader가 "더미갑"을 반환하도록 두고 4개 엔드포인트 + 에러 경로를 태운다.
+	if strings.Contains(buf.String(), "더미갑") {
+		t.Fatalf("entity name leaked into logs:\n%s", buf.String())
+	}
+}
+```
+Run: `go test ./internal/api/ -run TestGraphHandlers_DoNotLogEntityNames -v` → PASS(실패하면 핸들러 로그 문에서 이름을 제거한다)
+
+- [ ] **Step 5: 브라우저 확인** — 링크 클릭 시 근거 패널이 열리고 문서 링크가 동작한다. 마스킹 토글을 켜면 캔버스와 패널의 이름이 즉시 마스킹되고 새로고침 후에도 유지된다.
+
+- [ ] **Step 6: 전체 검증 후 커밋**
+```bash
+go test ./... 2>&1 | tail -20
+cd web && bun run type-check && bun run lint && bun run test && cd ..
+git add web/src/app/graph internal/api/graph_logging_test.go
+git commit -m "feat(graph): add evidence panel, name masking, and log guards"
+```
+
+---
+
+## 배포
+
+macmini에서 수행한다. 모든 compose 명령에 `--env-file .env.local`이 붙는다. Task 1–12가 전부 머지된 뒤 시작한다.
+
+**D1 사전 준비**
+- [ ] `.env.local`에 `NEO4J_PASSWORD`(새로 생성한 강한 비밀번호), `NEO4J_URI=bolt://neo4j:7687`, `NEO4J_USERNAME=neo4j`를 채운다. `GRAPH_PROJECTION_ENABLED`는 **아직 `false`로 둔다.**
+- [ ] `docker compose -f docker-compose.local.yml --env-file .env.local config >/dev/null` 로 문법 확인
+
+**D2 Neo4j만 먼저 기동**
+- [ ] `... up -d neo4j` → `... ps neo4j`가 60초 내 `healthy`
+- [ ] `... port neo4j 7687` 이 `127.0.0.1:7687` 인지 확인 (`0.0.0.0`이면 즉시 중단하고 compose를 고친다)
+- [ ] cloudflared 설정에 7474/7687 ingress 항목이 **없는지** 확인
+
+**D3 server 재배포**
+- [ ] `... up -d --build server`
+- [ ] `curl -s -H "Authorization: Bearer $API_KEY" localhost:8081/api/v1/graph/entry | head -c 200`
+      Expected: `{"nodes":[]}` (투영 전이므로 빈 배열이 정상). 404면 `WithGraph` 미배선, 503이면 Neo4j 연결 실패다.
+
+**D4 collector 재배포 후 투영 활성화**
+- [ ] `... up -d --build collector` (플래그가 꺼져 있어 워커는 대기만 한다)
+- [ ] `.env.local`에서 `GRAPH_PROJECTION_ENABLED=true`로 바꾸고 `... up -d collector`로 재생성
+- [ ] `... logs -f collector | grep -i graph` — 건수·소요시간만 있고 **이름이 없어야 한다**
+- [ ] 1 tick(5분) 뒤 카운트 확인:
+```bash
+docker compose -f docker-compose.local.yml --env-file .env.local exec neo4j cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
+  "MATCH (e:Entity) RETURN count(e) AS entities;
+   MATCH ()-[r]->() RETURN type(r) AS relType, count(r) AS n ORDER BY n DESC;"
+```
+Expected: 엔티티·관계 수가 0보다 크고 관계 타입이 화이트리스트 9종 밖으로 나오지 않는다.
+- [ ] **Postgres와 대조한다** — 이 검증이 투영 정확성의 판정이다.
+```bash
+docker compose -f docker-compose.local.yml --env-file .env.local exec postgres \
+  psql -U brain -d second_brain -tAc "SELECT count(*) FROM entity_relations;"
+```
+Expected: Neo4j의 엔티티 간 관계 총합(`MENTIONED_IN` 제외)과 **정확히 일치**. 어긋나면 워터마크가 실패 배치를 건너뛴 것이므로 D6 재구축 후 다시 대조한다.
+- [ ] 두 번째 tick 이후 관계 수가 **늘지 않는지** 확인(멱등성 실증). 새 추출분만큼만 늘어야 한다.
+
+**D5 웹 재배포**
+- [ ] `... up -d --build web`
+- [ ] `https://sb.baekenough.com/graph` → Access 통과 → 진입점 렌더, 노드 클릭 확장, 근거 패널, 마스킹 토글, 콘솔 에러 없음 확인
+
+**D6 전량 재구축 (필요 시)** — 둘 다 PostgreSQL을 건드리지 않는다.
+1. **리셋 토큰**(권장, 무중단): `.env.local`의 `GRAPH_PROJECTION_RESET_TOKEN`을 새 값(예: `2026-08-20-1`)으로 바꾸고 `... up -d collector`. 다음 tick에서 그래프를 비우고 워터마크 0부터 재투영한다. 토큰이 그대로면 재시작해도 다시 비우지 않는다.
+2. **볼륨 삭제**(확실): `... stop neo4j && ... rm -f neo4j && docker volume rm second-brain-local_neo4jdata && ... up -d neo4j && ... restart collector`
+
+수천 건 규모라 어느 쪽이든 수 초~수십 초에 끝난다.
+
+---
+
+## 롤백
+
+**Neo4j는 파생 투영이므로 롤백에 데이터 복구 절차가 없다.** 되돌릴 상태가 진실의 원천에 남지 않도록 설계했다 — 마이그레이션을 추가하지 않고, 워터마크를 Neo4j 안에 두며, `server`/`collector`가 Neo4j에 `depends_on`하지 않는다.
+
+**부분 롤백(기능만 끄기, 30초)**: `.env.local`에 `GRAPH_PROJECTION_ENABLED=false` → `... up -d collector`. 투영이 멈추고 읽기 API·화면은 살아 있으며 그래프는 마지막 상태로 얼어붙는다.
+
+**API·화면까지 끄기**: `NEO4J_URI`를 비우고 `... up -d server web`. server가 `WithGraph`를 호출하지 않아 `/api/v1/graph/*`가 404가 되고(Task 8 Step 1의 세 번째 테스트가 이 동작을 고정한다) `/graph`는 "그래프 일시 사용 불가"를 표시한다.
+
+**완전 제거**:
+```bash
+docker compose -f docker-compose.local.yml --env-file .env.local stop neo4j
+docker compose -f docker-compose.local.yml --env-file .env.local rm -f neo4j
+docker volume rm second-brain-local_neo4jdata
+# 코드 롤백이 필요하면 해당 커밋 revert. 마이그레이션이 없으므로 DB 조치는 없다.
+```
+
+**롤백 후 확인**: `... ps`에 `neo4j`가 없고, 수집·검색·`/ask`가 정상이며, collector 로그에 그래프 관련 에러 반복이 없다.
+
+---
+
+## Self-Review
+
+**1. 설계 문서 커버리지(§6 Part B)**
+
+| 설계 문서 요구 | 대응 |
+|---|---|
+| §6.1 별도 컨테이너, Postgres가 원천, 증분 `MERGE`, 전량 재빌드 | Task 1·5·6 + 배포 D6 |
+| §6.1 Postgres 먼저 쓰고 Neo4j는 그 뒤 — 그래프 실패가 추출을 실패시키지 않음 | Task 6(별도 워커·별도 플래그·`depends_on` 없음) |
+| §6.2 다중 라벨 `(:Entity:Person/Org/Topic)`, `(:Document)` | §그래프 데이터 모델 + Task 5 Step 2 |
+| §6.2 8종 + `MENTIONED_IN`, 전 관계에 `evidence_pg_id`/`confidence`/`observed_at` | §그래프 데이터 모델 + Task 3·5 |
+| §6.2 `MENTIONED_IN`은 기존 `document_entities` 투영(신규 추출 아님) | Task 4 Step 3 |
+| §6.3 전체 그래프 미표시, 진입점 N개 → 1홉 확장 | Task 10·11 |
+| §6.3 필터 4종 | Task 10 Step 1 |
+| §6.3 문서 노드 기본 숨김, "근거 보기"에서만 노출 | Task 12 Step 3 |
+| §6.3/§13 라이브러리·N값 확정 | 변경 2 + Task 11 Step 5 게이트 |
+| §11 프라이버시 | §프라이버시 처리 방침 + Task 12 |
+
+**2. 플레이스홀더 점검**: 모든 작업에 실행 명령과 기대 결과가 있다. 상한값·기본값을 전부 구체 수치로 확정했다.
+
+**3. 타입 일관성**: `model.ProjectionRelation`/`ProjectionMention`/`GraphProjectionState`(Task 4)가 Task 5·6에서 같은 이름으로 쓰인다. `graph.EntryNode`/`Neighbor`/`EvidenceRef`/`EntityHit`(Task 7)의 JSON 태그가 Task 9의 TS 필드명(`entity_id`, `rel_type`, `document_id`…)과 일치한다. `CypherRelType`(Task 3)을 Task 5와 Task 7의 `sanitizeRelTypes`가 동일 시그니처로 참조한다. Task 2의 `withDefaults`는 `New` 내부 헬퍼로 같은 파일에 둔다.
+
+---
+
+## 미해결 위험
+
+| 위험 | 영향 | 언제 다뤄야 하나 |
+|---|---|---|
+| `document_entities`에 단조 증가 키가 없어 전량 스윕에 의존 | 테이블이 커지면 매 tick 비용이 선형 증가 | 10만 행 초과 시 `created_at` 추가 + 시간 워터마크 전환 |
+| Community에는 관계 유니크 제약과 RBAC이 없다 | 중복 방지가 "단일 직렬 writer"라는 **운영 규약**에 의존한다. 두 번째 writer가 생기면 조용히 깨진다 | 워커를 복제하거나 자연어→Cypher를 붙일 때 Enterprise/읽기 복제본 재검토 |
+| 진입점 쿼리가 전역 관계 스캔이다 | 관계 50만 개 규모에서 느려진다 | `degree` 속성 materialize 또는 `observedAt` 관계 인덱스 추가 |
+| 사용자 본인 엔티티가 슈퍼노드가 된다 | 확장 결과가 상한에 잘리는데 그 사실이 화면에 드러나지 않는다 | 응답에 `truncated` 플래그 추가 + UI 표시(후속) |
+| Part A 추출 품질이 미검증이다 | 관계가 부정확하면 그래프도 그만큼 부정확하다. Part B는 이를 교정하지 않는다 | 초기 배치 1,213건 품질 검증 후 신뢰도 기본 하한 재조정 |
+| macmini에 컨테이너가 하나 더 늘어난다 | postgres·server·collector·whisper·web과 메모리를 나눠 쓴다(약 1GB 예약) | 배포 후 `docker stats` 실측, 압박 시 heap 256m로 축소 |
+| 향후 postgres가 ubuntu1로 이전되면 배치 전제가 다시 바뀐다 | Neo4j를 따라 옮길지 macmini에 남길지 재판단 필요 | postgres 이전 계획 착수 시점 |

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/mark3labs/mcp-go v0.54.1
+	github.com/neo4j/neo4j-go-driver/v5 v5.28.4
 	github.com/pgvector/pgvector-go v0.2.2
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/pkoukk/tiktoken-go-loader v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/neo4j/neo4j-go-driver/v5 v5.28.4 h1:7toxehVcYkZbyxV4W3Ib9VcnyRBQPucF+VwNNmtSXi4=
+github.com/neo4j/neo4j-go-driver/v5 v5.28.4/go.mod h1:Vff8OwT7QpLm7L2yYr85XNWe9Rbqlbeb9asNXJTHO4k=
 github.com/pgvector/pgvector-go v0.2.2 h1:Q/oArmzgbEcio88q0tWQksv/u9Gnb1c3F1K2TnalxR0=
 github.com/pgvector/pgvector-go v0.2.2/go.mod h1:u5sg3z9bnqVEdpe1pkTij8/rFhTaMCMNyQagPDLK8gQ=
 github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=

--- a/internal/api/graph.go
+++ b/internal/api/graph.go
@@ -1,0 +1,231 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/graph"
+)
+
+// Graph read API (Part B). Four GET routes over a fixed query catalogue.
+//
+// There is no write route and no endpoint that accepts Cypher. The projection
+// worker is the only writer to Neo4j; this API can only read, and only through
+// graph.Reader's constant queries.
+
+// Default query parameters. Limits are clamped by the graph package so the
+// numbers live in exactly one place.
+const (
+	graphDefaultDays          = 30
+	graphDefaultMinConfidence = 0.5
+	graphMaxDays              = 3650
+)
+
+// GraphReader is the read side of the projection. *graph.Reader satisfies it;
+// declared here so handler tests can substitute a fake.
+type GraphReader interface {
+	EntryPoints(ctx context.Context, f graph.EntryFilter) ([]graph.EntryNode, error)
+	Expand(ctx context.Context, f graph.ExpandFilter) ([]graph.Neighbor, error)
+	Evidence(ctx context.Context, fromPgID, toPgID int64, relType string, limit int) ([]graph.EvidenceRef, error)
+	SearchEntities(ctx context.Context, prefix string, limit int) ([]graph.EntityHit, error)
+}
+
+// WithGraph enables the /api/v1/graph/* routes. Must be called before
+// Handler(); leaving it out is the rollback path — the routes then do not
+// exist at all.
+func (s *Server) WithGraph(g GraphReader) *Server {
+	s.graph = g
+	return s
+}
+
+// --- handlers ---
+
+func (s *Server) graphEntryHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	days, err := parseGraphDays(q.Get("days"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	minConf, err := parseMinConfidence(q.Get("min_confidence"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	nodes, err := s.graph.EntryPoints(r.Context(), graph.EntryFilter{
+		Since:         sinceDays(days),
+		MinConfidence: minConf,
+		EntityTypes:   splitCSV(q.Get("types")),
+		Limit:         graph.ClampEntryLimit(parseIntDefault(q.Get("limit"), 0)),
+	})
+	if err != nil {
+		graphUnavailable(w, "entry", err)
+		return
+	}
+	if nodes == nil {
+		nodes = []graph.EntryNode{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"nodes": nodes})
+}
+
+func (s *Server) graphExpandHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	entityID, err := strconv.ParseInt(strings.TrimSpace(q.Get("entity_id")), 10, 64)
+	if err != nil || entityID <= 0 {
+		writeError(w, http.StatusBadRequest, "entity_id is required and must be a positive integer")
+		return
+	}
+	days, err := parseGraphDays(q.Get("days"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	minConf, err := parseMinConfidence(q.Get("min_confidence"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	neighbors, err := s.graph.Expand(r.Context(), graph.ExpandFilter{
+		EntityPgID:    entityID,
+		Since:         sinceDays(days),
+		MinConfidence: minConf,
+		RelTypes:      splitCSV(q.Get("rel_types")),
+		Limit:         graph.ClampExpandLimit(parseIntDefault(q.Get("limit"), 0)),
+	})
+	if err != nil {
+		graphUnavailable(w, "expand", err)
+		return
+	}
+	if neighbors == nil {
+		neighbors = []graph.Neighbor{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"neighbors": neighbors})
+}
+
+func (s *Server) graphEvidenceHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	from, errFrom := strconv.ParseInt(strings.TrimSpace(q.Get("from")), 10, 64)
+	to, errTo := strconv.ParseInt(strings.TrimSpace(q.Get("to")), 10, 64)
+	relType := strings.TrimSpace(q.Get("rel_type"))
+	if errFrom != nil || errTo != nil || from <= 0 || to <= 0 || relType == "" {
+		writeError(w, http.StatusBadRequest, "from, to and rel_type are required")
+		return
+	}
+
+	refs, err := s.graph.Evidence(r.Context(), from, to, relType,
+		graph.ClampEvidenceLimit(parseIntDefault(q.Get("limit"), 0)))
+	if err != nil {
+		graphUnavailable(w, "evidence", err)
+		return
+	}
+	if refs == nil {
+		refs = []graph.EvidenceRef{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"evidence": refs})
+}
+
+func (s *Server) graphEntitiesHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	prefix := strings.TrimSpace(q.Get("q"))
+	if prefix == "" {
+		writeError(w, http.StatusBadRequest, "q is required")
+		return
+	}
+
+	hits, err := s.graph.SearchEntities(r.Context(), prefix,
+		graph.ClampSearchLimit(parseIntDefault(q.Get("limit"), 0)))
+	if err != nil {
+		graphUnavailable(w, "entities", err)
+		return
+	}
+	if hits == nil {
+		hits = []graph.EntityHit{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"entities": hits})
+}
+
+// --- helpers ---
+
+// graphUnavailable maps a reader failure to 503, not 500: Neo4j is a derived
+// store that can be down while everything else is healthy, and the frontend
+// needs to tell those two cases apart.
+//
+// The log carries the endpoint name and the error only — never query
+// parameters, which contain entity ids and search prefixes (privacy policy §4
+// keeps names out of logs).
+func graphUnavailable(w http.ResponseWriter, endpoint string, err error) {
+	slog.Warn("graph read failed", "endpoint", endpoint, "error", err)
+	writeError(w, http.StatusServiceUnavailable, "graph temporarily unavailable")
+}
+
+func parseIntDefault(raw string, def int) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func parseGraphDays(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return graphDefaultDays, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0, errBadParam("days must be a positive integer")
+	}
+	if n > graphMaxDays {
+		n = graphMaxDays
+	}
+	return n, nil
+}
+
+func parseMinConfidence(raw string) (float64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return graphDefaultMinConfidence, nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v < 0 || v > 1 {
+		return 0, errBadParam("min_confidence must be between 0 and 1")
+	}
+	return v, nil
+}
+
+// errBadParam is a tiny helper so the handlers can return the message
+// verbatim without importing errors in four places.
+type badParamError string
+
+func (e badParamError) Error() string { return string(e) }
+
+func errBadParam(msg string) error { return badParamError(msg) }
+
+func splitCSV(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func sinceDays(days int) time.Time {
+	return time.Now().AddDate(0, 0, -days)
+}

--- a/internal/api/graph_test.go
+++ b/internal/api/graph_test.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/graph"
+)
+
+// --- fake reader ---
+
+type fakeGraphReader struct {
+	lastEntryFilter  graph.EntryFilter
+	lastExpandFilter graph.ExpandFilter
+	lastEvidence     struct {
+		from, to int64
+		relType  string
+		limit    int
+	}
+	lastSearchPrefix string
+	lastSearchLimit  int
+
+	calls int
+	err   error
+}
+
+func (f *fakeGraphReader) EntryPoints(_ context.Context, filter graph.EntryFilter) ([]graph.EntryNode, error) {
+	f.calls++
+	f.lastEntryFilter = filter
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []graph.EntryNode{{PgID: 11, Name: "더미갑", Type: "PERSON", Degree: 3}}, nil
+}
+
+func (f *fakeGraphReader) Expand(_ context.Context, filter graph.ExpandFilter) ([]graph.Neighbor, error) {
+	f.calls++
+	f.lastExpandFilter = filter
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []graph.Neighbor{{PgID: 22, Name: "더미을", Type: "PERSON", RelType: "COMMUNICATED_WITH", Direction: "out", Weight: 2}}, nil
+}
+
+func (f *fakeGraphReader) Evidence(_ context.Context, from, to int64, relType string, limit int) ([]graph.EvidenceRef, error) {
+	f.calls++
+	f.lastEvidence.from, f.lastEvidence.to = from, to
+	f.lastEvidence.relType, f.lastEvidence.limit = relType, limit
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []graph.EvidenceRef{{DocumentID: "00000000-0000-0000-0000-0000000000a1", SourceType: "sms"}}, nil
+}
+
+func (f *fakeGraphReader) SearchEntities(_ context.Context, prefix string, limit int) ([]graph.EntityHit, error) {
+	f.calls++
+	f.lastSearchPrefix, f.lastSearchLimit = prefix, limit
+	if f.err != nil {
+		return nil, f.err
+	}
+	return []graph.EntityHit{{PgID: 11, Name: "더미갑", Type: "PERSON"}}, nil
+}
+
+// --- helpers ---
+
+// newGraphTestServer builds a Server with Bearer auth enabled, mirroring the
+// production wiring (graph routes live inside the authenticated group).
+func newGraphTestServer() *Server {
+	return NewServer(&stubDocumentStore{}, nil, nil, nil, nil, "", "test-key")
+}
+
+func doGraphGet(t *testing.T, srv *Server, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	return rr
+}
+
+// --- tests ---
+
+func TestGraphEntryHandler_ClampsLimit(t *testing.T) {
+	fake := &fakeGraphReader{}
+	srv := newGraphTestServer().WithGraph(fake)
+	rr := doGraphGet(t, srv, "/api/v1/graph/entry?limit=9999")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rr.Code, rr.Body.String())
+	}
+	if fake.lastEntryFilter.Limit != 50 {
+		t.Fatalf("Limit = %d, want clamped to 50", fake.lastEntryFilter.Limit)
+	}
+}
+
+func TestGraphEntryHandler_Defaults(t *testing.T) {
+	fake := &fakeGraphReader{}
+	srv := newGraphTestServer().WithGraph(fake)
+	if rr := doGraphGet(t, srv, "/api/v1/graph/entry"); rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	f := fake.lastEntryFilter
+	if f.MinConfidence != 0.5 {
+		t.Errorf("MinConfidence = %v, want 0.5", f.MinConfidence)
+	}
+	if f.Limit != 20 {
+		t.Errorf("Limit = %d, want 20", f.Limit)
+	}
+	// days defaults to 30 → Since roughly 30 days ago.
+	age := time.Since(f.Since)
+	if age < 29*24*time.Hour || age > 31*24*time.Hour {
+		t.Errorf("Since = %v (age %v), want ~30 days ago", f.Since, age)
+	}
+}
+
+func TestGraphExpandHandler_RequiresEntityID(t *testing.T) {
+	fake := &fakeGraphReader{}
+	srv := newGraphTestServer().WithGraph(fake)
+	rr := doGraphGet(t, srv, "/api/v1/graph/expand")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("reader called %d times, want 0", fake.calls)
+	}
+}
+
+func TestGraphExpandHandler_PassesRelTypes(t *testing.T) {
+	fake := &fakeGraphReader{}
+	srv := newGraphTestServer().WithGraph(fake)
+	rr := doGraphGet(t, srv, "/api/v1/graph/expand?entity_id=11&rel_types=COMMUNICATED_WITH,ABOUT_TOPIC&limit=1000")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if got := fake.lastExpandFilter.RelTypes; len(got) != 2 {
+		t.Fatalf("RelTypes = %v, want 2 entries", got)
+	}
+	if fake.lastExpandFilter.Limit != 200 {
+		t.Fatalf("Limit = %d, want clamped to 200", fake.lastExpandFilter.Limit)
+	}
+}
+
+func TestGraphEvidenceHandler_RequiresAllParams(t *testing.T) {
+	for _, path := range []string{
+		"/api/v1/graph/evidence?to=22&rel_type=MENTIONS",
+		"/api/v1/graph/evidence?from=11&rel_type=MENTIONS",
+		"/api/v1/graph/evidence?from=11&to=22",
+	} {
+		fake := &fakeGraphReader{}
+		srv := newGraphTestServer().WithGraph(fake)
+		if rr := doGraphGet(t, srv, path); rr.Code != http.StatusBadRequest {
+			t.Errorf("%s: status = %d, want 400", path, rr.Code)
+		}
+		if fake.calls != 0 {
+			t.Errorf("%s: reader called %d times, want 0", path, fake.calls)
+		}
+	}
+}
+
+func TestGraphEntitiesHandler_RequiresQuery(t *testing.T) {
+	fake := &fakeGraphReader{}
+	srv := newGraphTestServer().WithGraph(fake)
+	if rr := doGraphGet(t, srv, "/api/v1/graph/entities?q="); rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("reader called %d times, want 0", fake.calls)
+	}
+}
+
+// TestGraphHandler_ReaderErrorIs503: Neo4j is a derived store that may be
+// down while the rest of the API is healthy. 503 (not 500) is what lets the
+// frontend say "graph temporarily unavailable" instead of "something broke".
+func TestGraphHandler_ReaderErrorIs503(t *testing.T) {
+	fake := &fakeGraphReader{err: errors.New("neo4j down")}
+	srv := newGraphTestServer().WithGraph(fake)
+	if rr := doGraphGet(t, srv, "/api/v1/graph/entry"); rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rr.Code)
+	}
+}
+
+// TestGraphRoutes_NotRegisteredWithoutWithGraph pins the rollback story: with
+// the graph unwired the feature simply does not exist in the router.
+func TestGraphRoutes_NotRegisteredWithoutWithGraph(t *testing.T) {
+	srv := newGraphTestServer() // WithGraph not called
+	for _, path := range []string{
+		"/api/v1/graph/entry", "/api/v1/graph/expand",
+		"/api/v1/graph/evidence", "/api/v1/graph/entities",
+	} {
+		if rr := doGraphGet(t, srv, path); rr.Code != http.StatusNotFound {
+			t.Errorf("%s: status = %d, want 404 when graph is not wired", path, rr.Code)
+		}
+	}
+}
+
+// TestGraphRoutes_WriteMethodsNotRegistered: the API exposes GET only, which
+// is the simplest possible proof that it cannot mutate the projection.
+func TestGraphRoutes_WriteMethodsNotRegistered(t *testing.T) {
+	srv := newGraphTestServer().WithGraph(&fakeGraphReader{})
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		req := httptest.NewRequest(method, "/api/v1/graph/entry", nil)
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, req)
+		if rr.Code == http.StatusOK {
+			t.Errorf("%s /api/v1/graph/entry returned 200, want a rejection", method)
+		}
+	}
+}
+
+func TestGraphEntryHandler_ResponseShape(t *testing.T) {
+	srv := newGraphTestServer().WithGraph(&fakeGraphReader{})
+	rr := doGraphGet(t, srv, "/api/v1/graph/entry")
+	var body struct {
+		Nodes []graph.EntryNode `json:"nodes"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, rr.Body.String())
+	}
+	if len(body.Nodes) != 1 || body.Nodes[0].PgID != 11 {
+		t.Fatalf("nodes = %+v, want one node with entity_id 11", body.Nodes)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -97,6 +97,12 @@ type Server struct {
 	// route is registered. Set via WithCollectStatus before calling Handler().
 	collectStatus CollectionStatusProvider
 
+	// graph is optional. When non-nil, the four read-only GET
+	// /api/v1/graph/* routes are registered. Set via WithGraph before calling
+	// Handler(). nil (the default) means the graph feature does not exist in
+	// the router at all — which is the rollback path for Part B.
+	graph GraphReader
+
 	// notesUpserter, notesChunks, and notesEmbedder are optional. When
 	// notesUpserter is non-nil, POST /api/v1/notes,
 	// POST /api/v1/notes/{id}/retry-enrichment, and DELETE /api/v1/notes/{id}
@@ -310,6 +316,14 @@ func (s *Server) buildHandler() http.Handler {
 		}
 		if s.recordingUpserter != nil && s.recordingDir != "" {
 			r.Post("/api/v1/ingest/recording", s.ingestRecordingHandler)
+		}
+		if s.graph != nil {
+			// GET only — no write route exists, which is the simplest
+			// guarantee that this API cannot change the projection.
+			r.Get("/api/v1/graph/entry", s.graphEntryHandler)
+			r.Get("/api/v1/graph/expand", s.graphExpandHandler)
+			r.Get("/api/v1/graph/evidence", s.graphEvidenceHandler)
+			r.Get("/api/v1/graph/entities", s.graphEntitiesHandler)
 		}
 		if s.notesUpserter != nil {
 			r.Post("/api/v1/notes", s.createNoteHandler)

--- a/internal/graph/client.go
+++ b/internal/graph/client.go
@@ -1,0 +1,146 @@
+// Package graph owns every interaction with the Neo4j derived projection.
+//
+// PostgreSQL is the source of truth; Neo4j is a projection that can be thrown
+// away and rebuilt at any time (see the Part B plan, "Global Constraints").
+// Two invariants shape this package:
+//
+//  1. The projection worker is the ONLY writer. Read paths go through
+//     Client.Read, which opens a read-mode session — a Cypher write clause
+//     reaching a read session is rejected by the server, so "the read API
+//     cannot mutate the graph" is enforced by the transport, not by review.
+//  2. Relationship types and node labels cannot be parameterised in Cypher.
+//     Every literal that ends up concatenated into a query string comes from
+//     a code-level whitelist (reltypes.go), never from a database value.
+package graph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+const (
+	// defaultGraphTimeout bounds connection acquisition and the initial
+	// connectivity probe.
+	defaultGraphTimeout = 10 * time.Second
+
+	// defaultMaxPoolSize is deliberately small: one serial projection worker
+	// plus a handful of concurrent read requests.
+	defaultMaxPoolSize = 10
+
+	// defaultTxTimeout is the server-side transaction timeout applied to every
+	// managed transaction. A read query that cannot finish in 5s on a graph of
+	// this size is a bug, and letting it run only holds a connection hostage.
+	defaultTxTimeout = 5 * time.Second
+)
+
+// Config holds the connection settings for the Neo4j projection store.
+type Config struct {
+	URI         string
+	Username    string
+	Password    string
+	MaxPoolSize int
+	Timeout     time.Duration
+}
+
+// Client owns one driver for the whole process. Sessions are short-lived and
+// never shared between goroutines (a neo4j session is not safe for concurrent
+// use); the driver itself is.
+type Client struct {
+	driver  neo4j.DriverWithContext
+	timeout time.Duration
+}
+
+// withDefaults fills in the optional fields. Exported behaviour depends on it
+// only through New, but it is unit-tested directly because these fallbacks are
+// what keep a half-configured deployment bounded.
+func withDefaults(cfg Config) Config {
+	if cfg.Username == "" {
+		cfg.Username = "neo4j"
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultGraphTimeout
+	}
+	if cfg.MaxPoolSize <= 0 {
+		cfg.MaxPoolSize = defaultMaxPoolSize
+	}
+	return cfg
+}
+
+// New validates cfg, constructs the driver and verifies connectivity once.
+// Verification happens here on purpose: callers (collector worker, server
+// wiring) treat a failure as "graph disabled for this process" and must learn
+// about it at startup rather than on the first tick.
+func New(ctx context.Context, cfg Config) (*Client, error) {
+	if cfg.URI == "" {
+		return nil, errors.New("graph: URI must not be empty")
+	}
+	if cfg.Password == "" {
+		return nil, errors.New("graph: password must not be empty")
+	}
+	cfg = withDefaults(cfg)
+
+	d, err := neo4j.NewDriverWithContext(
+		cfg.URI,
+		neo4j.BasicAuth(cfg.Username, cfg.Password, ""),
+		func(c *neo4j.Config) {
+			c.MaxConnectionPoolSize = cfg.MaxPoolSize
+			c.ConnectionAcquisitionTimeout = cfg.Timeout
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("graph: driver: %w", err)
+	}
+
+	vctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	if err := d.VerifyConnectivity(vctx); err != nil {
+		// Close the driver we just built — returning an error while leaving a
+		// live connection pool behind would leak goroutines for the lifetime
+		// of the process.
+		_ = d.Close(ctx)
+		return nil, fmt.Errorf("graph: connect: %w", err)
+	}
+	return &Client{driver: d, timeout: cfg.Timeout}, nil
+}
+
+// Close releases the driver's connection pool.
+func (c *Client) Close(ctx context.Context) error {
+	if c == nil || c.driver == nil {
+		return nil
+	}
+	if err := c.driver.Close(ctx); err != nil {
+		return fmt.Errorf("graph: close: %w", err)
+	}
+	return nil
+}
+
+// Read runs work inside a managed READ transaction. Read never opens a
+// write-mode session: that is one of the defence lines behind "the read API
+// cannot change the graph".
+func (c *Client) Read(ctx context.Context, work func(tx neo4j.ManagedTransaction) (any, error)) (any, error) {
+	session := c.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeRead})
+	defer func() { _ = session.Close(ctx) }()
+
+	out, err := session.ExecuteRead(ctx, work, neo4j.WithTxTimeout(defaultTxTimeout))
+	if err != nil {
+		return nil, fmt.Errorf("graph: read tx: %w", err)
+	}
+	return out, nil
+}
+
+// Write runs work inside a managed WRITE transaction. Only the projection
+// worker (and schema bootstrap) may call this.
+func (c *Client) Write(ctx context.Context, work func(tx neo4j.ManagedTransaction) (any, error)) (any, error) {
+	session := c.driver.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer func() { _ = session.Close(ctx) }()
+
+	out, err := session.ExecuteWrite(ctx, work, neo4j.WithTxTimeout(defaultTxTimeout))
+	if err != nil {
+		return nil, fmt.Errorf("graph: write tx: %w", err)
+	}
+	return out, nil
+}

--- a/internal/graph/client_test.go
+++ b/internal/graph/client_test.go
@@ -1,0 +1,43 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestNew_RejectsEmptyURI and TestNew_RejectsEmptyPassword pin the two
+// argument checks that must happen BEFORE any network call: a misconfigured
+// deployment has to fail loudly at wiring time rather than construct a driver
+// that silently points at nothing.
+func TestNew_RejectsEmptyURI(t *testing.T) {
+	if _, err := New(context.Background(), Config{Username: "neo4j", Password: "x"}); err == nil {
+		t.Fatal("New with empty URI: want error, got nil")
+	}
+}
+
+func TestNew_RejectsEmptyPassword(t *testing.T) {
+	if _, err := New(context.Background(), Config{URI: "bolt://localhost:7687", Username: "neo4j"}); err == nil {
+		t.Fatal("New with empty password: want error, got nil")
+	}
+}
+
+// TestWithDefaults covers the fallbacks so a caller that only sets URI and
+// password still gets a bounded pool and timeout.
+func TestWithDefaults(t *testing.T) {
+	got := withDefaults(Config{URI: "bolt://localhost:7687", Password: "x"})
+	if got.Username != "neo4j" {
+		t.Errorf("Username = %q, want %q", got.Username, "neo4j")
+	}
+	if got.Timeout != defaultGraphTimeout {
+		t.Errorf("Timeout = %v, want %v", got.Timeout, defaultGraphTimeout)
+	}
+	if got.MaxPoolSize != defaultMaxPoolSize {
+		t.Errorf("MaxPoolSize = %d, want %d", got.MaxPoolSize, defaultMaxPoolSize)
+	}
+
+	explicit := withDefaults(Config{URI: "bolt://localhost:7687", Password: "x", Username: "u", Timeout: time.Second, MaxPoolSize: 3})
+	if explicit.Username != "u" || explicit.Timeout != time.Second || explicit.MaxPoolSize != 3 {
+		t.Errorf("withDefaults overwrote explicit values: %+v", explicit)
+	}
+}

--- a/internal/graph/projector.go
+++ b/internal/graph/projector.go
@@ -1,0 +1,336 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// projectionStateID is the fixed key of the single bookkeeping node. The
+// watermark lives in Neo4j rather than PostgreSQL so that deleting the Neo4j
+// volume also deletes the watermark: a watermark that outlived its graph would
+// make the next rebuild resume mid-stream and silently skip everything before
+// it.
+const projectionStateID = "singleton"
+
+// wipeBatchSize bounds one DETACH DELETE transaction. CALL {...} IN
+// TRANSACTIONS is not usable inside a managed transaction, so Wipe loops
+// instead.
+const wipeBatchSize = 10000
+
+// Projector performs the PostgreSQL → Neo4j projection. It is the ONLY writer
+// to the graph; that fact is what replaces the relationship uniqueness
+// constraint Neo4j Community does not offer.
+type Projector struct {
+	c *Client
+}
+
+// NewProjector returns a Projector writing through c.
+func NewProjector(c *Client) *Projector { return &Projector{c: c} }
+
+// EnsureSchema forwards to the client so callers only depend on the projector.
+func (p *Projector) EnsureSchema(ctx context.Context) error { return p.c.EnsureSchema(ctx) }
+
+// normalizeEntityName mirrors store.normalizeEntityName (lower + trim), which
+// is how entities.normalized_name is produced. It is recomputed here rather
+// than carried through the projection row because the derivation is the same
+// pure function on the same input; if that ever stops being true, the column
+// has to be added to the projection query instead.
+func normalizeEntityName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// entityProps builds the property map merged onto an :Entity node.
+func entityProps(name, entityType string) map[string]any {
+	return map[string]any{
+		"name":           name,
+		"normalizedName": normalizeEntityName(name),
+		"type":           entityType,
+	}
+}
+
+// UpsertRelations projects a batch of relations. Rows are grouped by
+// relationship type because the type is a Cypher literal that cannot be
+// parameterised; the literal always comes from CypherRelType, never from the
+// row. Rows whose type is outside the whitelist are dropped (counted, not
+// named — privacy policy §4).
+//
+// The whole batch is one transaction: either the batch lands or the watermark
+// does not move.
+func (p *Projector) UpsertRelations(ctx context.Context, rows []model.ProjectionRelation) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	grouped := map[string][]map[string]any{}
+	skipped := 0
+	for _, r := range rows {
+		relType, ok := CypherRelType(r.Type)
+		if !ok {
+			skipped++
+			continue
+		}
+		grouped[relType] = append(grouped[relType], map[string]any{
+			"pgId":         r.ID,
+			"fromId":       r.FromEntityID,
+			"toId":         r.ToEntityID,
+			"from":         entityProps(r.FromName, r.FromType),
+			"to":           entityProps(r.ToName, r.ToType),
+			"evidencePgId": r.EvidenceDocumentID,
+			"confidence":   r.Confidence,
+			"observedAt":   r.ObservedAt.UTC().Format(time.RFC3339Nano),
+		})
+	}
+	if skipped > 0 {
+		slog.Warn("graph projector: skipped relations with out-of-vocabulary type", "count", skipped)
+	}
+	if len(grouped) == 0 {
+		return nil
+	}
+
+	// Deterministic statement order keeps failures reproducible.
+	relTypes := make([]string, 0, len(grouped))
+	for k := range grouped {
+		relTypes = append(relTypes, k)
+	}
+	sort.Strings(relTypes)
+
+	labelIDs := entityLabelGroups(rows)
+
+	_, err := p.c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		for _, relType := range relTypes {
+			// relType is a whitelist constant; everything else is a $parameter.
+			cypher := `
+				UNWIND $rows AS row
+				MERGE (a:Entity {pgId: row.fromId})
+				  ON CREATE SET a += row.from
+				  ON MATCH  SET a += row.from
+				MERGE (b:Entity {pgId: row.toId})
+				  ON CREATE SET b += row.to
+				  ON MATCH  SET b += row.to
+				MERGE (a)-[r:` + relType + ` {pgId: row.pgId}]->(b)
+				  ON CREATE SET r.evidencePgId = row.evidencePgId,
+				                r.confidence   = row.confidence,
+				                r.observedAt   = datetime(row.observedAt)`
+			if err := runWrite(ctx, tx, cypher, map[string]any{"rows": grouped[relType]}); err != nil {
+				return nil, err
+			}
+		}
+		return nil, applyEntityLabels(ctx, tx, labelIDs)
+	})
+	if err != nil {
+		return fmt.Errorf("graph projector: upsert relations: %w", err)
+	}
+	return nil
+}
+
+// UpsertMentions projects document_entities rows as (:Entity)-[:MENTIONED_IN]->(:Document).
+//
+// :Document carries pgId, sourceType and occurredAt only. Title and content
+// are deliberately absent: a leaked graph volume must expose structure, not
+// conversation text (privacy policy §1).
+func (p *Projector) UpsertMentions(ctx context.Context, rows []model.ProjectionMention) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	payload := make([]map[string]any, 0, len(rows))
+	labels := map[string][]int64{}
+	seenLabel := map[int64]bool{}
+	for _, m := range rows {
+		var occurredAt any // nil stays nil — "unknown" must not become epoch.
+		if m.OccurredAt != nil {
+			occurredAt = m.OccurredAt.UTC().Format(time.RFC3339Nano)
+		}
+		payload = append(payload, map[string]any{
+			"documentId": m.DocumentID,
+			"sourceType": m.SourceType,
+			"occurredAt": occurredAt,
+			"entityId":   m.EntityID,
+			"entity":     entityProps(m.EntityName, m.EntityType),
+		})
+		if label, ok := CypherEntityLabel(m.EntityType); ok && !seenLabel[m.EntityID] {
+			seenLabel[m.EntityID] = true
+			labels[label] = append(labels[label], m.EntityID)
+		}
+	}
+
+	const cypher = `
+		UNWIND $rows AS row
+		MERGE (d:Document {pgId: row.documentId})
+		  ON CREATE SET d.sourceType = row.sourceType,
+		                d.occurredAt = CASE WHEN row.occurredAt IS NULL THEN NULL ELSE datetime(row.occurredAt) END
+		  ON MATCH  SET d.sourceType = row.sourceType,
+		                d.occurredAt = CASE WHEN row.occurredAt IS NULL THEN NULL ELSE datetime(row.occurredAt) END
+		MERGE (e:Entity {pgId: row.entityId})
+		  ON CREATE SET e += row.entity
+		MERGE (e)-[m:MENTIONED_IN]->(d)
+		  ON CREATE SET m.evidencePgId = row.documentId`
+
+	_, err := p.c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		if err := runWrite(ctx, tx, cypher, map[string]any{"rows": payload}); err != nil {
+			return nil, err
+		}
+		return nil, applyEntityLabels(ctx, tx, labels)
+	})
+	if err != nil {
+		return fmt.Errorf("graph projector: upsert mentions: %w", err)
+	}
+	return nil
+}
+
+// State reads (creating on first call) the projection bookkeeping node.
+func (p *Projector) State(ctx context.Context) (model.GraphProjectionState, error) {
+	const cypher = `
+		MERGE (p:ProjectionState {id: $id})
+		  ON CREATE SET p.lastRelationId = 0, p.resetToken = '', p.updatedAt = datetime()
+		RETURN coalesce(p.lastRelationId, 0) AS lastRelationId,
+		       coalesce(p.resetToken, '')    AS resetToken`
+
+	out, err := p.c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, cypher, map[string]any{"id": projectionStateID})
+		if err != nil {
+			return nil, err
+		}
+		rec, err := res.Single(ctx)
+		if err != nil {
+			return nil, err
+		}
+		st := model.GraphProjectionState{}
+		if v, ok := rec.Get("lastRelationId"); ok {
+			if n, ok := v.(int64); ok {
+				st.LastRelationID = n
+			}
+		}
+		if v, ok := rec.Get("resetToken"); ok {
+			if s, ok := v.(string); ok {
+				st.ResetToken = s
+			}
+		}
+		return st, nil
+	})
+	if err != nil {
+		return model.GraphProjectionState{}, fmt.Errorf("graph projector: state: %w", err)
+	}
+	st, _ := out.(model.GraphProjectionState)
+	return st, nil
+}
+
+// SetLastRelationID advances the watermark. Callers must only call this after
+// the corresponding batch has been written successfully.
+func (p *Projector) SetLastRelationID(ctx context.Context, id int64) error {
+	const cypher = `
+		MERGE (p:ProjectionState {id: $id})
+		SET p.lastRelationId = $value, p.updatedAt = datetime()`
+	if _, err := p.c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		return nil, runWrite(ctx, tx, cypher, map[string]any{"id": projectionStateID, "value": id})
+	}); err != nil {
+		return fmt.Errorf("graph projector: set last relation id: %w", err)
+	}
+	return nil
+}
+
+// SetResetToken records the rebuild token that produced the current graph.
+func (p *Projector) SetResetToken(ctx context.Context, token string) error {
+	const cypher = `
+		MERGE (p:ProjectionState {id: $id})
+		SET p.resetToken = $value, p.updatedAt = datetime()`
+	if _, err := p.c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		return nil, runWrite(ctx, tx, cypher, map[string]any{"id": projectionStateID, "value": token})
+	}); err != nil {
+		return fmt.Errorf("graph projector: set reset token: %w", err)
+	}
+	return nil
+}
+
+// Wipe deletes the entire graph, including the ProjectionState node — a
+// rebuild has to restart from watermark 0, and leaving the watermark behind
+// would make the rebuilt graph permanently missing everything below it.
+//
+// Deletion is chunked because a single DETACH DELETE of the whole graph would
+// build one enormous transaction.
+func (p *Projector) Wipe(ctx context.Context) error {
+	const cypher = `MATCH (n) WITH n LIMIT $limit DETACH DELETE n RETURN count(*) AS deleted`
+	for {
+		out, err := p.c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+			res, err := tx.Run(ctx, cypher, map[string]any{"limit": wipeBatchSize})
+			if err != nil {
+				return nil, err
+			}
+			rec, err := res.Single(ctx)
+			if err != nil {
+				return nil, err
+			}
+			v, _ := rec.Get("deleted")
+			n, _ := v.(int64)
+			return n, nil
+		})
+		if err != nil {
+			return fmt.Errorf("graph projector: wipe: %w", err)
+		}
+		if n, _ := out.(int64); n == 0 {
+			return nil
+		}
+	}
+}
+
+// --- helpers ---
+
+// runWrite runs a write statement and drains it, so a server-side failure on a
+// statement that returns no rows is still reported.
+func runWrite(ctx context.Context, tx neo4j.ManagedTransaction, cypher string, params map[string]any) error {
+	res, err := tx.Run(ctx, cypher, params)
+	if err != nil {
+		return err
+	}
+	_, err = res.Consume(ctx)
+	return err
+}
+
+// entityLabelGroups buckets the endpoint entity ids of a relation batch by
+// their secondary label.
+func entityLabelGroups(rows []model.ProjectionRelation) map[string][]int64 {
+	out := map[string][]int64{}
+	seen := map[int64]bool{}
+	add := func(id int64, entityType string) {
+		if seen[id] {
+			return
+		}
+		label, ok := CypherEntityLabel(entityType)
+		if !ok {
+			return
+		}
+		seen[id] = true
+		out[label] = append(out[label], id)
+	}
+	for _, r := range rows {
+		add(r.FromEntityID, r.FromType)
+		add(r.ToEntityID, r.ToType)
+	}
+	return out
+}
+
+// applyEntityLabels attaches the secondary type label. Labels, like
+// relationship types, cannot be parameterised — the literal comes from
+// CypherEntityLabel and the ids are bound as $ids.
+func applyEntityLabels(ctx context.Context, tx neo4j.ManagedTransaction, groups map[string][]int64) error {
+	labels := make([]string, 0, len(groups))
+	for label := range groups {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+
+	for _, label := range labels {
+		cypher := `UNWIND $ids AS id MATCH (e:Entity {pgId: id}) SET e:` + label
+		if err := runWrite(ctx, tx, cypher, map[string]any{"ids": groups[label]}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/graph/projector_integration_test.go
+++ b/internal/graph/projector_integration_test.go
@@ -1,0 +1,203 @@
+package graph
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// All fixtures below use synthesised dummy names (더미갑/더미을). Real personal
+// data never enters a test fixture (privacy policy §4).
+
+func newTestProjector(t *testing.T) *Projector {
+	t.Helper()
+	return NewProjector(newTestClient(t)) // skips when NEO4J_TEST_URI is unset
+}
+
+func countScalar(t *testing.T, p *Projector, cypher string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	out, err := p.c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, cypher, nil)
+		if err != nil {
+			return nil, err
+		}
+		rec, err := res.Single(ctx)
+		if err != nil {
+			return nil, err
+		}
+		v, _ := rec.Get("n")
+		return v, nil
+	})
+	if err != nil {
+		t.Fatalf("count query %q: %v", cypher, err)
+	}
+	n, ok := out.(int64)
+	if !ok {
+		t.Fatalf("count query %q returned %T, want int64", cypher, out)
+	}
+	return n
+}
+
+func countRels(t *testing.T, p *Projector) int64 {
+	return countScalar(t, p, `MATCH ()-[r]->() RETURN count(r) AS n`)
+}
+
+func countNodes(t *testing.T, p *Projector, label string) int64 {
+	// label is a test-local constant, never user input.
+	return countScalar(t, p, `MATCH (x:`+label+`) RETURN count(x) AS n`)
+}
+
+// Every test in this file is named *Integration* on purpose: the documented
+// verification command is `go test ./internal/graph/ -run Integration`, and a
+// name that does not contain "Integration" is silently excluded from it — the
+// tests would look "green" while never having touched a server.
+//
+// TestProjectorIntegration_UpsertRelations_Idempotent is the load-bearing test of this
+// whole design: the relationship MERGE keys on pgId (= entity_relations.id),
+// so replaying the same Postgres rows must never grow the graph. Every
+// rebuild/overlap strategy elsewhere assumes this holds.
+func TestProjectorIntegration_UpsertRelations_Idempotent(t *testing.T) {
+	p := newTestProjector(t)
+	ctx := context.Background()
+	if err := p.Wipe(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows := []model.ProjectionRelation{{
+		ID: 1, FromEntityID: 11, FromName: "더미갑", FromType: "PERSON",
+		ToEntityID: 22, ToName: "더미을", ToType: "PERSON",
+		Type:               model.RelationCommunicatedWith,
+		EvidenceDocumentID: "00000000-0000-0000-0000-0000000000aa",
+		Confidence:         0.9, ObservedAt: time.Now().UTC(),
+	}}
+	for i := 0; i < 2; i++ {
+		if err := p.UpsertRelations(ctx, rows); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := countRels(t, p); got != 1 {
+		t.Fatalf("rel count after 2 identical upserts = %d, want 1", got)
+	}
+	if got := countNodes(t, p, "Entity"); got != 2 {
+		t.Fatalf("Entity count = %d, want 2", got)
+	}
+	if got := countNodes(t, p, "Person"); got != 2 {
+		t.Fatalf("Person label count = %d, want 2", got)
+	}
+}
+
+// TestProjectorIntegration_UpsertRelations_SkipsUnknownType pins that a relation type
+// outside the whitelist is dropped rather than concatenated into Cypher.
+func TestProjectorIntegration_UpsertRelations_SkipsUnknownType(t *testing.T) {
+	p := newTestProjector(t)
+	ctx := context.Background()
+	if err := p.Wipe(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	rows := []model.ProjectionRelation{{
+		ID: 2, FromEntityID: 11, FromName: "더미갑", FromType: "PERSON",
+		ToEntityID: 22, ToName: "더미을", ToType: "PERSON",
+		Type:               model.RelationType("MENTIONS`]->() DETACH DELETE n //"),
+		EvidenceDocumentID: "00000000-0000-0000-0000-0000000000aa",
+		Confidence:         0.9, ObservedAt: time.Now().UTC(),
+	}}
+	if err := p.UpsertRelations(ctx, rows); err != nil {
+		t.Fatalf("unknown type should be skipped, not error: %v", err)
+	}
+	if got := countRels(t, p); got != 0 {
+		t.Fatalf("rel count = %d, want 0 (row must be skipped)", got)
+	}
+}
+
+// TestProjectorIntegration_UpsertMentions_Idempotent covers the second projection pass
+// and the privacy invariant that no document text reaches Neo4j.
+func TestProjectorIntegration_UpsertMentions_Idempotent(t *testing.T) {
+	p := newTestProjector(t)
+	ctx := context.Background()
+	if err := p.Wipe(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Now().UTC()
+	rows := []model.ProjectionMention{
+		{DocumentID: "00000000-0000-0000-0000-0000000000ab", SourceType: "sms", OccurredAt: &when,
+			EntityID: 11, EntityName: "더미갑", EntityType: "PERSON"},
+		{DocumentID: "00000000-0000-0000-0000-0000000000ac", SourceType: "sms", OccurredAt: nil,
+			EntityID: 11, EntityName: "더미갑", EntityType: "PERSON"},
+	}
+	for i := 0; i < 2; i++ {
+		if err := p.UpsertMentions(ctx, rows); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := countRels(t, p); got != 2 {
+		t.Fatalf("MENTIONED_IN count = %d, want 2", got)
+	}
+	if got := countNodes(t, p, "Document"); got != 2 {
+		t.Fatalf("Document count = %d, want 2", got)
+	}
+	if got := countScalar(t, p,
+		`MATCH (d:Document) WHERE d.title IS NOT NULL OR d.content IS NOT NULL RETURN count(d) AS n`); got != 0 {
+		t.Fatalf("%d Document nodes carry title/content — privacy invariant broken", got)
+	}
+}
+
+func TestProjectorIntegration_State_RoundTrip(t *testing.T) {
+	p := newTestProjector(t)
+	ctx := context.Background()
+	if err := p.Wipe(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SetLastRelationID(ctx, 42); err != nil {
+		t.Fatal(err)
+	}
+	st, err := p.State(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.LastRelationID != 42 {
+		t.Fatalf("LastRelationID = %d, want 42", st.LastRelationID)
+	}
+	if err := p.SetResetToken(ctx, "token-1"); err != nil {
+		t.Fatal(err)
+	}
+	st, err = p.State(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.ResetToken != "token-1" || st.LastRelationID != 42 {
+		t.Fatalf("state = %+v, want {42 token-1}", st)
+	}
+}
+
+// TestProjectorIntegration_Wipe_ClearsWatermark pins that a rebuild also drops the
+// watermark — otherwise the next cycle would resume mid-stream over an empty
+// graph and silently lose everything before the watermark.
+func TestProjectorIntegration_Wipe_ClearsWatermark(t *testing.T) {
+	p := newTestProjector(t)
+	ctx := context.Background()
+	if err := p.SetLastRelationID(ctx, 99); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Wipe(ctx); err != nil {
+		t.Fatal(err)
+	}
+	st, err := p.State(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.LastRelationID != 0 || st.ResetToken != "" {
+		t.Fatalf("state after Wipe = %+v, want zero values", st)
+	}
+}

--- a/internal/graph/queries.go
+++ b/internal/graph/queries.go
@@ -1,0 +1,454 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// This file is the entire read surface of the graph. Four constant queries,
+// every value bound as a parameter, every result bounded by a server-side
+// clamp. There is deliberately no way to execute caller-supplied Cypher: the
+// catalogue is the API.
+
+// Result-size limits. Defaults are what the UI asks for; maxima are what the
+// server will actually return no matter what the caller sends.
+const (
+	entryLimitDefault = 20
+	entryLimitMax     = 50
+
+	expandLimitDefault = 50
+	expandLimitMax     = 200
+
+	evidenceLimitDefault = 20
+	evidenceLimitMax     = 100
+
+	searchLimitDefault = 10
+	searchLimitMax     = 50
+)
+
+// EntryFilter selects the starting nodes of an exploration.
+type EntryFilter struct {
+	Since         time.Time
+	MinConfidence float64
+	EntityTypes   []string
+	Limit         int
+}
+
+// ExpandFilter selects one node's neighbours (always exactly one hop).
+type ExpandFilter struct {
+	EntityPgID    int64
+	Since         time.Time
+	MinConfidence float64
+	RelTypes      []string
+	Limit         int
+}
+
+// EntryNode is one candidate entry point, ranked by degree within the filter.
+type EntryNode struct {
+	PgID   int64  `json:"entity_id"`
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Degree int64  `json:"degree"`
+}
+
+// Neighbor is one entity adjacent to the expanded node. Weight is the number
+// of parallel edges of that type (one edge per Postgres row), i.e. how many
+// times the relation was observed.
+type Neighbor struct {
+	PgID      int64     `json:"entity_id"`
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	RelType   string    `json:"rel_type"`
+	Direction string    `json:"direction"` // "out" | "in"
+	Weight    int64     `json:"weight"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// EvidenceRef points at the document that justified one observation. It
+// carries no document text — the UI links to the existing document API, which
+// is behind the same auth.
+type EvidenceRef struct {
+	DocumentID string     `json:"document_id"`
+	SourceType string     `json:"source_type"`
+	OccurredAt *time.Time `json:"occurred_at"`
+	Confidence float64    `json:"confidence"`
+	ObservedAt time.Time  `json:"observed_at"`
+}
+
+// EntityHit is one entity matched by prefix search.
+type EntityHit struct {
+	PgID int64  `json:"entity_id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Reader executes the fixed query catalogue. Every method goes through
+// Client.Read (read-mode session, 5s transaction timeout).
+type Reader struct {
+	c *Client
+}
+
+// NewReader returns a Reader backed by c.
+func NewReader(c *Client) *Reader { return &Reader{c: c} }
+
+// errReaderNoClient keeps a zero-value Reader (used by unit tests that only
+// exercise validation) from panicking.
+var errReaderNoClient = errors.New("graph: reader has no client")
+
+// --- query catalogue ---
+
+const (
+	// entryQuery is the only query that scans relationships globally. At a few
+	// thousand relationships that costs milliseconds; the plan flags 500k as
+	// the point to add an observedAt relationship index. The e.pgId tiebreak
+	// keeps the screen stable across reloads when degrees tie.
+	entryQuery = `
+		MATCH (e:Entity)-[r]-(:Entity)
+		WHERE r.observedAt >= datetime($since) AND r.confidence >= $minConfidence
+		  AND (size($types) = 0 OR e.type IN $types)
+		WITH e, count(r) AS degree
+		ORDER BY degree DESC, e.pgId ASC
+		LIMIT $limit
+		RETURN e.pgId AS pgId, e.name AS name, e.type AS type, degree`
+
+	// expandQuery enters through the uniqueness-constrained pgId index, so a
+	// supernode only costs its own adjacency, bounded further by LIMIT. No
+	// variable-length paths: the UI expands exactly one hop at a time.
+	expandQuery = `
+		MATCH (e:Entity {pgId: $pgId})-[r]-(n:Entity)
+		WHERE r.observedAt >= datetime($since) AND r.confidence >= $minConfidence
+		  AND (size($relTypes) = 0 OR type(r) IN $relTypes)
+		WITH n, type(r) AS relType,
+		     CASE WHEN startNode(r) = e THEN 'out' ELSE 'in' END AS direction,
+		     count(r) AS weight, max(r.observedAt) AS lastSeen
+		ORDER BY weight DESC, lastSeen DESC, n.pgId ASC
+		LIMIT $limit
+		RETURN n.pgId AS pgId, n.name AS name, n.type AS type, relType, direction, weight, lastSeen`
+
+	evidenceQuery = `
+		MATCH (a:Entity {pgId: $from})-[r]-(b:Entity {pgId: $to})
+		WHERE type(r) = $relType
+		MATCH (d:Document {pgId: r.evidencePgId})
+		RETURN d.pgId AS documentId, d.sourceType AS sourceType, d.occurredAt AS occurredAt,
+		       r.confidence AS confidence, r.observedAt AS observedAt
+		ORDER BY r.observedAt DESC
+		LIMIT $limit`
+
+	// searchQuery uses STARTS WITH, not CONTAINS: the range index on
+	// normalizedName accelerates prefix matches only. Substring search would
+	// need a text/full-text index (out of scope).
+	searchQuery = `
+		MATCH (e:Entity)
+		WHERE e.normalizedName STARTS WITH $prefix
+		RETURN e.pgId AS pgId, e.name AS name, e.type AS type
+		ORDER BY e.normalizedName ASC
+		LIMIT $limit`
+)
+
+// fixedQueries exposes the catalogue for the read-only guard test.
+func fixedQueries() map[string]string {
+	return map[string]string{
+		"entry":    entryQuery,
+		"expand":   expandQuery,
+		"evidence": evidenceQuery,
+		"search":   searchQuery,
+	}
+}
+
+// --- input sanitising ---
+
+// clampLimit applies the default for non-positive input and the ceiling for
+// anything larger than max. Every read response is bounded this way.
+func clampLimit(in, def, max int) int {
+	if in <= 0 {
+		return def
+	}
+	if in > max {
+		return max
+	}
+	return in
+}
+
+// The four Clamp* wrappers exist so the HTTP layer clamps against exactly the
+// same numbers this package enforces, instead of keeping a second copy of the
+// constants that can drift. The Reader clamps again on its own input — the
+// limit is enforced at the boundary that owns the query, not only at the edge.
+func ClampEntryLimit(n int) int    { return clampLimit(n, entryLimitDefault, entryLimitMax) }
+func ClampExpandLimit(n int) int   { return clampLimit(n, expandLimitDefault, expandLimitMax) }
+func ClampEvidenceLimit(n int) int { return clampLimit(n, evidenceLimitDefault, evidenceLimitMax) }
+func ClampSearchLimit(n int) int   { return clampLimit(n, searchLimitDefault, searchLimitMax) }
+
+// sanitizeRelTypes keeps only the 8 whitelisted Cypher relationship literals.
+func sanitizeRelTypes(in []string) []string {
+	allowed := map[string]bool{}
+	for _, t := range AllCypherRelTypes() {
+		allowed[t] = true
+	}
+	out := make([]string, 0, len(in))
+	for _, t := range in {
+		if allowed[t] {
+			out = append(out, t)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sanitizeEntityTypes keeps only the 4 known entities.type values.
+func sanitizeEntityTypes(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, t := range in {
+		if _, ok := CypherEntityLabel(t); ok {
+			out = append(out, t)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// toAnySlice converts to []any because the driver rejects []string for a
+// parameter compared against a stored string property list in some versions;
+// []any is always accepted.
+func toAnySlice(in []string) []any {
+	out := make([]any, 0, len(in))
+	for _, v := range in {
+		out = append(out, v)
+	}
+	return out
+}
+
+// sinceParam renders the lower time bound. A zero Since means "no bound",
+// rendered as the Unix epoch rather than omitted, so the query text stays
+// constant.
+func sinceParam(t time.Time) string {
+	if t.IsZero() {
+		t = time.Unix(0, 0).UTC()
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// --- reads ---
+
+// EntryPoints returns the highest-degree entities matching the filter.
+func (r *Reader) EntryPoints(ctx context.Context, f EntryFilter) ([]EntryNode, error) {
+	if r == nil || r.c == nil {
+		return nil, errReaderNoClient
+	}
+	params := map[string]any{
+		"since":         sinceParam(f.Since),
+		"minConfidence": f.MinConfidence,
+		"types":         toAnySlice(sanitizeEntityTypes(f.EntityTypes)),
+		"limit":         clampLimit(f.Limit, entryLimitDefault, entryLimitMax),
+	}
+
+	out, err := r.c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, entryQuery, params)
+		if err != nil {
+			return nil, err
+		}
+		var nodes []EntryNode
+		for res.Next(ctx) {
+			rec := res.Record()
+			nodes = append(nodes, EntryNode{
+				PgID:   recInt(rec, "pgId"),
+				Name:   recString(rec, "name"),
+				Type:   recString(rec, "type"),
+				Degree: recInt(rec, "degree"),
+			})
+		}
+		return nodes, res.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("graph: entry points: %w", err)
+	}
+	nodes, _ := out.([]EntryNode)
+	return nodes, nil
+}
+
+// Expand returns one hop of neighbours around f.EntityPgID.
+func (r *Reader) Expand(ctx context.Context, f ExpandFilter) ([]Neighbor, error) {
+	if r == nil || r.c == nil {
+		return nil, errReaderNoClient
+	}
+	params := map[string]any{
+		"pgId":          f.EntityPgID,
+		"since":         sinceParam(f.Since),
+		"minConfidence": f.MinConfidence,
+		"relTypes":      toAnySlice(sanitizeRelTypes(f.RelTypes)),
+		"limit":         clampLimit(f.Limit, expandLimitDefault, expandLimitMax),
+	}
+
+	out, err := r.c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, expandQuery, params)
+		if err != nil {
+			return nil, err
+		}
+		var neighbors []Neighbor
+		for res.Next(ctx) {
+			rec := res.Record()
+			neighbors = append(neighbors, Neighbor{
+				PgID:      recInt(rec, "pgId"),
+				Name:      recString(rec, "name"),
+				Type:      recString(rec, "type"),
+				RelType:   recString(rec, "relType"),
+				Direction: recString(rec, "direction"),
+				Weight:    recInt(rec, "weight"),
+				LastSeen:  recTime(rec, "lastSeen"),
+			})
+		}
+		return neighbors, res.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("graph: expand: %w", err)
+	}
+	neighbors, _ := out.([]Neighbor)
+	return neighbors, nil
+}
+
+// Evidence returns the documents backing one (from, to, relType) pair.
+// relType must be one of the whitelisted literals; anything else is refused
+// before a query is issued.
+func (r *Reader) Evidence(ctx context.Context, fromPgID, toPgID int64, relType string, limit int) ([]EvidenceRef, error) {
+	if len(sanitizeRelTypes([]string{relType})) != 1 {
+		return nil, fmt.Errorf("graph: unknown relationship type")
+	}
+	if r == nil || r.c == nil {
+		return nil, errReaderNoClient
+	}
+	params := map[string]any{
+		"from":    fromPgID,
+		"to":      toPgID,
+		"relType": relType,
+		"limit":   clampLimit(limit, evidenceLimitDefault, evidenceLimitMax),
+	}
+
+	out, err := r.c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, evidenceQuery, params)
+		if err != nil {
+			return nil, err
+		}
+		var refs []EvidenceRef
+		for res.Next(ctx) {
+			rec := res.Record()
+			ref := EvidenceRef{
+				DocumentID: recString(rec, "documentId"),
+				SourceType: recString(rec, "sourceType"),
+				Confidence: recFloat(rec, "confidence"),
+				ObservedAt: recTime(rec, "observedAt"),
+			}
+			if v, ok := rec.Get("occurredAt"); ok && v != nil {
+				if t, ok := v.(time.Time); ok {
+					tt := t
+					ref.OccurredAt = &tt
+				}
+			}
+			refs = append(refs, ref)
+		}
+		return refs, res.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("graph: evidence: %w", err)
+	}
+	refs, _ := out.([]EvidenceRef)
+	return refs, nil
+}
+
+// SearchEntities does a prefix lookup over normalizedName. The prefix is
+// normalised the same way the projection normalises names, so callers can pass
+// what the user typed.
+func (r *Reader) SearchEntities(ctx context.Context, prefix string, limit int) ([]EntityHit, error) {
+	normalized := strings.ToLower(strings.TrimSpace(prefix))
+	if normalized == "" {
+		return nil, fmt.Errorf("graph: search prefix must not be empty")
+	}
+	if r == nil || r.c == nil {
+		return nil, errReaderNoClient
+	}
+	params := map[string]any{
+		"prefix": normalized,
+		"limit":  clampLimit(limit, searchLimitDefault, searchLimitMax),
+	}
+
+	out, err := r.c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, searchQuery, params)
+		if err != nil {
+			return nil, err
+		}
+		var hits []EntityHit
+		for res.Next(ctx) {
+			rec := res.Record()
+			hits = append(hits, EntityHit{
+				PgID: recInt(rec, "pgId"),
+				Name: recString(rec, "name"),
+				Type: recString(rec, "type"),
+			})
+		}
+		return hits, res.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("graph: search entities: %w", err)
+	}
+	hits, _ := out.([]EntityHit)
+	return hits, nil
+}
+
+// EntityTypeValues returns the 4 entity type values, used by callers that need
+// to validate a filter before building an EntryFilter.
+func EntityTypeValues() []string {
+	out := []string{
+		string(model.EntityTypePerson),
+		string(model.EntityTypeOrg),
+		string(model.EntityTypeConcept),
+		string(model.EntityTypeOther),
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- record helpers ---
+
+func recInt(rec *neo4j.Record, key string) int64 {
+	if v, ok := rec.Get(key); ok {
+		if n, ok := v.(int64); ok {
+			return n
+		}
+	}
+	return 0
+}
+
+func recFloat(rec *neo4j.Record, key string) float64 {
+	if v, ok := rec.Get(key); ok {
+		switch n := v.(type) {
+		case float64:
+			return n
+		case int64:
+			return float64(n)
+		}
+	}
+	return 0
+}
+
+func recString(rec *neo4j.Record, key string) string {
+	if v, ok := rec.Get(key); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func recTime(rec *neo4j.Record, key string) time.Time {
+	if v, ok := rec.Get(key); ok {
+		if t, ok := v.(time.Time); ok {
+			return t
+		}
+	}
+	return time.Time{}
+}

--- a/internal/graph/queries_integration_test.go
+++ b/internal/graph/queries_integration_test.go
@@ -1,0 +1,171 @@
+package graph
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// seedDummyGraph builds a 3-entity / 4-relation graph through the projector,
+// so the read tests exercise exactly the shape the projection produces.
+// Names are synthesised dummies (privacy policy §4).
+func seedDummyGraph(t *testing.T, p *Projector) (ctx context.Context, observed time.Time) {
+	t.Helper()
+	ctx = context.Background()
+	if err := p.Wipe(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	observed = time.Now().UTC().Add(-1 * time.Hour)
+
+	rel := func(id, from, to int64, fromName, toName, fromType, toType string, rt model.RelationType, doc string) model.ProjectionRelation {
+		return model.ProjectionRelation{
+			ID: id, FromEntityID: from, FromName: fromName, FromType: fromType,
+			ToEntityID: to, ToName: toName, ToType: toType, Type: rt,
+			EvidenceDocumentID: doc, Confidence: 0.9, ObservedAt: observed,
+		}
+	}
+	rows := []model.ProjectionRelation{
+		rel(1, 11, 22, "더미갑", "더미을", "PERSON", "PERSON", model.RelationCommunicatedWith, "00000000-0000-0000-0000-0000000000a1"),
+		rel(2, 11, 22, "더미갑", "더미을", "PERSON", "PERSON", model.RelationCommunicatedWith, "00000000-0000-0000-0000-0000000000a2"),
+		rel(3, 11, 33, "더미갑", "더미주제", "PERSON", "CONCEPT", model.RelationAboutTopic, "00000000-0000-0000-0000-0000000000a3"),
+		rel(4, 22, 33, "더미을", "더미주제", "PERSON", "CONCEPT", model.RelationAboutTopic, "00000000-0000-0000-0000-0000000000a3"),
+	}
+	if err := p.UpsertRelations(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	mentions := []model.ProjectionMention{
+		{DocumentID: "00000000-0000-0000-0000-0000000000a1", SourceType: "sms", OccurredAt: &observed,
+			EntityID: 11, EntityName: "더미갑", EntityType: "PERSON"},
+		{DocumentID: "00000000-0000-0000-0000-0000000000a2", SourceType: "sms", OccurredAt: &observed,
+			EntityID: 11, EntityName: "더미갑", EntityType: "PERSON"},
+		{DocumentID: "00000000-0000-0000-0000-0000000000a3", SourceType: "gmail", OccurredAt: nil,
+			EntityID: 22, EntityName: "더미을", EntityType: "PERSON"},
+	}
+	if err := p.UpsertMentions(ctx, mentions); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, observed
+}
+
+func TestReaderIntegration_EntryExpandEvidenceSearch(t *testing.T) {
+	c := newTestClient(t)
+	p := NewProjector(c)
+	r := NewReader(c)
+	ctx, observed := seedDummyGraph(t, p)
+	since := observed.Add(-24 * time.Hour)
+
+	// Entry points: 더미갑 (id 11) has degree 3, the highest.
+	entries, err := r.EntryPoints(ctx, EntryFilter{Since: since, MinConfidence: 0.5, Limit: 999})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("entry nodes = %d, want 3", len(entries))
+	}
+	if entries[0].PgID != 11 || entries[0].Degree != 3 {
+		t.Fatalf("top entry = %+v, want pgId 11 with degree 3", entries[0])
+	}
+
+	// Type filter.
+	topics, err := r.EntryPoints(ctx, EntryFilter{Since: since, MinConfidence: 0.5, EntityTypes: []string{"CONCEPT"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(topics) != 1 || topics[0].PgID != 33 {
+		t.Fatalf("CONCEPT-filtered entries = %+v, want only pgId 33", topics)
+	}
+
+	// Expand: 더미갑 has 2 neighbours; the COMMUNICATED_WITH edge to 22 was
+	// observed twice, so weight is 2 — parallel edges, counted at query time.
+	neighbors, err := r.Expand(ctx, ExpandFilter{EntityPgID: 11, Since: since, MinConfidence: 0.5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(neighbors) != 2 {
+		t.Fatalf("neighbours = %d, want 2", len(neighbors))
+	}
+	if neighbors[0].PgID != 22 || neighbors[0].Weight != 2 || neighbors[0].Direction != "out" {
+		t.Fatalf("top neighbour = %+v, want pgId 22 weight 2 direction out", neighbors[0])
+	}
+
+	// Rel-type filter.
+	filtered, err := r.Expand(ctx, ExpandFilter{EntityPgID: 11, Since: since, MinConfidence: 0.5,
+		RelTypes: []string{"ABOUT_TOPIC"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].RelType != "ABOUT_TOPIC" {
+		t.Fatalf("ABOUT_TOPIC-filtered neighbours = %+v", filtered)
+	}
+
+	// Evidence: two documents back the 11–22 COMMUNICATED_WITH pair.
+	evidence, err := r.Evidence(ctx, 11, 22, "COMMUNICATED_WITH", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 2 {
+		t.Fatalf("evidence rows = %d, want 2", len(evidence))
+	}
+
+	// Search: prefix match on normalizedName.
+	hits, err := r.SearchEntities(ctx, "더미", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 3 {
+		t.Fatalf("search hits = %d, want 3", len(hits))
+	}
+}
+
+// TestReaderIntegration_ExpandPlanUsesIndexSeek pins the supernode defence:
+// expansion must enter through the pgId uniqueness index, never a full scan.
+func TestReaderIntegration_ExpandPlanUsesIndexSeek(t *testing.T) {
+	c := newTestClient(t)
+	p := NewProjector(c)
+	r := NewReader(c)
+	ctx, _ := seedDummyGraph(t, p)
+	_ = r
+
+	out, err := c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, "EXPLAIN "+expandQuery, map[string]any{
+			"pgId": int64(11), "since": sinceParam(time.Unix(0, 0)), "minConfidence": 0.0,
+			"relTypes": []any{}, "limit": 10,
+		})
+		if err != nil {
+			return nil, err
+		}
+		summary, err := res.Consume(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return planOperators(summary.Plan()), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ops, _ := out.(string)
+	if !strings.Contains(ops, "IndexSeek") {
+		t.Errorf("expand plan has no index seek: %s", ops)
+	}
+	if strings.Contains(ops, "AllNodesScan") {
+		t.Errorf("expand plan falls back to AllNodesScan: %s", ops)
+	}
+}
+
+func planOperators(p neo4j.Plan) string {
+	if p == nil {
+		return ""
+	}
+	out := p.Operator()
+	for _, child := range p.Children() {
+		out += " " + planOperators(child)
+	}
+	return out
+}

--- a/internal/graph/queries_test.go
+++ b/internal/graph/queries_test.go
@@ -1,0 +1,78 @@
+package graph
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestClampLimit(t *testing.T) {
+	for _, c := range []struct{ in, def, max, want int }{
+		{0, 20, 50, 20}, {-5, 20, 50, 20}, {10, 20, 50, 10}, {999, 20, 50, 50},
+	} {
+		if got := clampLimit(c.in, c.def, c.max); got != c.want {
+			t.Errorf("clampLimit(%d,%d,%d) = %d, want %d", c.in, c.def, c.max, got, c.want)
+		}
+	}
+}
+
+// TestSanitizeRelTypes_DropsUnknown: relationship types are only ever used in
+// a parameterisable position here (`type(r) IN $relTypes`), but they still go
+// through the whitelist so a typo or a probe is cut at the edge instead of
+// silently returning nothing.
+func TestSanitizeRelTypes_DropsUnknown(t *testing.T) {
+	if got := sanitizeRelTypes([]string{"COMMUNICATED_WITH", "DROP_EVERYTHING", "MENTIONS"}); len(got) != 2 {
+		t.Fatalf("kept %d entries, want 2 (%v)", len(got), got)
+	}
+	if got := sanitizeRelTypes(nil); len(got) != 0 {
+		t.Errorf("nil input kept %d entries, want 0", len(got))
+	}
+	if got := sanitizeRelTypes([]string{"communicated_with"}); len(got) != 0 {
+		t.Errorf("lowercase input kept %d entries, want 0", len(got))
+	}
+}
+
+func TestSanitizeEntityTypes_DropsUnknown(t *testing.T) {
+	got := sanitizeEntityTypes([]string{"PERSON", "ORG", "ROBOT", ""})
+	if len(got) != 2 {
+		t.Fatalf("kept %d entries, want 2 (%v)", len(got), got)
+	}
+}
+
+// TestEvidence_RejectsUnknownRelType keeps an unvalidated relationship type
+// from reaching the query at all.
+func TestEvidence_RejectsUnknownRelType(t *testing.T) {
+	r := &Reader{} // no client: the guard must fire before any query runs
+	if _, err := r.Evidence(context.Background(), 1, 2, "DROP_EVERYTHING", 10); err == nil {
+		t.Fatal("unknown rel type: want error, got nil")
+	}
+}
+
+// TestSearchEntities_RejectsEmptyPrefix avoids a prefix scan that would return
+// the entire entity table.
+func TestSearchEntities_RejectsEmptyPrefix(t *testing.T) {
+	r := &Reader{}
+	if _, err := r.SearchEntities(context.Background(), "   ", 10); err == nil {
+		t.Fatal("blank prefix: want error, got nil")
+	}
+}
+
+// TestFixedQueriesAreReadOnly is a static guard on the query catalogue: no
+// fixed read query may contain a write clause. The read API exposes these
+// four strings and nothing else — there is no path that executes
+// caller-supplied Cypher.
+func TestFixedQueriesAreReadOnly(t *testing.T) {
+	writeClauses := []string{"CREATE", "MERGE", "DELETE", "SET ", "REMOVE", "DROP", "LOAD CSV", "IN TRANSACTIONS", "CALL"}
+	queries := fixedQueries()
+	if len(queries) != 4 {
+		t.Fatalf("fixedQueries() has %d entries, want 4", len(queries))
+	}
+	for name, q := range queries {
+		upper := strings.ToUpper(q)
+		for _, clause := range writeClauses {
+			if strings.Contains(upper, clause) {
+				t.Errorf("query %q contains write clause %q", name, clause)
+			}
+		}
+	}
+}

--- a/internal/graph/reltypes.go
+++ b/internal/graph/reltypes.go
@@ -1,0 +1,71 @@
+package graph
+
+import (
+	"sort"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// This file exists for exactly one reason: Cypher cannot parameterise
+// relationship types or node labels. `-[r:$type]->` is a syntax error, so the
+// type has to be a literal inside the query string. If that literal were a
+// value read from the database, that single spot would be the only Cypher
+// injection path in the whole system.
+//
+// The maps below close it. Nothing outside them is ever concatenated into a
+// query: callers must go through CypherRelType / CypherEntityLabel and skip
+// rows whose lookup fails.
+
+// MentionedInRelType is the projection of document_entities. It is not part of
+// the 8-item closed vocabulary (which describes entity-to-entity relations),
+// so it lives as its own constant rather than inside the map.
+const MentionedInRelType = "MENTIONED_IN"
+
+// cypherRelTypes maps the lowercase wire vocabulary stored in
+// entity_relations.type to the uppercase-snake Cypher literal.
+var cypherRelTypes = map[model.RelationType]string{
+	model.RelationCommunicatedWith: "COMMUNICATED_WITH",
+	model.RelationRequestedOf:      "REQUESTED_OF",
+	model.RelationCommittedTo:      "COMMITTED_TO",
+	model.RelationMentions:         "MENTIONS",
+	model.RelationBelongsTo:        "BELONGS_TO",
+	model.RelationScheduledWith:    "SCHEDULED_WITH",
+	model.RelationAboutTopic:       "ABOUT_TOPIC",
+	model.RelationRelatedTo:        "RELATED_TO",
+}
+
+// cypherEntityLabels maps entities.type to the secondary node label.
+// CONCEPT becomes Topic — the graph model's naming, kept in one place so the
+// two vocabularies cannot drift silently.
+var cypherEntityLabels = map[string]string{
+	string(model.EntityTypePerson):  "Person",
+	string(model.EntityTypeOrg):     "Org",
+	string(model.EntityTypeConcept): "Topic",
+	string(model.EntityTypeOther):   "Other",
+}
+
+// CypherRelType returns the Cypher literal for t, and false when t is not one
+// of the 8 closed-vocabulary values. A false return means "do not project this
+// row" — never "fall back to something".
+func CypherRelType(t model.RelationType) (string, bool) {
+	v, ok := cypherRelTypes[t]
+	return v, ok
+}
+
+// CypherEntityLabel returns the secondary node label for an entities.type
+// value, and false for anything outside the 4 known types.
+func CypherEntityLabel(entityType string) (string, bool) {
+	v, ok := cypherEntityLabels[entityType]
+	return v, ok
+}
+
+// AllCypherRelTypes returns the 8 entity-to-entity literals, sorted, for use
+// as the allow-set when validating caller-supplied filters.
+func AllCypherRelTypes() []string {
+	out := make([]string, 0, len(cypherRelTypes))
+	for _, v := range cypherRelTypes {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/graph/reltypes_test.go
+++ b/internal/graph/reltypes_test.go
@@ -1,0 +1,75 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+func TestCypherRelType(t *testing.T) {
+	cases := map[model.RelationType]string{
+		model.RelationCommunicatedWith: "COMMUNICATED_WITH",
+		model.RelationRequestedOf:      "REQUESTED_OF",
+		model.RelationCommittedTo:      "COMMITTED_TO",
+		model.RelationMentions:         "MENTIONS",
+		model.RelationBelongsTo:        "BELONGS_TO",
+		model.RelationScheduledWith:    "SCHEDULED_WITH",
+		model.RelationAboutTopic:       "ABOUT_TOPIC",
+		model.RelationRelatedTo:        "RELATED_TO",
+	}
+	for in, want := range cases {
+		if got, ok := CypherRelType(in); !ok || got != want {
+			t.Errorf("CypherRelType(%q) = %q,%v; want %q,true", in, got, ok, want)
+		}
+	}
+}
+
+// TestCypherRelType_RejectsUnknown is the injection guard. The uppercase
+// "RELATED_TO" case matters: input always comes from the lowercase vocabulary
+// stored in Postgres, so an already-uppercased value means it travelled
+// through some other conversion path — which must not be trusted.
+func TestCypherRelType_RejectsUnknown(t *testing.T) {
+	for _, raw := range []string{"", "drop_all", "RELATED_TO", "MENTIONS`]->() DETACH DELETE n //"} {
+		if got, ok := CypherRelType(model.RelationType(raw)); ok {
+			t.Errorf("CypherRelType(%q) = %q,true; want ok=false", raw, got)
+		}
+	}
+}
+
+func TestAllCypherRelTypes_HasEightEntries(t *testing.T) {
+	if n := len(AllCypherRelTypes()); n != 8 {
+		t.Errorf("length = %d, want 8", n)
+	}
+}
+
+// TestAllCypherRelTypes_IsSorted keeps the slice deterministic — it is used to
+// build query parameters and test expectations.
+func TestAllCypherRelTypes_IsSorted(t *testing.T) {
+	got := AllCypherRelTypes()
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Fatalf("AllCypherRelTypes not sorted/unique at %d: %v", i, got)
+		}
+	}
+}
+
+// TestCypherEntityLabel pins the second literal that cannot be parameterised:
+// node labels. Same whitelist discipline as relationship types.
+func TestCypherEntityLabel(t *testing.T) {
+	cases := map[string]string{
+		string(model.EntityTypePerson):  "Person",
+		string(model.EntityTypeOrg):     "Org",
+		string(model.EntityTypeConcept): "Topic",
+		string(model.EntityTypeOther):   "Other",
+	}
+	for in, want := range cases {
+		if got, ok := CypherEntityLabel(in); !ok || got != want {
+			t.Errorf("CypherEntityLabel(%q) = %q,%v; want %q,true", in, got, ok, want)
+		}
+	}
+	for _, raw := range []string{"", "person", "Person", "PERSON`) DETACH DELETE n //"} {
+		if got, ok := CypherEntityLabel(raw); ok {
+			t.Errorf("CypherEntityLabel(%q) = %q,true; want ok=false", raw, got)
+		}
+	}
+}

--- a/internal/graph/schema.go
+++ b/internal/graph/schema.go
@@ -1,0 +1,50 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// schemaStatements are the constraints and indexes the projection depends on.
+//
+// The three uniqueness constraints are the safety net under every MERGE: a
+// MERGE on a property with no uniqueness constraint can create duplicate nodes
+// under concurrency. They also provide the backing index, which is why no
+// separate index on pgId is declared.
+//
+// Neo4j Community does not support relationship uniqueness/existence
+// constraints (Enterprise only), so relationship de-duplication is guaranteed
+// structurally instead: the projection worker is the single serial writer and
+// every relationship MERGE keys on pgId (= entity_relations.id).
+var schemaStatements = []string{
+	`CREATE CONSTRAINT entity_pg_id IF NOT EXISTS FOR (e:Entity) REQUIRE e.pgId IS UNIQUE`,
+	`CREATE CONSTRAINT document_pg_id IF NOT EXISTS FOR (d:Document) REQUIRE d.pgId IS UNIQUE`,
+	`CREATE CONSTRAINT projection_state_id IF NOT EXISTS FOR (p:ProjectionState) REQUIRE p.id IS UNIQUE`,
+	`CREATE INDEX entity_normalized_name IF NOT EXISTS FOR (e:Entity) ON (e.normalizedName)`,
+}
+
+// EnsureSchema applies the DDL above. Every statement is IF NOT EXISTS, so
+// repeated calls are safe — the worker calls it once per process on its first
+// successful tick.
+//
+// One transaction per statement is required, not stylistic: Neo4j refuses to
+// mix schema and data operations inside a single transaction, and batching
+// several schema commands together is also rejected on some versions.
+func (c *Client) EnsureSchema(ctx context.Context) error {
+	for _, stmt := range schemaStatements {
+		if _, err := c.Write(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+			res, err := tx.Run(ctx, stmt, nil)
+			if err != nil {
+				return nil, err
+			}
+			// Consume, not just Run: server-side failures for a statement that
+			// streams no rows are only surfaced when the result is drained.
+			return res.Consume(ctx)
+		}); err != nil {
+			return fmt.Errorf("graph: ensure schema: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/graph/schema_integration_test.go
+++ b/internal/graph/schema_integration_test.go
@@ -1,0 +1,76 @@
+package graph
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+)
+
+// newTestClient returns a Client pointed at a throwaway Neo4j, or skips.
+//
+// CI runs without Neo4j, and the projection is a derived store, so these tests
+// are opt-in: set NEO4J_TEST_URI (and NEO4J_TEST_PASSWORD) to run them. They
+// are destructive — they wipe the target database — so they must never be
+// pointed at anything but a scratch instance.
+func newTestClient(t *testing.T) *Client {
+	t.Helper()
+	uri := os.Getenv("NEO4J_TEST_URI")
+	if uri == "" {
+		t.Skip("NEO4J_TEST_URI not set — skipping Neo4j integration test")
+	}
+	c, err := New(context.Background(), Config{
+		URI: uri,
+		// Both spellings are accepted: a mismatch here fails open (falls back to
+		// "neo4j") instead of erroring, so the wrong variable name would be
+		// invisible until the day the scratch instance uses a different user.
+		Username: envOrDefault("NEO4J_TEST_USERNAME", envOrDefault("NEO4J_TEST_USER", "neo4j")),
+		Password: os.Getenv("NEO4J_TEST_PASSWORD"),
+	})
+	if err != nil {
+		t.Fatalf("connect to test neo4j: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close(context.Background()) })
+	return c
+}
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// TestEnsureSchemaIntegration pins idempotency (the worker calls EnsureSchema
+// on every process start) and the constraint count the MERGE safety argument
+// depends on.
+func TestEnsureSchemaIntegration(t *testing.T) {
+	c := newTestClient(t)
+	ctx := context.Background()
+
+	for i := 0; i < 2; i++ {
+		if err := c.EnsureSchema(ctx); err != nil {
+			t.Fatalf("EnsureSchema call %d: %v", i+1, err)
+		}
+	}
+
+	out, err := c.Read(ctx, func(tx neo4j.ManagedTransaction) (any, error) {
+		res, err := tx.Run(ctx, `SHOW CONSTRAINTS YIELD name RETURN count(*) AS n`, nil)
+		if err != nil {
+			return nil, err
+		}
+		rec, err := res.Single(ctx)
+		if err != nil {
+			return nil, err
+		}
+		n, _ := rec.Get("n")
+		return n, nil
+	})
+	if err != nil {
+		t.Fatalf("SHOW CONSTRAINTS: %v", err)
+	}
+	if got, ok := out.(int64); !ok || got < 3 {
+		t.Fatalf("constraint count = %v, want at least 3", out)
+	}
+}

--- a/internal/model/projection.go
+++ b/internal/model/projection.go
@@ -1,0 +1,55 @@
+package model
+
+import "time"
+
+// Types in this file are the wire shape between the PostgreSQL read queries
+// (store.GraphSource) and the Neo4j projector (graph.Projector). They are
+// deliberately flat: one row of the projection query is one struct, so the
+// projector never has to re-join anything.
+
+// ProjectionRelation is one entity_relations row joined with both endpoint
+// entities. Relations and their endpoints are fetched together on purpose —
+// projecting entities in a separate pass would create a "relation arrived
+// before its node" ordering dependency, and skipping such a relation while
+// still advancing the watermark would lose it permanently.
+type ProjectionRelation struct {
+	ID           int64
+	FromEntityID int64
+	FromName     string
+	FromType     string
+	ToEntityID   int64
+	ToName       string
+	ToType       string
+	Type         RelationType
+	// EvidenceDocumentID is the UUID in string form: it is used as a Neo4j
+	// node key, and Neo4j has no UUID type.
+	EvidenceDocumentID string
+	Confidence         float64
+	ObservedAt         time.Time
+}
+
+// ProjectionMention is one document_entities row joined with its document and
+// entity. OccurredAt is nullable (documents.occurred_at) and is passed to
+// Neo4j as null rather than a zero time, so "unknown" stays distinguishable
+// from "epoch".
+//
+// Note what is absent: title and content. The graph never stores document
+// text (privacy policy §1) — a leaked Neo4j volume must expose the shape of
+// the graph, not the contents of conversations.
+type ProjectionMention struct {
+	DocumentID string
+	SourceType string
+	OccurredAt *time.Time
+	EntityID   int64
+	EntityName string
+	EntityType string
+}
+
+// GraphProjectionState is the projector's bookkeeping, stored inside Neo4j
+// (not PostgreSQL) so that deleting the Neo4j volume also deletes the
+// watermark. A watermark that outlives the graph it describes would make a
+// rebuild silently incomplete.
+type GraphProjectionState struct {
+	LastRelationID int64
+	ResetToken     string
+}

--- a/internal/store/graph_source.go
+++ b/internal/store/graph_source.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+)
+
+// GraphSource is the read-only PostgreSQL side of the Neo4j projection.
+// It is a separate type (not a method set bolted onto an existing store) so
+// that the projection pipeline owns its own queries and cannot accidentally
+// acquire write methods.
+type GraphSource struct {
+	pg *Postgres
+}
+
+// NewGraphSource returns a GraphSource backed by the given Postgres instance.
+func NewGraphSource(pg *Postgres) *GraphSource {
+	return &GraphSource{pg: pg}
+}
+
+// errGraphSourceNoDB is returned instead of panicking on a zero-value
+// GraphSource, which is what unit tests construct to exercise validation.
+var errGraphSourceNoDB = errors.New("graph source: no database handle")
+
+const listRelationsSQL = `
+	SELECT r.id, fe.id, fe.name, fe.type, te.id, te.name, te.type,
+	       r.type, r.evidence_document_id, r.confidence, r.observed_at
+	  FROM entity_relations r
+	  JOIN entities fe ON fe.id = r.from_entity_id
+	  JOIN entities te ON te.id = r.to_entity_id
+	 WHERE r.id > $1
+	 ORDER BY r.id
+	 LIMIT $2`
+
+// ListRelationsAfter returns relations with id greater than afterID, oldest
+// first, together with both endpoint entities.
+//
+// entity_relations is append-only (inserted with ON CONFLICT DO NOTHING and
+// never updated), which is what makes an id watermark correct here. The one
+// gap is that BIGSERIAL ids are handed out before commit, so a transaction
+// holding id 100 can commit after one holding 101 — a strictly increasing
+// watermark can step over it. That is handled by the worker re-reading an
+// overlap window each cycle, which is only safe because the projection is
+// idempotent.
+func (s *GraphSource) ListRelationsAfter(ctx context.Context, afterID int64, limit int) ([]model.ProjectionRelation, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("graph source: limit must be positive, got %d", limit)
+	}
+	if s == nil || s.pg == nil {
+		return nil, errGraphSourceNoDB
+	}
+
+	rows, err := s.pg.pool.Query(ctx, listRelationsSQL, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("graph source: list relations: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]model.ProjectionRelation, 0, limit)
+	for rows.Next() {
+		var (
+			rel        model.ProjectionRelation
+			evidenceID uuid.UUID
+		)
+		if err := rows.Scan(
+			&rel.ID,
+			&rel.FromEntityID, &rel.FromName, &rel.FromType,
+			&rel.ToEntityID, &rel.ToName, &rel.ToType,
+			&rel.Type, &evidenceID, &rel.Confidence, &rel.ObservedAt,
+		); err != nil {
+			return nil, fmt.Errorf("graph source: scan relation: %w", err)
+		}
+		rel.EvidenceDocumentID = evidenceID.String()
+		out = append(out, rel)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("graph source: list relations iter: %w", err)
+	}
+	return out, nil
+}
+
+// mentionCursorClause returns the keyset predicate for a non-empty cursor and
+// the empty string otherwise.
+//
+// Two statement variants instead of one with `($1 = '' OR (…) > ($1::uuid, $2))`:
+// PostgreSQL is free to evaluate both sides of an OR, and casting '' to uuid
+// raises "invalid input syntax for type uuid". The cursor VALUE is still bound
+// as a parameter — only the presence of the clause is decided in Go.
+func mentionCursorClause(afterDocumentID string) string {
+	if afterDocumentID == "" {
+		return ""
+	}
+	return `AND (de.document_id, de.entity_id) > ($1::uuid, $2)`
+}
+
+// ListMentionsAfter returns document_entities rows (joined to their document
+// and entity) after the given keyset cursor, ordered by (document_id,
+// entity_id).
+//
+// document_entities has no monotonic key — its primary key is composite and
+// document ids are random UUIDs — so a keyset cursor can only paginate one
+// sweep; it cannot be used as an incremental watermark across cycles, because
+// a newly inserted row can land "below" a saved cursor. The worker therefore
+// restarts each cycle from an empty cursor and sweeps the whole table. That is
+// cheap at the current table size and is flagged in the plan's open risks for
+// revisiting past ~100k rows.
+func (s *GraphSource) ListMentionsAfter(ctx context.Context, afterDocumentID string, afterEntityID int64, limit int) ([]model.ProjectionMention, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("graph source: limit must be positive, got %d", limit)
+	}
+	if s == nil || s.pg == nil {
+		return nil, errGraphSourceNoDB
+	}
+
+	var (
+		sql  string
+		args []any
+	)
+	if clause := mentionCursorClause(afterDocumentID); clause != "" {
+		sql = `
+			SELECT d.id, d.source_type, d.occurred_at, e.id, e.name, e.type
+			  FROM document_entities de
+			  JOIN documents d ON d.id = de.document_id
+			  JOIN entities  e ON e.id = de.entity_id
+			 WHERE d.status = 'active'
+			   ` + clause + `
+			 ORDER BY de.document_id, de.entity_id
+			 LIMIT $3`
+		args = []any{afterDocumentID, afterEntityID, limit}
+	} else {
+		sql = `
+			SELECT d.id, d.source_type, d.occurred_at, e.id, e.name, e.type
+			  FROM document_entities de
+			  JOIN documents d ON d.id = de.document_id
+			  JOIN entities  e ON e.id = de.entity_id
+			 WHERE d.status = 'active'
+			 ORDER BY de.document_id, de.entity_id
+			 LIMIT $1`
+		args = []any{limit}
+	}
+
+	rows, err := s.pg.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("graph source: list mentions: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]model.ProjectionMention, 0, limit)
+	for rows.Next() {
+		var (
+			m     model.ProjectionMention
+			docID uuid.UUID
+		)
+		if err := rows.Scan(&docID, &m.SourceType, &m.OccurredAt, &m.EntityID, &m.EntityName, &m.EntityType); err != nil {
+			return nil, fmt.Errorf("graph source: scan mention: %w", err)
+		}
+		m.DocumentID = docID.String()
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("graph source: list mentions iter: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/graph_source_test.go
+++ b/internal/store/graph_source_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The store package has no database harness — these tests cover only the pure
+// parts (argument validation and cursor-clause construction). The SQL itself
+// is validated separately against a real PostgreSQL (see the Part B plan,
+// Task 4 Step 4); a passing unit test here proves nothing about SQL validity.
+
+func TestListRelationsAfter_RejectsNonPositiveLimit(t *testing.T) {
+	if _, err := (&GraphSource{}).ListRelationsAfter(context.Background(), 0, 0); err == nil {
+		t.Fatal("limit=0: want error, got nil")
+	}
+	if _, err := (&GraphSource{}).ListRelationsAfter(context.Background(), 0, -1); err == nil {
+		t.Fatal("limit=-1: want error, got nil")
+	}
+}
+
+func TestListMentionsAfter_RejectsNonPositiveLimit(t *testing.T) {
+	if _, err := (&GraphSource{}).ListMentionsAfter(context.Background(), "", 0, 0); err == nil {
+		t.Fatal("limit=0: want error, got nil")
+	}
+}
+
+// TestMentionCursorClause pins the reason the mention query is assembled from
+// two variants instead of one statement with an `$1 = '' OR ...` guard:
+// PostgreSQL does not guarantee OR short-circuiting, so an empty cursor
+// reaching a `$1::uuid` cast is a runtime error waiting to happen.
+func TestMentionCursorClause(t *testing.T) {
+	if got := mentionCursorClause(""); got != "" {
+		t.Errorf("empty cursor = %q, want %q", got, "")
+	}
+	got := mentionCursorClause("00000000-0000-0000-0000-0000000000aa")
+	if got == "" {
+		t.Fatal("non-empty cursor: want WHERE clause")
+	}
+	if !strings.Contains(got, "$1::uuid") || !strings.Contains(got, "$2") {
+		t.Errorf("cursor clause = %q, want it to bind $1::uuid and $2", got)
+	}
+}
+
+// TestMentionCursorClause_NoInterpolation guards the clause builder against
+// ever embedding the cursor value itself into SQL.
+func TestMentionCursorClause_NoInterpolation(t *testing.T) {
+	cursor := "'; DROP TABLE documents; --"
+	if got := mentionCursorClause(cursor); strings.Contains(got, "DROP") {
+		t.Fatalf("cursor value leaked into SQL: %q", got)
+	}
+}

--- a/internal/worker/graph_projection_worker.go
+++ b/internal/worker/graph_projection_worker.go
@@ -1,0 +1,268 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// Tunables for the graph projection worker.
+const (
+	defaultGraphProjectionInterval = 5 * time.Minute
+	defaultGraphProjectionBatch    = 500
+
+	// defaultGraphProjectionOverlap re-reads this many relation ids below the
+	// watermark on every cycle. entity_relations ids come from a BIGSERIAL, so
+	// a transaction that reserved a lower id can commit after one with a
+	// higher id; without an overlap window a strictly-increasing watermark
+	// would step over it. Re-reading is free in correctness terms because
+	// every projection write is idempotent (relationship MERGE keys on pgId).
+	defaultGraphProjectionOverlap int64 = 1000
+
+	// graphProjectionTickTimeout bounds one whole tick. Unlike the extraction
+	// worker there is no LLM in this path, so a single modest budget is
+	// enough — the only remote calls are PostgreSQL reads and Neo4j writes.
+	graphProjectionTickTimeout = 2 * time.Minute
+
+	// maxRelationBatchesPerTick keeps a first-run backfill from monopolising
+	// the process: the remaining batches are simply picked up next tick.
+	maxRelationBatchesPerTick = 20
+
+	// maxMentionPagesPerTick bounds the full sweep of document_entities for
+	// the same reason.
+	maxMentionPagesPerTick = 200
+)
+
+// GraphProjectionSource is the PostgreSQL read side. *store.GraphSource
+// satisfies it.
+type GraphProjectionSource interface {
+	ListRelationsAfter(ctx context.Context, afterID int64, limit int) ([]model.ProjectionRelation, error)
+	ListMentionsAfter(ctx context.Context, afterDocumentID string, afterEntityID int64, limit int) ([]model.ProjectionMention, error)
+}
+
+// GraphProjector is the Neo4j write side. *graph.Projector satisfies it; the
+// interface is declared here so tests can substitute a fake without a live
+// database.
+type GraphProjector interface {
+	EnsureSchema(ctx context.Context) error
+	State(ctx context.Context) (model.GraphProjectionState, error)
+	UpsertRelations(ctx context.Context, rows []model.ProjectionRelation) error
+	UpsertMentions(ctx context.Context, rows []model.ProjectionMention) error
+	SetLastRelationID(ctx context.Context, id int64) error
+	SetResetToken(ctx context.Context, token string) error
+	Wipe(ctx context.Context) error
+}
+
+// GraphProjectionWorkerConfig holds configuration for GraphProjectionWorker.
+type GraphProjectionWorkerConfig struct {
+	Source    GraphProjectionSource
+	Projector GraphProjector
+	Interval  time.Duration
+	BatchSize int
+	Overlap   int64
+	// ResetToken is compared against the token stored in the graph. Changing
+	// it is the rebuild switch: the next tick wipes the graph and reprojects
+	// from scratch. Empty on both sides (the default) means "never rebuild".
+	ResetToken string
+}
+
+// GraphProjectionWorker mirrors ExtractionWorker's shape — a ticker driving
+// serial batches, where an individual failure logs and returns instead of
+// killing the worker.
+//
+// The one invariant worth stating out loud: the watermark only advances after
+// the corresponding batch has been written successfully. Advancing past a
+// failed batch would lose those relations permanently, since nothing ever
+// revisits ids below the watermark (outside the overlap window).
+type GraphProjectionWorker struct {
+	source     GraphProjectionSource
+	projector  GraphProjector
+	interval   time.Duration
+	batchSize  int
+	overlap    int64
+	resetToken string
+
+	// schemaReady records that EnsureSchema succeeded once in this process.
+	// Constraints survive a Wipe, so this is not reset on rebuild.
+	schemaReady bool
+}
+
+// NewGraphProjectionWorker constructs a worker from cfg. Panics when required
+// fields are nil (programming error) — mirrors NewExtractionWorker.
+func NewGraphProjectionWorker(cfg GraphProjectionWorkerConfig) *GraphProjectionWorker {
+	if cfg.Source == nil {
+		panic("GraphProjectionWorkerConfig.Source must not be nil")
+	}
+	if cfg.Projector == nil {
+		panic("GraphProjectionWorkerConfig.Projector must not be nil")
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = defaultGraphProjectionInterval
+	}
+	batchSize := cfg.BatchSize
+	if batchSize <= 0 {
+		batchSize = defaultGraphProjectionBatch
+	}
+	overlap := cfg.Overlap
+	if overlap <= 0 {
+		overlap = defaultGraphProjectionOverlap
+	}
+	return &GraphProjectionWorker{
+		source:     cfg.Source,
+		projector:  cfg.Projector,
+		interval:   interval,
+		batchSize:  batchSize,
+		overlap:    overlap,
+		resetToken: cfg.ResetToken,
+	}
+}
+
+// Run blocks until ctx is cancelled (mirrors ExtractionWorker.Run).
+func (w *GraphProjectionWorker) Run(ctx context.Context) {
+	slog.Info("graph projection worker started", "interval", w.interval, "batch_size", w.batchSize)
+	w.tick(ctx)
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("graph projection worker stopped")
+			return
+		case <-ticker.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+// tick projects one cycle: schema → state/rebuild → relations → mentions.
+//
+// Logging carries counts and durations only. Entity names, document titles and
+// Cypher parameter maps are never logged (privacy policy §4) — the graph's
+// value is precisely that it contains real names.
+func (w *GraphProjectionWorker) tick(parent context.Context) {
+	ctx, cancel := context.WithTimeout(parent, graphProjectionTickTimeout)
+	defer cancel()
+	started := time.Now()
+
+	if !w.schemaReady {
+		if err := w.projector.EnsureSchema(ctx); err != nil {
+			slog.Warn("graph projection: ensure schema failed", "error", err)
+			return
+		}
+		w.schemaReady = true
+	}
+
+	state, err := w.projector.State(ctx)
+	if err != nil {
+		slog.Warn("graph projection: read state failed", "error", err)
+		return
+	}
+
+	if state.ResetToken != w.resetToken {
+		slog.Info("graph projection: reset token changed, rebuilding graph")
+		if err := w.projector.Wipe(ctx); err != nil {
+			slog.Warn("graph projection: wipe failed", "error", err)
+			return
+		}
+		if err := w.projector.SetResetToken(ctx, w.resetToken); err != nil {
+			slog.Warn("graph projection: set reset token failed", "error", err)
+			return
+		}
+		state = model.GraphProjectionState{ResetToken: w.resetToken}
+	}
+
+	relations := w.projectRelations(ctx, state.LastRelationID)
+	mentions := w.projectMentions(ctx)
+
+	if relations > 0 || mentions > 0 {
+		slog.Info("graph projection: cycle complete",
+			"relations", relations, "mentions", mentions, "duration_ms", time.Since(started).Milliseconds())
+	}
+}
+
+// projectRelations walks forward from the watermark (minus the overlap window)
+// and returns how many rows were projected.
+func (w *GraphProjectionWorker) projectRelations(ctx context.Context, watermark int64) int {
+	cursor := watermark - w.overlap
+	if cursor < 0 {
+		cursor = 0
+	}
+
+	projected := 0
+	for batch := 0; batch < maxRelationBatchesPerTick; batch++ {
+		if ctx.Err() != nil {
+			return projected
+		}
+		rows, err := w.source.ListRelationsAfter(ctx, cursor, w.batchSize)
+		if err != nil {
+			slog.Warn("graph projection: list relations failed", "error", err)
+			return projected
+		}
+		if len(rows) == 0 {
+			return projected
+		}
+		if err := w.projector.UpsertRelations(ctx, rows); err != nil {
+			// Return WITHOUT advancing the watermark. The same rows are read
+			// again next tick.
+			slog.Warn("graph projection: upsert relations failed", "count", len(rows), "error", err)
+			return projected
+		}
+		projected += len(rows)
+
+		maxID := rows[len(rows)-1].ID
+		if err := w.projector.SetLastRelationID(ctx, maxID); err != nil {
+			slog.Warn("graph projection: set watermark failed", "error", err)
+			return projected
+		}
+		cursor = maxID
+		if len(rows) < w.batchSize {
+			return projected
+		}
+	}
+	slog.Info("graph projection: relation batch cap reached, continuing next tick")
+	return projected
+}
+
+// projectMentions sweeps document_entities from the beginning every cycle.
+//
+// A saved cursor cannot work here: the keyset is (document_id, entity_id) and
+// document ids are random UUIDs, so a newly linked document can sort BELOW a
+// previously saved cursor and would never be picked up. The table is small
+// enough that a full sweep is cheap; the plan flags ~100k rows as the point to
+// switch to a created_at watermark instead.
+func (w *GraphProjectionWorker) projectMentions(ctx context.Context) int {
+	var (
+		cursorDoc    string
+		cursorEntity int64
+		projected    int
+	)
+	for page := 0; page < maxMentionPagesPerTick; page++ {
+		if ctx.Err() != nil {
+			return projected
+		}
+		rows, err := w.source.ListMentionsAfter(ctx, cursorDoc, cursorEntity, w.batchSize)
+		if err != nil {
+			slog.Warn("graph projection: list mentions failed", "error", err)
+			return projected
+		}
+		if len(rows) == 0 {
+			return projected
+		}
+		if err := w.projector.UpsertMentions(ctx, rows); err != nil {
+			slog.Warn("graph projection: upsert mentions failed", "count", len(rows), "error", err)
+			return projected
+		}
+		projected += len(rows)
+
+		last := rows[len(rows)-1]
+		cursorDoc, cursorEntity = last.DocumentID, last.EntityID
+		if len(rows) < w.batchSize {
+			return projected
+		}
+	}
+	slog.Info("graph projection: mention page cap reached, continuing next tick")
+	return projected
+}

--- a/internal/worker/graph_projection_worker_test.go
+++ b/internal/worker/graph_projection_worker_test.go
@@ -1,0 +1,227 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// --- fakes ---
+
+type fakeGraphSource struct {
+	mu        sync.Mutex
+	relations []model.ProjectionRelation
+	mentions  []model.ProjectionMention
+	relErr    error
+	mentErr   error
+
+	relCalls  []int64
+	mentCalls []string
+}
+
+func (f *fakeGraphSource) ListRelationsAfter(_ context.Context, afterID int64, limit int) ([]model.ProjectionRelation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.relCalls = append(f.relCalls, afterID)
+	if f.relErr != nil {
+		return nil, f.relErr
+	}
+	out := make([]model.ProjectionRelation, 0, limit)
+	for _, r := range f.relations {
+		if r.ID > afterID && len(out) < limit {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeGraphSource) ListMentionsAfter(_ context.Context, afterDocumentID string, afterEntityID int64, limit int) ([]model.ProjectionMention, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.mentCalls = append(f.mentCalls, afterDocumentID)
+	if f.mentErr != nil {
+		return nil, f.mentErr
+	}
+	out := make([]model.ProjectionMention, 0, limit)
+	for _, m := range f.mentions {
+		after := m.DocumentID > afterDocumentID ||
+			(m.DocumentID == afterDocumentID && m.EntityID > afterEntityID)
+		if afterDocumentID == "" {
+			after = true
+		}
+		if after && len(out) < limit {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+type fakeProjector struct {
+	state          model.GraphProjectionState
+	lastRelationID int64
+	resetToken     string
+	wiped          bool
+	schemaCalls    int
+
+	upsertErr   error
+	upsertCalls int
+	mentionRows int
+}
+
+func (f *fakeProjector) EnsureSchema(context.Context) error { f.schemaCalls++; return nil }
+func (f *fakeProjector) State(context.Context) (model.GraphProjectionState, error) {
+	return f.state, nil
+}
+
+func (f *fakeProjector) UpsertRelations(_ context.Context, rows []model.ProjectionRelation) error {
+	f.upsertCalls++
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	_ = rows
+	return nil
+}
+
+func (f *fakeProjector) UpsertMentions(_ context.Context, rows []model.ProjectionMention) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.mentionRows += len(rows)
+	return nil
+}
+
+func (f *fakeProjector) SetLastRelationID(_ context.Context, id int64) error {
+	f.lastRelationID = id
+	f.state.LastRelationID = id
+	return nil
+}
+
+func (f *fakeProjector) SetResetToken(_ context.Context, token string) error {
+	f.resetToken = token
+	f.state.ResetToken = token
+	return nil
+}
+
+func (f *fakeProjector) Wipe(context.Context) error {
+	f.wiped = true
+	f.state = model.GraphProjectionState{}
+	return nil
+}
+
+// --- tests ---
+
+func TestGraphProjectionWorker_TickAdvancesWatermark(t *testing.T) {
+	src := &fakeGraphSource{relations: []model.ProjectionRelation{{ID: 7}, {ID: 9}}}
+	proj := &fakeProjector{}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{Source: src, Projector: proj, BatchSize: 10, Overlap: 1000}).
+		tick(context.Background())
+	if proj.lastRelationID != 9 {
+		t.Fatalf("lastRelationID = %d, want 9", proj.lastRelationID)
+	}
+}
+
+func TestGraphProjectionWorker_ResetTokenTriggersWipe(t *testing.T) {
+	proj := &fakeProjector{state: model.GraphProjectionState{LastRelationID: 100, ResetToken: "old"}}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{Source: &fakeGraphSource{}, Projector: proj, ResetToken: "new"}).
+		tick(context.Background())
+	if !proj.wiped {
+		t.Fatal("reset token changed: want Wipe() called")
+	}
+	if proj.resetToken != "new" {
+		t.Fatalf("resetToken = %q, want %q", proj.resetToken, "new")
+	}
+}
+
+// TestGraphProjectionWorker_SameResetTokenDoesNotWipe is the other half of the
+// rebuild switch: the default (empty token on both sides) must never destroy
+// the graph on a routine tick.
+func TestGraphProjectionWorker_SameResetTokenDoesNotWipe(t *testing.T) {
+	proj := &fakeProjector{state: model.GraphProjectionState{LastRelationID: 100, ResetToken: ""}}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{Source: &fakeGraphSource{}, Projector: proj, ResetToken: ""}).
+		tick(context.Background())
+	if proj.wiped {
+		t.Fatal("unchanged reset token: Wipe() must not be called")
+	}
+}
+
+// TestGraphProjectionWorker_SurvivesProjectorError is the core safety
+// property: a batch that failed to project must NOT move the watermark.
+// Advancing past a failed batch loses those relations permanently, because
+// nothing ever revisits ids below the watermark.
+func TestGraphProjectionWorker_SurvivesProjectorError(t *testing.T) {
+	proj := &fakeProjector{upsertErr: errors.New("neo4j down")}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{
+		Source: &fakeGraphSource{relations: []model.ProjectionRelation{{ID: 1}}}, Projector: proj,
+	}).tick(context.Background()) // must not panic
+	if proj.lastRelationID != 0 {
+		t.Fatalf("watermark advanced past a failed batch: %d, want 0", proj.lastRelationID)
+	}
+}
+
+// TestGraphProjectionWorker_SurvivesSourceError covers the same invariant for
+// a PostgreSQL-side failure.
+func TestGraphProjectionWorker_SurvivesSourceError(t *testing.T) {
+	proj := &fakeProjector{state: model.GraphProjectionState{LastRelationID: 5}}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{
+		Source: &fakeGraphSource{relErr: errors.New("postgres down")}, Projector: proj,
+	}).tick(context.Background())
+	if proj.lastRelationID != 0 {
+		t.Fatalf("SetLastRelationID called after a source error (=%d); watermark must not move", proj.lastRelationID)
+	}
+}
+
+// TestGraphProjectionWorker_RereadsOverlapWindow pins the BIGSERIAL
+// commit-order defence: each cycle re-reads Overlap ids below the watermark,
+// which is only safe because the projection is idempotent.
+func TestGraphProjectionWorker_RereadsOverlapWindow(t *testing.T) {
+	src := &fakeGraphSource{}
+	proj := &fakeProjector{state: model.GraphProjectionState{LastRelationID: 5000}}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{
+		Source: src, Projector: proj, BatchSize: 10, Overlap: 1000,
+	}).tick(context.Background())
+	if len(src.relCalls) == 0 || src.relCalls[0] != 4000 {
+		t.Fatalf("first ListRelationsAfter cursor = %v, want 4000", src.relCalls)
+	}
+}
+
+// TestGraphProjectionWorker_OverlapNeverGoesNegative guards the early-life
+// case where the watermark is smaller than the overlap window.
+func TestGraphProjectionWorker_OverlapNeverGoesNegative(t *testing.T) {
+	src := &fakeGraphSource{}
+	proj := &fakeProjector{state: model.GraphProjectionState{LastRelationID: 3}}
+	NewGraphProjectionWorker(GraphProjectionWorkerConfig{
+		Source: src, Projector: proj, BatchSize: 10, Overlap: 1000,
+	}).tick(context.Background())
+	if len(src.relCalls) == 0 || src.relCalls[0] != 0 {
+		t.Fatalf("first ListRelationsAfter cursor = %v, want 0", src.relCalls)
+	}
+}
+
+// TestGraphProjectionWorker_MentionSweepStartsFromScratch pins the full-sweep
+// decision: document_entities has no monotonic key, so a saved cursor would
+// miss rows inserted "below" it (document ids are random UUIDs).
+func TestGraphProjectionWorker_MentionSweepStartsFromScratch(t *testing.T) {
+	src := &fakeGraphSource{mentions: []model.ProjectionMention{
+		{DocumentID: "00000000-0000-0000-0000-00000000000a", EntityID: 1},
+		{DocumentID: "00000000-0000-0000-0000-00000000000b", EntityID: 2},
+	}}
+	proj := &fakeProjector{}
+	w := NewGraphProjectionWorker(GraphProjectionWorkerConfig{
+		Source: src, Projector: proj, BatchSize: 10, Overlap: 1000,
+	})
+	w.tick(context.Background())
+	w.tick(context.Background())
+
+	if proj.mentionRows != 4 {
+		t.Fatalf("mention rows projected over 2 ticks = %d, want 4 (full sweep each tick)", proj.mentionRows)
+	}
+	for _, c := range src.mentCalls {
+		if c == "" {
+			return // at least one sweep started from an empty cursor
+		}
+	}
+	t.Fatalf("no mention sweep started from an empty cursor: %v", src.mentCalls)
+}


### PR DESCRIPTION
## 증상/배경

Part B(지식 그래프)는 PostgreSQL의 `entity_relations`/`document_entities`를 Neo4j로 투영해 그래프 순회 질의(연관 엔티티, 근거 문서, 관계 경로)를 지원하기 위한 백엔드다. PostgreSQL이 진실의 원천이고 Neo4j는 언제든 재구축 가능한 파생 투영으로 설계했다.

Neo4j 배치는 원래 계획서(`docs/superpowers/plans/2026-08-18-graph-projection-view.md`)에서 ubuntu1을 전제했으나, macmini 컨테이너가 ubuntu1의 Tailscale IP에 도달하지 못하고 역방향도 막혀 있음을 실측으로 확인했다. postgres의 ubuntu1 이전이 보류되며 ubuntu1 배치 근거가 사라져, 이번 PR은 **Neo4j를 macmini에 배치**하는 것으로 방향을 조정했다.

## 설계 요약

- `internal/graph/`: Neo4j 드라이버(`client.go`), 스키마 보증(`schema.go`, 인덱스/제약), 관계 타입 화이트리스트(`reltypes.go`, 8종 닫힌 어휘), 멱등 투영기(`projector.go`, MERGE 키 = `entity_relations.id`), 고정 읽기 쿼리 카탈로그(`queries.go`, 4종)
- 투영 워커(`internal/worker/graph_projection_worker.go`): 기존 `ExtractionWorker` 패턴(ticker + 직렬 배치 + env 게이팅)을 재사용. **기본 비활성**. 실패한 배치에서 워터마크가 전진하지 않도록 테스트로 고정
- 읽기 API(`internal/api/graph.go`): GET 엔드포인트 4종. Cypher 쓰기 절(`CREATE`/`MERGE`/`DELETE`/`SET`/`REMOVE` 등)을 정적 가드로 차단, 응답 크기 상한 적용
- `internal/model/projection.go`, `internal/store/graph_source.go`: PostgreSQL 쪽 투영 소스 읽기 계층

## 검증

스크래치 Neo4j 5.26-community 컨테이너를 띄워 `internal/graph` 통합 테스트 8건을 전부 실행 검증했다:
- 멱등성: 동일 소스에 대해 2회 투영 후 관계 수 동일
- `PROFILE`로 인덱스 사용 확인 (AllNodesScan 없음)
- `:Document` 노드에 `title`/`content`가 저장되지 않음 (원문 미유출)
- 질의 로그에 파라미터 값이 남지 않음

## 배포 후 확인사항

- **`NEO4J_PASSWORD`가 macmini `.env.local`에 반드시 있어야 한다.** 값이 없으면 neo4j 서비스를 띄우지 않아도 `docker-compose` 파싱 자체가 실패해 다른 서비스 재기동까지 막힌다.
- 투영 워커는 **기본 비활성**이다. 활성화는 별도 조작(env 설정)이 필요하다.
- `internal/graph` 통합 테스트는 `NEO4J_TEST_URI`가 없으면 SKIP된다. 실행 시 **8건 전부 PASS**해야 하며, `-run Integration` 같은 이름 필터는 일부 테스트를 조용히 제외할 수 있으니 실행된 테스트 건수를 세어 확인할 것.

## 알려진 위험

- `entry` 읽기 쿼리는 라벨 스캔이다. 합성 그래프(관계 20k)에서 cold 546ms이고 dbHits가 관계 수에 선형으로 증가해, 관계 100k 부근에서 5초 트랜잭션 타임아웃에 근접할 수 있다.
- `Evidence()`는 멘션이 아직 투영되지 않은 경우 오류 없이 0건을 반환한다. UI에서 "근거 없음"과 "미투영"이 구분되지 않는다.
- Neo4j Community에는 관계 유니크 제약도 RBAC도 없다. 중복 방지가 "투영 워커가 유일한 직렬 writer"라는 운영 규약에 의존한다.
- `cmd/collector/main.go`에는 `llm.Config.Thinking` 배선이 없다(`cmd/server/main.go`에는 포함됨). 제로값이 disabled이므로 동작에는 영향이 없고, `LLM_THINKING=enabled`가 collector에서만 무시된다.

## 부록

Part C(액션·브리핑), Part D(피드백 루프) 구현 계획서를 함께 포함한다(코드 구현은 이 PR 범위 밖).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>