### PR TITLE
지식 그래프 뷰 화면 (Part B 프런트엔드)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -13,6 +13,7 @@
         "next-auth": "^5.0.0-beta.31",
         "react": "19.2.5",
         "react-dom": "19.2.5",
+        "react-force-graph-2d": "^1.29.1",
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "remark-gfm": "^4.0.1",
@@ -374,6 +375,8 @@
 
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": "4.2.2" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@25.0.0", "", {}, "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -484,6 +487,8 @@
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
+    "accessor-fn": ["accessor-fn@1.5.3", "", {}, "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "8.16.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -536,6 +541,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.18", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A=="],
 
+    "bezier-js": ["bezier-js@6.1.4", "", {}, "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "1.0.2", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -553,6 +560,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001787", "", {}, "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg=="],
+
+    "canvas-color-tracker": ["canvas-color-tracker@1.3.2", "", { "dependencies": { "tinycolor2": "^1.6.0" } }, "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -611,6 +620,44 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-binarytree": ["d3-binarytree@1.0.2", "", {}, "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-force-3d": ["d3-force-3d@3.0.6", "", { "dependencies": { "d3-binarytree": "1", "d3-dispatch": "1 - 3", "d3-octree": "1", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-octree": ["d3-octree@1.1.0", "", {}, "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
 
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
@@ -750,7 +797,11 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "float-tooltip": ["float-tooltip@1.7.5", "", { "dependencies": { "d3-selection": "2 - 3", "kapsule": "^1.16", "preact": "10" } }, "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "force-graph": ["force-graph@1.51.4", "", { "dependencies": { "@tweenjs/tween.js": "18 - 25", "accessor-fn": "1", "bezier-js": "3 - 6", "canvas-color-tracker": "^1.3", "d3-array": "1 - 3", "d3-drag": "2 - 3", "d3-force-3d": "2 - 3", "d3-scale": "1 - 4", "d3-scale-chromatic": "1 - 3", "d3-selection": "2 - 3", "d3-zoom": "2 - 3", "float-tooltip": "^1.7", "index-array-by": "1", "kapsule": "^1.16", "lodash-es": "4" } }, "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -834,11 +885,15 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "index-array-by": ["index-array-by@1.4.2", "", {}, "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw=="],
+
     "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "1.3.0", "hasown": "2.0.2", "side-channel": "1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -918,6 +973,8 @@
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "1.1.4", "es-object-atoms": "1.1.1", "get-intrinsic": "1.3.0", "get-proto": "1.0.1", "has-symbols": "1.1.0", "set-function-name": "2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
+    "jerrypick": ["jerrypick@1.1.2", "", {}, "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
@@ -941,6 +998,8 @@
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "3.1.9", "array.prototype.flat": "1.3.3", "object.assign": "4.1.7", "object.values": "1.2.1" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "kapsule": ["kapsule@1.16.3", "", { "dependencies": { "lodash-es": "4" } }, "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -983,6 +1042,8 @@
     "listr2": ["listr2@8.3.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
@@ -1218,7 +1279,11 @@
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "0.27.0" }, "peerDependencies": { "react": "19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
+    "react-force-graph-2d": ["react-force-graph-2d@1.29.1", "", { "dependencies": { "force-graph": "^1.51", "prop-types": "15", "react-kapsule": "^2.5" }, "peerDependencies": { "react": "*" } }, "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ=="],
+
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-kapsule": ["react-kapsule@2.6.0", "", { "dependencies": { "jerrypick": "^1.1.2" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-HzLJoYb1n1kfwjXbqFFcRR0EA6oPsJ64tNdDmCSaL/bz2o9wUZRSb0cMe//grLFeF9EVoL4CD/e6ozLyzEv+PQ=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "3.0.4", "@types/mdast": "4.0.4", "devlop": "1.1.0", "hast-util-to-jsx-runtime": "2.3.6", "html-url-attributes": "3.0.1", "mdast-util-to-hast": "13.2.1", "remark-parse": "11.0.0", "remark-rehype": "11.1.2", "unified": "11.0.5", "unist-util-visit": "5.1.0", "vfile": "6.0.3" }, "peerDependencies": { "@types/react": "19.2.14", "react": "19.2.5" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -1355,6 +1420,8 @@
     "through": ["through@2.3.8", "", {}, "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "next-auth": "^5.0.0-beta.31",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",

--- a/web/src/app/api/graph/entities/route.ts
+++ b/web/src/app/api/graph/entities/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const BRAIN_API_URL = process.env.BRAIN_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+function authHeaders(): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (API_KEY) {
+    headers["Authorization"] = `Bearer ${API_KEY}`;
+  }
+  return headers;
+}
+
+/** GET /api/graph/entities → proxies to GET /api/v1/graph/entities
+ *
+ * The upstream body carries entity names, so it is never logged (plan
+ * §privacy 4) — only the transport error is. */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const qs = request.nextUrl.searchParams.toString();
+    const upstream = await fetch(`${BRAIN_API_URL}/api/v1/graph/entities${qs ? `?${qs}` : ""}`, {
+      headers: authHeaders(),
+    });
+    const data: unknown = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (err) {
+    console.error("[api/graph/entities] upstream error:", err);
+    return NextResponse.json({ error: "upstream error" }, { status: 502 });
+  }
+}

--- a/web/src/app/api/graph/entry/route.ts
+++ b/web/src/app/api/graph/entry/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const BRAIN_API_URL = process.env.BRAIN_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+function authHeaders(): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (API_KEY) {
+    headers["Authorization"] = `Bearer ${API_KEY}`;
+  }
+  return headers;
+}
+
+/** GET /api/graph/entry → proxies to GET /api/v1/graph/entry
+ *
+ * The upstream body carries entity names, so it is never logged (plan
+ * §privacy 4) — only the transport error is. */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const qs = request.nextUrl.searchParams.toString();
+    const upstream = await fetch(`${BRAIN_API_URL}/api/v1/graph/entry${qs ? `?${qs}` : ""}`, {
+      headers: authHeaders(),
+    });
+    const data: unknown = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (err) {
+    console.error("[api/graph/entry] upstream error:", err);
+    return NextResponse.json({ error: "upstream error" }, { status: 502 });
+  }
+}

--- a/web/src/app/api/graph/evidence/route.ts
+++ b/web/src/app/api/graph/evidence/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const BRAIN_API_URL = process.env.BRAIN_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+function authHeaders(): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (API_KEY) {
+    headers["Authorization"] = `Bearer ${API_KEY}`;
+  }
+  return headers;
+}
+
+/** GET /api/graph/evidence → proxies to GET /api/v1/graph/evidence
+ *
+ * The upstream body carries entity names, so it is never logged (plan
+ * §privacy 4) — only the transport error is. */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const qs = request.nextUrl.searchParams.toString();
+    const upstream = await fetch(`${BRAIN_API_URL}/api/v1/graph/evidence${qs ? `?${qs}` : ""}`, {
+      headers: authHeaders(),
+    });
+    const data: unknown = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (err) {
+    console.error("[api/graph/evidence] upstream error:", err);
+    return NextResponse.json({ error: "upstream error" }, { status: 502 });
+  }
+}

--- a/web/src/app/api/graph/expand/route.ts
+++ b/web/src/app/api/graph/expand/route.ts
@@ -1,0 +1,30 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const BRAIN_API_URL = process.env.BRAIN_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+function authHeaders(): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (API_KEY) {
+    headers["Authorization"] = `Bearer ${API_KEY}`;
+  }
+  return headers;
+}
+
+/** GET /api/graph/expand → proxies to GET /api/v1/graph/expand
+ *
+ * The upstream body carries entity names, so it is never logged (plan
+ * §privacy 4) — only the transport error is. */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  try {
+    const qs = request.nextUrl.searchParams.toString();
+    const upstream = await fetch(`${BRAIN_API_URL}/api/v1/graph/expand${qs ? `?${qs}` : ""}`, {
+      headers: authHeaders(),
+    });
+    const data: unknown = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
+  } catch (err) {
+    console.error("[api/graph/expand] upstream error:", err);
+    return NextResponse.json({ error: "upstream error" }, { status: 502 });
+  }
+}

--- a/web/src/app/graph/EvidencePanel.tsx
+++ b/web/src/app/graph/EvidencePanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import Link from "next/link";
+import { Badge, Button, SourceBadge, Spinner } from "@/components/ui";
+import { getGraphEvidence, GraphUnavailableError } from "@/lib/api";
+import type { GraphEvidence, SourceType } from "@/lib/types";
+import { formatDateTime } from "@/lib/dates";
+import { displayName } from "./mask";
+import { REL_TYPE_LABELS } from "./labels";
+
+export interface EvidenceTarget {
+  from: number;
+  to: number;
+  relType: string;
+  fromName: string;
+  toName: string;
+}
+
+export interface EvidencePanelProps {
+  target: EvidenceTarget;
+  maskNames: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Right-hand panel listing the documents behind one relation.
+ *
+ * Only source type / occurrence time / confidence are shown: Neo4j never
+ * stores document titles or bodies (plan §privacy 1), so reading the original
+ * is delegated to /documents/{id}, which is already behind Access + Bearer.
+ */
+export default function EvidencePanel({ target, maskNames, onClose }: EvidencePanelProps) {
+  const [items, setItems] = useState<GraphEvidence[] | null>(null);
+  // React 19 transition: the project lint rule forbids setState directly in an
+  // effect body, so the fetch and its state writes run inside a transition.
+  const [loading, startLoad] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const { from, to, relType } = target;
+
+  useEffect(() => {
+    let cancelled = false;
+    startLoad(async () => {
+      setError(null);
+      try {
+        const rows = await getGraphEvidence(from, to, relType);
+        if (!cancelled) setItems(rows);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setItems([]);
+        setError(
+          err instanceof GraphUnavailableError
+            ? "그래프를 일시적으로 사용할 수 없습니다."
+            : "근거를 불러오지 못했습니다.",
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [from, to, relType, startLoad]);
+
+  return (
+    <aside
+      className="rounded-lg border border-border bg-surface p-4"
+      aria-label="선택한 관계의 근거 문서"
+    >
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h2 className="text-sm font-medium text-foreground">근거 문서</h2>
+          <p className="mt-1 text-xs break-words text-foreground-muted">
+            {displayName(target.fromName, maskNames)}
+            <span className="mx-1 text-foreground-subtle">
+              → {REL_TYPE_LABELS[relType] ?? relType} →
+            </span>
+            {displayName(target.toName, maskNames)}
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose} aria-label="근거 패널 닫기">
+          닫기
+        </Button>
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-sm text-foreground-muted">
+          <Spinner size="sm" /> 불러오는 중…
+        </div>
+      )}
+
+      {error && !loading && (
+        <p className="rounded-md border border-danger/30 bg-[--status-danger-light] p-2 text-sm text-danger">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && items !== null && items.length === 0 && (
+        <p className="text-sm text-foreground-muted">
+          표시할 근거 문서가 없습니다. 이 관계의 문서 멘션이 아직 그래프에 투영되지 않았을 수
+          있습니다.
+        </p>
+      )}
+
+      {!loading && items !== null && items.length > 0 && (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.document_id}>
+              <Link
+                href={`/documents/${item.document_id}`}
+                className="block rounded-md border border-border p-2 transition-colors hover:border-accent/40 hover:bg-surface-subtle"
+              >
+                <div className="flex items-center gap-1.5">
+                  <SourceBadge sourceType={item.source_type as SourceType} size="sm" />
+                  <Badge size="sm" variant="default">
+                    신뢰도 {item.confidence.toFixed(2)}
+                  </Badge>
+                </div>
+                <div className="mt-1 text-xs text-foreground-subtle">
+                  {item.occurred_at ? formatDateTime(item.occurred_at) : "발생 시각 미상"}
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/web/src/app/graph/GraphCanvas.tsx
+++ b/web/src/app/graph/GraphCanvas.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import ForceGraph2D from "react-force-graph-2d";
+import { displayName } from "./mask";
+import { REL_TYPE_LABELS } from "./labels";
+
+// Client-only canvas wrapper. `react-force-graph-2d` touches `window` and
+// `canvas` at import time, so the page must pull this in through
+// next/dynamic({ ssr: false }) — that also keeps the library out of the
+// initial bundle.
+
+export interface CanvasNode {
+  id: number;
+  name: string;
+  type: string;
+  degree: number;
+  /** Entry points are drawn slightly larger than nodes pulled in by expansion. */
+  seed: boolean;
+}
+
+export interface CanvasLink {
+  /** Stable identity: one Postgres relation row = one edge. */
+  key: string;
+  source: number;
+  target: number;
+  relType: string;
+  weight: number;
+}
+
+export interface GraphCanvasProps {
+  nodes: CanvasNode[];
+  links: CanvasLink[];
+  onNodeClick: (node: CanvasNode) => void;
+  onLinkClick: (link: CanvasLink) => void;
+  maskNames: boolean;
+  /** Currently focused entity, drawn with a ring. */
+  selectedId: number | null;
+}
+
+// Tinted, non-primary hues so the four entity types stay distinguishable
+// without reading as a traffic-light palette.
+const TYPE_COLOR: Record<string, string> = {
+  PERSON: "#3f6ee0",
+  ORG: "#0f9488",
+  CONCEPT: "#b4690e",
+  OTHER: "#7a7f8c",
+};
+
+const FALLBACK_COLOR = "#7a7f8c";
+
+function colorFor(type: string): string {
+  return TYPE_COLOR[type] ?? FALLBACK_COLOR;
+}
+
+export default function GraphCanvas({
+  nodes,
+  links,
+  onNodeClick,
+  onLinkClick,
+  maskNames,
+  selectedId,
+}: GraphCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 480 });
+
+  // The force layout needs pixel dimensions; the container is fluid, so track
+  // it rather than hardcoding a width.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setSize({ width: el.clientWidth, height: el.clientHeight });
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // force-graph mutates the objects it is given (adding x/y/vx/vy), so hand it
+  // copies keyed off the incoming props.
+  const graphData = useMemo(
+    () => ({
+      nodes: nodes.map((n) => ({ ...n })),
+      links: links.map((l) => ({ ...l })),
+    }),
+    [nodes, links],
+  );
+
+  const paintNode = useCallback(
+    (
+      node: CanvasNode & { x?: number; y?: number },
+      ctx: CanvasRenderingContext2D,
+      scale: number,
+    ) => {
+      const { x = 0, y = 0 } = node;
+      const radius = node.seed ? 6 : 4;
+
+      ctx.beginPath();
+      ctx.arc(x, y, radius, 0, 2 * Math.PI);
+      ctx.fillStyle = colorFor(node.type);
+      ctx.fill();
+
+      if (node.id === selectedId) {
+        ctx.strokeStyle = "#111827";
+        ctx.lineWidth = 1.5 / scale;
+        ctx.stroke();
+      }
+
+      // Labels are the point of this screen, but they turn into noise when
+      // zoomed far out — drop them below a readable scale.
+      if (scale < 0.7) return;
+      const label = displayName(node.name, maskNames);
+      const fontSize = Math.max(10 / scale, 2);
+      ctx.font = `${fontSize}px sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
+      ctx.fillStyle = "#374151";
+      ctx.fillText(label, x, y + radius + 1);
+    },
+    [maskNames, selectedId],
+  );
+
+  // Widen edges by observation count, log-scaled: a pair seen 40 times should
+  // read as heavier than one seen twice without swamping the canvas.
+  const linkWidth = useCallback(
+    (link: CanvasLink) => 1 + Math.log2(Math.max(link.weight, 1)) / 2,
+    [],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[480px] w-full overflow-hidden rounded-lg border border-border bg-surface"
+      role="application"
+      aria-label="지식 그래프 캔버스. 노드를 클릭하면 1홉 확장, 링크를 클릭하면 근거 목록이 열립니다."
+    >
+      {size.width > 0 && (
+        <ForceGraph2D<CanvasNode, CanvasLink>
+          graphData={graphData}
+          width={size.width}
+          height={size.height}
+          backgroundColor="transparent"
+          nodeId="id"
+          nodeRelSize={5}
+          nodeLabel={(n) => displayName(n.name, maskNames)}
+          nodeCanvasObject={paintNode}
+          nodePointerAreaPaint={(node, color, ctx) => {
+            const { x = 0, y = 0 } = node;
+            ctx.fillStyle = color;
+            ctx.beginPath();
+            ctx.arc(x, y, 8, 0, 2 * Math.PI);
+            ctx.fill();
+          }}
+          linkLabel={(l) => REL_TYPE_LABELS[l.relType] ?? l.relType}
+          linkColor={() => "#cbd5e1"}
+          linkWidth={linkWidth}
+          linkDirectionalArrowLength={4}
+          linkDirectionalArrowRelPos={1}
+          cooldownTicks={120}
+          onNodeClick={(n) => onNodeClick(n as CanvasNode)}
+          onLinkClick={(l) => onLinkClick(l as unknown as CanvasLink)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/app/graph/labels.ts
+++ b/web/src/app/graph/labels.ts
@@ -1,0 +1,21 @@
+import type { GraphEntityType, GraphRelType } from "@/lib/types";
+
+/** Korean labels for the closed relation vocabulary (internal/model/relation.go). */
+export const REL_TYPE_LABELS: Record<string, string> = {
+  communicated_with: "연락",
+  requested_of: "요청",
+  committed_to: "약속",
+  mentions: "언급",
+  belongs_to: "소속",
+  scheduled_with: "일정",
+  about_topic: "주제",
+  related_to: "관련",
+} satisfies Record<GraphRelType, string>;
+
+/** Korean labels for the four entity types (internal/model/entity.go). */
+export const ENTITY_TYPE_LABELS: Record<string, string> = {
+  PERSON: "사람",
+  ORG: "조직",
+  CONCEPT: "개념",
+  OTHER: "기타",
+} satisfies Record<GraphEntityType, string>;

--- a/web/src/app/graph/mask.test.ts
+++ b/web/src/app/graph/mask.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { displayName, maskName } from "./mask";
+
+describe("maskName", () => {
+  it("keeps the first character and masks the rest", () => {
+    expect(maskName("더미갑")).toBe("더**");
+    expect(maskName("Acme Corp")).toBe("A********");
+  });
+
+  it("handles short and empty input", () => {
+    expect(maskName("A")).toBe("A");
+    expect(maskName("")).toBe("");
+  });
+
+  it("counts astral-plane characters as one character", () => {
+    expect(maskName("😀ab")).toBe("😀**");
+  });
+});
+
+describe("displayName", () => {
+  it("passes the name through when masking is off", () => {
+    expect(displayName("더미을", false)).toBe("더미을");
+    expect(displayName("더미을", true)).toBe("더**");
+  });
+});

--- a/web/src/app/graph/mask.ts
+++ b/web/src/app/graph/mask.ts
@@ -1,0 +1,61 @@
+/**
+ * Client-side display masking for entity names (plan §privacy 3).
+ *
+ * This is a screen-sharing aid, not a security boundary: the API response is
+ * unchanged and still carries the real names, because server-side masking
+ * would make evidence cross-checking impossible. Masking is applied only at
+ * render time, in the browser.
+ *
+ * Rule: keep the first character, replace every remaining character —
+ * including spaces — with `*`, so the masked length does not hint at word
+ * boundaries.
+ */
+export function maskName(name: string): string {
+  const chars = Array.from(name);
+  if (chars.length <= 1) return name;
+  return chars[0] + "*".repeat(chars.length - 1);
+}
+
+/** Convenience wrapper for render paths that carry the toggle state. */
+export function displayName(name: string, mask: boolean): string {
+  return mask ? maskName(name) : name;
+}
+
+/** localStorage key for the masking toggle. */
+export const MASK_STORAGE_KEY = "graph.maskNames";
+
+// ── Toggle store ──────────────────────────────────────────────────────────
+//
+// Exposed as an external store (useSyncExternalStore) rather than an effect
+// that reads localStorage after mount: the server snapshot is "off", so the
+// prerendered HTML never depends on a browser-only value.
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+let cached: boolean | null = null;
+
+export function subscribeMask(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getMaskSnapshot(): boolean {
+  if (cached === null) {
+    cached = window.localStorage.getItem(MASK_STORAGE_KEY) === "true";
+  }
+  return cached;
+}
+
+/** Masking is always off in prerendered output. */
+export function getMaskServerSnapshot(): boolean {
+  return false;
+}
+
+export function setMask(value: boolean): void {
+  cached = value;
+  window.localStorage.setItem(MASK_STORAGE_KEY, String(value));
+  for (const listener of listeners) listener();
+}

--- a/web/src/app/graph/page.tsx
+++ b/web/src/app/graph/page.tsx
@@ -1,0 +1,569 @@
+"use client";
+
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  useTransition,
+} from "react";
+import dynamic from "next/dynamic";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Badge, Button, Card, Spinner } from "@/components/ui";
+import {
+  expandGraphNode,
+  getGraphEntry,
+  GraphUnavailableError,
+  searchGraphEntities,
+} from "@/lib/api";
+import {
+  GRAPH_ENTITY_TYPES,
+  GRAPH_REL_TYPES,
+  type GraphEntityHit,
+  type GraphFilters,
+  type GraphNode,
+} from "@/lib/types";
+import type { CanvasLink, CanvasNode } from "./GraphCanvas";
+import EvidencePanel, { type EvidenceTarget } from "./EvidencePanel";
+import { ENTITY_TYPE_LABELS, REL_TYPE_LABELS } from "./labels";
+import {
+  displayName,
+  getMaskServerSnapshot,
+  getMaskSnapshot,
+  setMask,
+  subscribeMask,
+} from "./mask";
+
+// The canvas is loaded client-side only: react-force-graph-2d reaches for
+// `window`/`canvas` at import time and would break server rendering. The same
+// dynamic boundary keeps the library out of the initial bundle.
+const GraphCanvas = dynamic(() => import("./GraphCanvas"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-[480px] items-center justify-center rounded-lg border border-border bg-surface">
+      <Spinner size="lg" />
+    </div>
+  ),
+});
+
+const DAY_OPTIONS = [7, 30, 90] as const;
+const DEFAULT_DAYS = 30;
+const DEFAULT_MIN_CONFIDENCE = 0.5;
+/** Readability ceiling on the client, separate from the server's own clamps. */
+const MAX_CANVAS_NODES = 300;
+
+function parseDays(raw: string | null): number {
+  const n = Number(raw);
+  return DAY_OPTIONS.includes(n as (typeof DAY_OPTIONS)[number]) ? n : DEFAULT_DAYS;
+}
+
+function parseConfidence(raw: string | null): number {
+  const n = Number(raw);
+  if (raw === null || Number.isNaN(n) || n < 0 || n > 1) return DEFAULT_MIN_CONFIDENCE;
+  return n;
+}
+
+function parseList(raw: string | null, allowed: readonly string[]): string[] {
+  if (raw === null) return [...allowed];
+  const picked = raw.split(",").filter((v) => allowed.includes(v));
+  return picked.length > 0 ? picked : [...allowed];
+}
+
+function parseEntry(raw: string | null): number | null {
+  const n = Number(raw);
+  return raw && Number.isInteger(n) && n > 0 ? n : null;
+}
+
+function toggle(list: string[], value: string, allowed: readonly string[]): string[] {
+  const next = list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+  // Empty means "no filter" to the backend, which reads as "everything" —
+  // keep the UI honest by refusing to reach that state by unchecking.
+  return next.length === 0 ? [...allowed] : next;
+}
+
+function linkKey(from: number, to: number, relType: string): string {
+  return `${from}->${to}:${relType}`;
+}
+
+/** Canvas state for one filter generation (see `genKey`). */
+interface GraphSession {
+  gen: string;
+  nodes: Map<number, CanvasNode>;
+  links: Map<string, CanvasLink>;
+  expanded: Set<number>;
+  capReached: boolean;
+  evidence: EvidenceTarget | null;
+}
+
+// Shared empties so an invalidated session keeps stable identities and does
+// not retrigger the force layout on every render.
+const EMPTY_NODES: Map<number, CanvasNode> = new Map();
+const EMPTY_LINKS: Map<string, CanvasLink> = new Map();
+const EMPTY_EXPANDED: Set<number> = new Set();
+
+function emptySession(gen: string): GraphSession {
+  return {
+    gen,
+    nodes: EMPTY_NODES,
+    links: EMPTY_LINKS,
+    expanded: EMPTY_EXPANDED,
+    capReached: false,
+    evidence: null,
+  };
+}
+
+function GraphPageInner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Filters live in the query string so a view can be refreshed and shared.
+  // Only ids and thresholds go in — never names (plan §privacy).
+  const [days, setDays] = useState(() => parseDays(searchParams.get("days")));
+  const [minConfidence, setMinConfidence] = useState(() =>
+    parseConfidence(searchParams.get("minconf")),
+  );
+  const [entityTypes, setEntityTypes] = useState<string[]>(() =>
+    parseList(searchParams.get("types"), GRAPH_ENTITY_TYPES),
+  );
+  const [relTypes, setRelTypes] = useState<string[]>(() =>
+    parseList(searchParams.get("rels"), GRAPH_REL_TYPES),
+  );
+  const [entryId, setEntryId] = useState<number | null>(() =>
+    parseEntry(searchParams.get("entry")),
+  );
+
+  const filters: GraphFilters = useMemo(
+    () => ({ days, minConfidence, entityTypes, relTypes }),
+    [days, minConfidence, entityTypes, relTypes],
+  );
+
+  const [entryNodes, setEntryNodes] = useState<GraphNode[]>([]);
+  // React 19 transition: the entry-point load must not setState synchronously
+  // inside the effect body (project lint rule), so it runs in a transition.
+  const [loading, startEntryLoad] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  // Everything built on top of the entry points belongs to one filter
+  // generation. Changing a filter invalidates it by key instead of an effect
+  // that clears state after the fact.
+  const genKey = `${entryId ?? "all"}|${days}|${minConfidence}|${entityTypes.join(",")}|${relTypes.join(",")}`;
+  const [session, setSession] = useState<GraphSession>(() => emptySession(genKey));
+  const active = session.gen === genKey ? session : emptySession(genKey);
+
+  const [expanding, setExpanding] = useState(false);
+
+  const maskNames = useSyncExternalStore(subscribeMask, getMaskSnapshot, getMaskServerSnapshot);
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [searchHits, setSearchHits] = useState<GraphEntityHit[]>([]);
+
+  // ── URL sync ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (days !== DEFAULT_DAYS) params.set("days", String(days));
+    if (minConfidence !== DEFAULT_MIN_CONFIDENCE) params.set("minconf", String(minConfidence));
+    if (entityTypes.length !== GRAPH_ENTITY_TYPES.length)
+      params.set("types", entityTypes.join(","));
+    if (relTypes.length !== GRAPH_REL_TYPES.length) params.set("rels", relTypes.join(","));
+    if (entryId !== null) params.set("entry", String(entryId));
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [days, minConfidence, entityTypes, relTypes, entryId, pathname, router]);
+
+  // ── Entry points ──────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    startEntryLoad(async () => {
+      setError(null);
+      try {
+        const rows = await getGraphEntry(filters);
+        if (!cancelled) setEntryNodes(rows);
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setEntryNodes([]);
+        setError(
+          err instanceof GraphUnavailableError
+            ? "그래프를 일시적으로 사용할 수 없습니다. 투영 저장소가 내려갔을 수 있습니다."
+            : "진입점을 불러오지 못했습니다.",
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [filters, startEntryLoad]);
+
+  // The canvas seed is derived, not stored: entry points, or the single
+  // pinned entity when one is selected.
+  const seedNodes = useMemo<CanvasNode[]>(() => {
+    if (entryId !== null) {
+      const known = entryNodes.find((n) => n.entity_id === entryId);
+      return [
+        {
+          id: entryId,
+          name: known?.name ?? `엔티티 #${entryId}`,
+          type: known?.type ?? "OTHER",
+          degree: known?.degree ?? 0,
+          seed: true,
+        },
+      ];
+    }
+    return entryNodes.map((n) => ({
+      id: n.entity_id,
+      name: n.name,
+      type: n.type,
+      degree: n.degree,
+      seed: true,
+    }));
+  }, [entryNodes, entryId]);
+
+  const nodeList = useMemo(() => {
+    const merged = new Map<number, CanvasNode>();
+    for (const n of seedNodes) merged.set(n.id, n);
+    for (const [id, n] of active.nodes) if (!merged.has(id)) merged.set(id, n);
+    return [...merged.values()];
+  }, [seedNodes, active.nodes]);
+
+  const linkList = useMemo(() => [...active.links.values()], [active.links]);
+
+  // ── Entity search (debounced; the term never reaches the page URL) ─────
+  useEffect(() => {
+    const term = searchTerm.trim();
+    const timer = setTimeout(() => {
+      if (term.length < 2) {
+        setSearchHits([]);
+        return;
+      }
+      searchGraphEntities(term)
+        .then(setSearchHits)
+        .catch(() => setSearchHits([]));
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm]);
+
+  // ── One-hop expansion ─────────────────────────────────────────────────
+  const handleNodeClick = useCallback(
+    (node: CanvasNode) => {
+      if (active.expanded.has(node.id) || expanding) return;
+      if (nodeList.length >= MAX_CANVAS_NODES) {
+        setSession((prev) => ({
+          ...(prev.gen === genKey ? prev : emptySession(genKey)),
+          gen: genKey,
+          capReached: true,
+        }));
+        return;
+      }
+      setExpanding(true);
+      expandGraphNode(node.id, filters)
+        .then((neighbors) => {
+          setSession((prev) => {
+            const base = prev.gen === genKey ? prev : emptySession(genKey);
+            const nextNodes = new Map(base.nodes);
+            const nextLinks = new Map(base.links);
+            for (const n of neighbors) {
+              const existing = nextNodes.get(n.entity_id);
+              nextNodes.set(n.entity_id, {
+                id: n.entity_id,
+                name: n.name,
+                type: n.type,
+                degree: existing?.degree ?? 0,
+                seed: false,
+              });
+              const from = n.direction === "out" ? node.id : n.entity_id;
+              const to = n.direction === "out" ? n.entity_id : node.id;
+              const key = linkKey(from, to, n.rel_type);
+              nextLinks.set(key, {
+                key,
+                source: from,
+                target: to,
+                relType: n.rel_type,
+                weight: n.weight,
+              });
+            }
+            return {
+              gen: genKey,
+              nodes: nextNodes,
+              links: nextLinks,
+              expanded: new Set(base.expanded).add(node.id),
+              capReached: base.capReached || nextNodes.size + seedNodes.length > MAX_CANVAS_NODES,
+              evidence: base.evidence,
+            };
+          });
+        })
+        .catch((err: unknown) => {
+          setError(
+            err instanceof GraphUnavailableError
+              ? "그래프를 일시적으로 사용할 수 없습니다."
+              : "이웃을 불러오지 못했습니다.",
+          );
+        })
+        .finally(() => setExpanding(false));
+    },
+    [active.expanded, expanding, filters, genKey, nodeList.length, seedNodes.length],
+  );
+
+  const handleLinkClick = useCallback(
+    (link: CanvasLink) => {
+      // force-graph swaps source/target for node objects once the layout has
+      // run, so accept either shape.
+      const from = typeof link.source === "object" ? (link.source as CanvasNode).id : link.source;
+      const to = typeof link.target === "object" ? (link.target as CanvasNode).id : link.target;
+      const nameOf = (id: number) => nodeList.find((n) => n.id === id)?.name ?? `엔티티 #${id}`;
+      setSession((prev) => ({
+        ...(prev.gen === genKey ? prev : emptySession(genKey)),
+        gen: genKey,
+        evidence: { from, to, relType: link.relType, fromName: nameOf(from), toName: nameOf(to) },
+      }));
+    },
+    [genKey, nodeList],
+  );
+
+  const resetCanvas = useCallback(() => {
+    setEntryId(null);
+    // "" never matches a generation key, so the session reads as empty even
+    // when the filters themselves did not change.
+    setSession(emptySession(""));
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-serif text-2xl font-semibold tracking-tight">지식 그래프</h1>
+          <p className="mt-1 text-sm text-foreground-muted">
+            진입점을 고르고 노드를 눌러 한 홉씩 넓혀 보세요. 링크를 누르면 근거 문서가 열립니다.
+          </p>
+        </div>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-foreground-muted">
+          <input
+            type="checkbox"
+            checked={maskNames}
+            onChange={(e) => setMask(e.target.checked)}
+            className="h-4 w-4 accent-[--color-accent]"
+          />
+          이름 가리기
+        </label>
+      </header>
+
+      {/* ── Filters ── */}
+      <Card padding="md" className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="w-20 text-xs text-foreground-subtle">기간</span>
+          <div className="flex gap-1" role="group" aria-label="기간 필터">
+            {DAY_OPTIONS.map((d) => (
+              <Button
+                key={d}
+                size="sm"
+                variant={days === d ? "primary" : "secondary"}
+                aria-pressed={days === d}
+                onClick={() => setDays(d)}
+              >
+                {d}일
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="w-20 text-xs text-foreground-subtle">엔티티</span>
+          {GRAPH_ENTITY_TYPES.map((t) => {
+            const on = entityTypes.includes(t);
+            return (
+              <button
+                key={t}
+                type="button"
+                aria-pressed={on}
+                onClick={() => setEntityTypes((prev) => toggle(prev, t, GRAPH_ENTITY_TYPES))}
+                className="rounded focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none"
+              >
+                <Badge variant={on ? "accent" : "default"}>{ENTITY_TYPE_LABELS[t]}</Badge>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="w-20 text-xs text-foreground-subtle">관계</span>
+          {GRAPH_REL_TYPES.map((t) => {
+            const on = relTypes.includes(t);
+            return (
+              <button
+                key={t}
+                type="button"
+                aria-pressed={on}
+                onClick={() => setRelTypes((prev) => toggle(prev, t, GRAPH_REL_TYPES))}
+                className="rounded focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none"
+              >
+                <Badge variant={on ? "accent" : "default"}>{REL_TYPE_LABELS[t]}</Badge>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <label htmlFor="minconf" className="w-20 text-xs text-foreground-subtle">
+            최소 신뢰도
+          </label>
+          <input
+            id="minconf"
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={minConfidence}
+            onChange={(e) => setMinConfidence(Number(e.target.value))}
+            className="w-48 accent-[--color-accent]"
+          />
+          <span className="font-mono text-xs text-foreground-muted">
+            {minConfidence.toFixed(2)}
+          </span>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <label htmlFor="entity-search" className="w-20 text-xs text-foreground-subtle">
+            엔티티 검색
+          </label>
+          <input
+            id="entity-search"
+            type="search"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="두 글자 이상 입력"
+            autoComplete="off"
+            className="h-9 w-64 rounded-md border border-border bg-surface px-3 text-sm text-foreground placeholder:text-foreground-subtle focus-visible:ring-2 focus-visible:ring-accent focus-visible:outline-none"
+          />
+          {entryId !== null && (
+            <Button size="sm" variant="ghost" onClick={resetCanvas}>
+              진입점 고정 해제
+            </Button>
+          )}
+        </div>
+
+        {searchHits.length > 0 && (
+          <ul className="flex flex-wrap gap-2">
+            {searchHits.map((hit) => (
+              <li key={hit.entity_id}>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => {
+                    setEntryNodes((prev) =>
+                      prev.some((n) => n.entity_id === hit.entity_id)
+                        ? prev
+                        : [...prev, { ...hit, degree: 0 }],
+                    );
+                    setEntryId(hit.entity_id);
+                    setSearchTerm("");
+                    setSearchHits([]);
+                  }}
+                >
+                  {displayName(hit.name, maskNames)}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {error && (
+        <p
+          role="alert"
+          className="rounded-md border border-danger/30 bg-[--status-danger-light] p-3 text-sm text-danger"
+        >
+          {error}
+        </p>
+      )}
+
+      {active.capReached && (
+        <div
+          role="status"
+          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-surface-subtle p-3 text-sm text-foreground-muted"
+        >
+          <span>노드가 너무 많습니다 — 필터를 좁히거나 초기화하세요.</span>
+          <Button size="sm" variant="secondary" onClick={resetCanvas}>
+            초기화
+          </Button>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center gap-2 text-sm text-foreground-muted">
+          <Spinner size="sm" /> 진입점을 불러오는 중…
+        </div>
+      )}
+
+      {!loading && !error && entryNodes.length === 0 && (
+        <p className="rounded-md border border-border bg-surface-subtle p-4 text-sm text-foreground-muted">
+          이 조건에 해당하는 엔티티가 없습니다 — 기간을 넓히거나 신뢰도를 낮춰보세요.
+        </p>
+      )}
+
+      {/* ── Canvas + evidence ── */}
+      {nodeList.length > 0 && (
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <GraphCanvas
+            nodes={nodeList}
+            links={linkList}
+            onNodeClick={handleNodeClick}
+            onLinkClick={handleLinkClick}
+            maskNames={maskNames}
+            selectedId={entryId}
+          />
+          {active.evidence && (
+            <EvidencePanel
+              target={active.evidence}
+              maskNames={maskNames}
+              onClose={() =>
+                setSession((prev) => ({
+                  ...(prev.gen === genKey ? prev : emptySession(genKey)),
+                  gen: genKey,
+                  evidence: null,
+                }))
+              }
+            />
+          )}
+        </div>
+      )}
+
+      {/* ── Entry point list (works without the canvas) ── */}
+      {entryNodes.length > 0 && (
+        <section aria-label="진입점 목록" className="space-y-2">
+          <h2 className="text-sm font-medium text-foreground">진입점 {entryNodes.length}개</h2>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {entryNodes.map((n) => (
+              <li key={n.entity_id}>
+                <button
+                  type="button"
+                  onClick={() => setEntryId(n.entity_id)}
+                  aria-pressed={entryId === n.entity_id}
+                  className={`flex w-full items-center justify-between gap-2 rounded-lg border p-3 text-left transition-colors hover:bg-surface-subtle ${
+                    entryId === n.entity_id ? "border-accent" : "border-border"
+                  }`}
+                >
+                  <span className="min-w-0 truncate text-sm text-foreground">
+                    {displayName(n.name, maskNames)}
+                  </span>
+                  <span className="flex shrink-0 items-center gap-1.5">
+                    <Badge size="sm">{ENTITY_TYPE_LABELS[n.type] ?? n.type}</Badge>
+                    <span className="font-mono text-xs text-foreground-subtle">{n.degree}</span>
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default function GraphPage() {
+  return (
+    <Suspense>
+      <GraphPageInner />
+    </Suspense>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -73,6 +73,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 수집 현황
               </Link>
               <Link
+                href="/graph"
+                className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"
+              >
+                그래프
+              </Link>
+              <Link
                 href="/governance"
                 className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"
               >

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,15 @@ import type {
   CreateNoteResponse,
   DocumentDetail,
   DocumentsResponse,
+  GraphEntitiesResponse,
+  GraphEntityHit,
+  GraphEntryResponse,
+  GraphEvidence,
+  GraphEvidenceResponse,
+  GraphExpandResponse,
+  GraphFilters,
+  GraphNeighbor,
+  GraphNode,
   IngestFileResponse,
   RecentItemsResponse,
   SearchParams,
@@ -186,6 +195,86 @@ export async function getConversation(id: string): Promise<AskConversationTurn[]
   return fetchJson<AskConversationTurn[]>(
     `${getApiBase()}/ask/conversations/${encodeURIComponent(id)}`,
   );
+}
+
+// ── Knowledge graph (Part B) ─────────────────────────────────────────────
+//
+// Browser-only helpers: they hit the /api/graph/* proxy pair
+// (web/src/app/api/graph/*), which forwards to the backend's
+// /api/v1/graph/*. The backend clamps every limit, so anything sent here is
+// a hint, not a guarantee.
+//
+// No response body is ever logged — entity names would leak into the browser
+// console (plan §privacy 4).
+
+/** Thrown when the backend answers 503: Neo4j is a derived store that can be
+ * down while search/ask stay healthy, and the page must say so specifically
+ * instead of showing a generic failure. */
+export class GraphUnavailableError extends Error {
+  constructor() {
+    super("graph temporarily unavailable");
+    this.name = "GraphUnavailableError";
+  }
+}
+
+async function fetchGraph<T>(path: string, params: URLSearchParams): Promise<T> {
+  const qs = params.toString();
+  const response = await fetch(`${getApiBase()}/graph/${path}${qs ? `?${qs}` : ""}`);
+  if (response.status === 503) {
+    throw new GraphUnavailableError();
+  }
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function baseGraphParams(f: GraphFilters): URLSearchParams {
+  const params = new URLSearchParams({
+    days: String(f.days),
+    min_confidence: String(f.minConfidence),
+  });
+  return params;
+}
+
+export async function getGraphEntry(f: GraphFilters, limit?: number): Promise<GraphNode[]> {
+  const params = baseGraphParams(f);
+  if (f.entityTypes.length > 0) params.set("types", f.entityTypes.join(","));
+  if (limit !== undefined) params.set("limit", String(limit));
+  const res = await fetchGraph<GraphEntryResponse>("entry", params);
+  return res.nodes ?? [];
+}
+
+export async function expandGraphNode(
+  entityId: number,
+  f: GraphFilters,
+  limit?: number,
+): Promise<GraphNeighbor[]> {
+  const params = baseGraphParams(f);
+  params.set("entity_id", String(entityId));
+  if (f.relTypes.length > 0) params.set("rel_types", f.relTypes.join(","));
+  if (limit !== undefined) params.set("limit", String(limit));
+  const res = await fetchGraph<GraphExpandResponse>("expand", params);
+  return res.neighbors ?? [];
+}
+
+export async function getGraphEvidence(
+  from: number,
+  to: number,
+  relType: string,
+): Promise<GraphEvidence[]> {
+  const params = new URLSearchParams({
+    from: String(from),
+    to: String(to),
+    rel_type: relType,
+  });
+  const res = await fetchGraph<GraphEvidenceResponse>("evidence", params);
+  return res.evidence ?? [];
+}
+
+export async function searchGraphEntities(q: string): Promise<GraphEntityHit[]> {
+  const res = await fetchGraph<GraphEntitiesResponse>("entities", new URLSearchParams({ q }));
+  return res.entities ?? [];
 }
 
 // ── File upload (Capture) ────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -222,3 +222,83 @@ export interface SourcesResponse {
 export interface DocumentsResponse {
   documents: DocumentDetail[];
 }
+
+// ── Knowledge graph (Part B) ─────────────────────────────────────────────
+//
+// Mirrors graph.EntryNode / Neighbor / EvidenceRef / EntityHit in
+// internal/graph/queries.go. The backend normalises nil slices to [], so no
+// response field is ever null except EvidenceRef.occurred_at.
+
+/** Entity types projected as secondary Neo4j labels (internal/model/entity.go). */
+export const GRAPH_ENTITY_TYPES = ["PERSON", "ORG", "CONCEPT", "OTHER"] as const;
+export type GraphEntityType = (typeof GRAPH_ENTITY_TYPES)[number];
+
+/** Closed relation vocabulary (internal/model/relation.go). Values outside
+ * this set are downgraded to `related_to` by the backend. */
+export const GRAPH_REL_TYPES = [
+  "communicated_with",
+  "requested_of",
+  "committed_to",
+  "mentions",
+  "belongs_to",
+  "scheduled_with",
+  "about_topic",
+  "related_to",
+] as const;
+export type GraphRelType = (typeof GRAPH_REL_TYPES)[number];
+
+export interface GraphNode {
+  entity_id: number;
+  name: string;
+  type: string;
+  degree: number;
+}
+
+export interface GraphNeighbor {
+  entity_id: number;
+  name: string;
+  type: string;
+  rel_type: string;
+  direction: "out" | "in";
+  weight: number;
+  last_seen: string;
+}
+
+export interface GraphEvidence {
+  document_id: string;
+  source_type: string;
+  occurred_at: string | null;
+  confidence: number;
+  observed_at: string;
+}
+
+export interface GraphEntityHit {
+  entity_id: number;
+  name: string;
+  type: string;
+}
+
+/** Shared filter state for the /graph screen. `minConfidence` defaults to 0.5
+ * (plan §13); `days` defaults to 30, matching the backend default. */
+export interface GraphFilters {
+  days: number;
+  minConfidence: number;
+  entityTypes: string[];
+  relTypes: string[];
+}
+
+export interface GraphEntryResponse {
+  nodes: GraphNode[];
+}
+
+export interface GraphExpandResponse {
+  neighbors: GraphNeighbor[];
+}
+
+export interface GraphEvidenceResponse {
+  evidence: GraphEvidence[];
+}
+
+export interface GraphEntitiesResponse {
+  entities: GraphEntityHit[];
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/lib/**/*.test.ts"],
+    include: ["src/lib/**/*.test.ts", "src/app/**/*.test.ts"],
     environment: "node",
   },
 });


### PR DESCRIPTION
## 개요

백엔드 지식 그래프 읽기 API(#201, Neo4j 투영)를 사용하는 프런트엔드 화면을 추가한다. BFF 프록시 라우트 4종 + `/graph` 페이지(진입점 목록, 필터, 캔버스, 근거 패널)로 구성된다.

## 변경 내용

- **BFF 프록시 4종** (`web/src/app/api/graph/{entry,expand,evidence,entities}/route.ts`): 기존 `documents/recent` 패턴을 따르며, 응답 본문은 로그하지 않고 transport 에러만 기록한다.
- **그래프 화면** (`web/src/app/graph/`): 기간·엔티티 타입·관계 타입·신뢰도 필터(기본 하한 0.5), 진입점 목록, 디바운스 엔티티 검색, 캔버스(`GraphCanvas.tsx`), 근거 패널(`EvidencePanel.tsx`).
- **캔버스 lazy loading**: `react-force-graph-2d`를 `next/dynamic({ ssr: false })`로 로드해 초기 번들이 아닌 lazy 청크로 분리(gzip 60KB, 전체 증가 68KB — 계획서의 250KB 게이트 통과).
- **마스킹 토글** (`mask.ts`): 이름 마스킹 상태는 `localStorage`에 유지. 엔티티 검색어는 개인 식별 정보이므로 URL 쿼리스트링에 동기화하지 않는다.
- **vitest 설정**: `include`에 `src/app/**` 추가 — 기존 설정이 `src/lib/**`만 포함해 계획서가 지정한 위치(`web/src/app/graph/mask.test.ts`)의 테스트가 수집되지 않던 문제 수정.

## 검증

- `bun run build` 프로덕션 빌드 성공, `/graph` 라우트 오류 없이 prerender됨
- `mask.test.ts` 단위 테스트 통과 (vitest include 수정 후 수집 확인)
- 캔버스 청크가 lazy-load로 분리되어 초기 번들 증가가 계획서의 250KB 게이트 이내(68KB)임을 빌드 산출물로 확인

## 미검증 항목 (중요)

**브라우저 렌더를 전혀 확인하지 못했다.** `web/src/proxy.ts`가 fail-closed라 Cloudflare Access 설정 없이는 모든 요청이 503이고, 로컬 백엔드도 준비되지 않았다. 확보한 증거는 "프로덕션 빌드에서 `/graph`가 오류 없이 prerender됨"뿐이다.

따라서 다음이 미검증이다:
- 캔버스 실제 그리기
- 노드 클릭 시 1홉 확장 동작
- 링크 클릭 시 근거 패널 열림
- 마스킹 토글 즉시 반영 및 새로고침 후 유지
- 레이아웃(2단 그리드, 캔버스 높이, 필터 줄바꿈)
- 다크모드 대비
- 콘솔 에러 유무

**배포 후 실제 화면 확인이 완료 조건이다.**

## 알려진 위험

- `SourceBadge`가 `source_type`을 캐스팅한다. 알 수 없는 소스 타입이 오면 배지 라벨이 비어 보일 수 있다.
- 캔버스 노드 상한 300은 "확장 시도 차단 + 배너"로만 걸린다. 서버가 한 번에 200개를 돌려주면 한 번의 확장으로 상한을 넘을 수 있다.
- `Evidence()`는 멘션이 투영되지 않은 경우 오류 없이 0건을 반환한다. UI 문구는 단정적 표현을 피하도록 작성했다.
- Go 로그 가드 회귀 테스트(`internal/api/graph_logging_test.go`)는 작성되지 않았다. `internal/api/graph.go`의 `graphUnavailable`이 endpoint와 error만 로깅하는 것은 코드로 확인했으나 테스트로 고정되지는 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)