### PR TITLE
chore: 시크릿을 담는 임시 파일을 gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,20 @@ vendor/
 .env.*.local
 .env.laptop-collector
 
+# Deploy backups (created on every macmini/ubuntu deploy, contain live secrets)
+.env.local.bak.*
+**/.env.local.bak.*
+
+# CI stub-verification leftovers (can contain real values if run against real .env.local)
+.env.local.ci-test-tmp
+**/.env.local.ci-test-tmp
+
+# Generic env backup pattern (defense-in-depth for ad-hoc backups)
+.env.*.bak
+
+# .env.local.example must stay tracked — CI derives compose stubs from it
+!.env.local.example
+
 # IDE and editor files
 .idea/
 .vscode/


### PR DESCRIPTION
## 요약
- 배포 백업(`.env.local.bak.*`)과 CI 스텁 잔여물(`.env.local.ci-test-tmp`)이 untracked이면서 gitignore 되지 않은 상태로 리포에 남아있던 문제 수정
- 세션 중 루트에서 실제 시크릿 값을 포함한 `.env.local.ci-test-tmp` (API_KEY/HF_TOKEN/WHISPER_API_KEY/DATABASE_URL 등) 발견 후 삭제(리포 미추적 상태였으므로 커밋 대상 아님)
- `.gitignore`에 5개 패턴 추가: `.env.local.bak.*`, `**/.env.local.bak.*`, `.env.local.ci-test-tmp`, `**/.env.local.ci-test-tmp`, `.env.*.bak`
- `.env.local.example`은 CI가 compose 스텁을 파생시키는 원본이라 계속 추적됨 (검증 완료, 무시되지 않음)

## Test plan
- [x] `git check-ignore -v`로 5개 패턴 전부 무시 확인
- [x] `git check-ignore -v .env.local.example` → 무시 안 됨 확인
- [x] `git status --porcelain | grep -c "env.local"` → 0
- [x] `.gitignore`만 스테이지되어 커밋됨 확인