### PR TITLE
feat(actions): 액션 목록과 근거 강제 브리핑

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -120,3 +120,13 @@ GRAPH_PROJECTION_INTERVAL=5m
 GRAPH_PROJECTION_BATCH_SIZE=500
 # 값을 바꾸면 다음 tick 에 그래프를 통째로 지우고 워터마크 0 부터 재구축한다.
 GRAPH_PROJECTION_RESET_TOKEN=
+
+# --- 액션 & 브리핑 (Part C) ---
+# 둘 다 기본 false: 라우트가 아예 등록되지 않는 것(404)이 롤백 수단이다.
+# BRIEFING_ENABLED 는 ACTIONS_API_ENABLED=true 일 때만 의미가 있고,
+# LLM 클라이언트가 설정되지 않으면(LLM_API_KEY 등 미설정) true 로 켜도
+# 안전하게 비활성 상태로 남는다.
+ACTIONS_API_ENABLED=false
+BRIEFING_ENABLED=false
+# 브리핑 한 번에 반영할 최대 open action 개수
+BRIEFING_MAX_ACTIONS=40

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -166,6 +166,7 @@ func run() error {
 		MaxTokens:   cfg.LLMMaxTokens,
 		Temperature: cfg.LLMTemperature,
 		Timeout:     time.Duration(cfg.LLMTimeoutSeconds) * time.Second,
+		Thinking:    cfg.LLMThinking,
 	}, nil)
 
 	// --- Summarizer worker ---

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,15 +13,22 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/baekenough/second-brain/internal/api"
+	"github.com/baekenough/second-brain/internal/briefing"
 	"github.com/baekenough/second-brain/internal/config"
 	"github.com/baekenough/second-brain/internal/graph"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/store"
 	"github.com/baekenough/second-brain/internal/telemetry"
+	"github.com/joho/godotenv"
 )
+
+// briefingCacheSize bounds the in-memory LRU briefing.Cache (plan Task 12).
+// Small on purpose: the cache key is the full open-action set, so a single-
+// user deployment rarely has more than a handful of distinct sets active at
+// once.
+const briefingCacheSize = 8
 
 // otelShutdownTimeout bounds how long the deferred telemetry shutdown may
 // block process exit. A dead/unreachable Langfuse collector must never
@@ -150,6 +157,10 @@ func run() error {
 		WithAskConfig(time.Duration(cfg.AskTimeoutSeconds)*time.Second, cfg.AskContextTopK, cfg.AskContextInsightM).
 		WithAskSessions(askSessionStore)
 
+	// --- Actions & Briefing (Part C, plan Task 12, feature-flagged off) ---
+	actionStore := store.NewActionQueryStore(pg)
+	srv = wireActionsAndBriefing(srv, cfg, actionStore, actionStore, llmClient.Enabled())
+
 	// --- Graph read API (Part B, optional) ---
 	// Wired only when both NEO4J_URI and NEO4J_PASSWORD are present. A
 	// connection failure logs a warning and leaves the graph routes
@@ -203,6 +214,34 @@ func run() error {
 
 	slog.Info("shutdown complete")
 	return nil
+}
+
+// wireActionsAndBriefing conditionally registers the /api/v1/actions and
+// /api/v1/briefing routes (plan Task 12). It is a pure function — no I/O —
+// so the on/off wiring driven by cfg is unit-testable without a live
+// Postgres connection (see main_test.go).
+//
+// Both feature flags default to false: leaving them unset means the routes
+// simply do not exist in the router (404), which IS the rollback mechanism
+// (spec §Rollback). BriefingEnabled only takes effect when ActionsAPIEnabled
+// is also true — the briefing reads through the actions query path — and is
+// additionally skipped when the LLM client is not configured (llmEnabled
+// false), since api.Server's own llmClient != nil guard cannot detect
+// "configured but disabled" (llm.New always returns a non-nil *Client).
+func wireActionsAndBriefing(srv *api.Server, cfg *config.Config, lister api.ActionLister, setter api.ActionStateSetter, llmEnabled bool) *api.Server {
+	if !cfg.ActionsAPIEnabled {
+		return srv
+	}
+	srv = srv.WithActions(lister, setter)
+
+	if !cfg.BriefingEnabled {
+		return srv
+	}
+	if !llmEnabled {
+		slog.Warn("briefing disabled — LLM client not configured despite BRIEFING_ENABLED=true")
+		return srv
+	}
+	return srv.WithBriefing(briefing.NewCache(briefingCacheSize), cfg.BriefingMaxActions)
 }
 
 // migrationsPath returns the path to the migrations directory.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/api"
+	"github.com/baekenough/second-brain/internal/config"
+	"github.com/baekenough/second-brain/internal/llm"
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+)
+
+// stubActionStore is a minimal ActionLister + ActionStateSetter fake used to
+// verify route registration without a live Postgres connection. It never
+// needs to return real data — these tests only assert whether the route
+// exists (404 vs. handled), not the response body.
+type stubActionStore struct{}
+
+func (stubActionStore) ListOpenActions(_ context.Context, _ store.ActionFilter) ([]store.ActionListItem, error) {
+	return nil, nil
+}
+
+func (stubActionStore) SetActionState(_ context.Context, _ string, _ model.ActionState, _ string) (bool, error) {
+	return true, nil
+}
+
+// newWiringTestServer builds the same api.Server shape run() constructs,
+// minus the DB/LLM dependencies that require live infrastructure.
+func newWiringTestServer(llmClient llm.Completer) *api.Server {
+	return api.NewServer(nil, nil, nil, nil, llmClient, "", "")
+}
+
+func getStatus(t *testing.T, srv *api.Server, method, path string) int {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	return rr.Code
+}
+
+// TestWireActionsAndBriefing_DisabledByDefault pins the rollback story for
+// Task 12: with both flags off (the zero value of config.Config), neither
+// route exists in the router at all — a 404, not a 401/500 from a nil
+// dependency.
+func TestWireActionsAndBriefing_DisabledByDefault(t *testing.T) {
+	cfg := &config.Config{} // ActionsAPIEnabled=false, BriefingEnabled=false
+	llmClient := llm.New(llm.Config{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o-mini", APIKey: "test-key"}, nil)
+
+	srv := wireActionsAndBriefing(newWiringTestServer(llmClient), cfg, stubActionStore{}, stubActionStore{}, llmClient.Enabled())
+
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/actions"); code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/actions = %d, want 404 when ACTIONS_API_ENABLED is unset", code)
+	}
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/briefing"); code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/briefing = %d, want 404 when both flags are unset", code)
+	}
+}
+
+// TestWireActionsAndBriefing_ActionsEnabledBriefingOff verifies the actions
+// route registers on its own without briefing following automatically.
+func TestWireActionsAndBriefing_ActionsEnabledBriefingOff(t *testing.T) {
+	cfg := &config.Config{ActionsAPIEnabled: true, BriefingMaxActions: 40}
+	llmClient := llm.New(llm.Config{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o-mini", APIKey: "test-key"}, nil)
+
+	srv := wireActionsAndBriefing(newWiringTestServer(llmClient), cfg, stubActionStore{}, stubActionStore{}, llmClient.Enabled())
+
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/actions"); code == http.StatusNotFound {
+		t.Errorf("GET /api/v1/actions = 404, want the route to be registered when ACTIONS_API_ENABLED=true")
+	}
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/briefing"); code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/briefing = %d, want 404 when BRIEFING_ENABLED is unset", code)
+	}
+}
+
+// TestWireActionsAndBriefing_BothEnabled verifies the briefing route
+// registers once both flags are on and the LLM client is configured.
+func TestWireActionsAndBriefing_BothEnabled(t *testing.T) {
+	cfg := &config.Config{ActionsAPIEnabled: true, BriefingEnabled: true, BriefingMaxActions: 40}
+	llmClient := llm.New(llm.Config{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o-mini", APIKey: "test-key"}, nil)
+
+	srv := wireActionsAndBriefing(newWiringTestServer(llmClient), cfg, stubActionStore{}, stubActionStore{}, llmClient.Enabled())
+
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/actions"); code == http.StatusNotFound {
+		t.Errorf("GET /api/v1/actions = 404, want registered")
+	}
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/briefing"); code == http.StatusNotFound {
+		t.Errorf("GET /api/v1/briefing = 404, want registered when both flags are true and the LLM client is configured")
+	}
+}
+
+// TestWireActionsAndBriefing_BriefingRequiresActionsEnabled verifies the
+// documented dependency: BRIEFING_ENABLED=true with ACTIONS_API_ENABLED=false
+// is a no-op combination (plan Task 12 design note — "그 반대는 무시된다").
+func TestWireActionsAndBriefing_BriefingRequiresActionsEnabled(t *testing.T) {
+	cfg := &config.Config{ActionsAPIEnabled: false, BriefingEnabled: true, BriefingMaxActions: 40}
+	llmClient := llm.New(llm.Config{BaseURL: "https://api.openai.com/v1", Model: "gpt-4o-mini", APIKey: "test-key"}, nil)
+
+	srv := wireActionsAndBriefing(newWiringTestServer(llmClient), cfg, stubActionStore{}, stubActionStore{}, llmClient.Enabled())
+
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/actions"); code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/actions = %d, want 404 when ACTIONS_API_ENABLED=false", code)
+	}
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/briefing"); code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/briefing = %d, want 404 — briefing must not activate without actions", code)
+	}
+}
+
+// TestWireActionsAndBriefing_LLMDisabledSkipsBriefing verifies requirement 4:
+// when the LLM client is not configured (Enabled() == false), briefing must
+// stay off even though BRIEFING_ENABLED=true — it degrades safely instead of
+// registering a route that can only 500.
+func TestWireActionsAndBriefing_LLMDisabledSkipsBriefing(t *testing.T) {
+	cfg := &config.Config{ActionsAPIEnabled: true, BriefingEnabled: true, BriefingMaxActions: 40}
+	llmClient := llm.New(llm.Config{}, nil) // no APIKey/AuthFile → Enabled() == false
+
+	if llmClient.Enabled() {
+		t.Fatal("test setup invalid: llmClient.Enabled() should be false with no APIKey/AuthFile")
+	}
+
+	srv := wireActionsAndBriefing(newWiringTestServer(llmClient), cfg, stubActionStore{}, stubActionStore{}, llmClient.Enabled())
+
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/actions"); code == http.StatusNotFound {
+		t.Errorf("GET /api/v1/actions = 404, want registered (actions do not depend on the LLM client)")
+	}
+	if code := getStatus(t, srv, http.MethodGet, "/api/v1/briefing"); code != http.StatusNotFound {
+		t.Errorf("GET /api/v1/briefing = %d, want 404 when the LLM client is not configured, even with BRIEFING_ENABLED=true", code)
+	}
+}

--- a/internal/api/actions.go
+++ b/internal/api/actions.go
@@ -1,0 +1,246 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// Bounds for GET /api/v1/actions. They mirror store.clampActionLimit; the store
+// clamps as well, because a bound that lives only in the handler protects
+// nothing the moment a second caller appears.
+const (
+	actionsDefaultLimit = 50
+	actionsMaxLimit     = 200
+)
+
+// ActionLister is the read side of the actions feature.
+type ActionLister interface {
+	ListOpenActions(ctx context.Context, f store.ActionFilter) ([]store.ActionListItem, error)
+}
+
+// ActionStateSetter is the user-driven state transition. It returns found=false
+// (with a nil error) when identityKey does not exist, so the handler can answer
+// 404 instead of leaking a foreign-key violation as a 500.
+type ActionStateSetter interface {
+	SetActionState(ctx context.Context, identityKey string, state model.ActionState, note string) (bool, error)
+}
+
+// actionResponseItem is the wire shape of one action.
+//
+// It deliberately carries no document content: the response gives a
+// document_id, and the body is fetched from the existing document detail route.
+// That keeps the amount of personal data sitting in any proxy or cache along
+// this path down to a one-line summary (privacy convention, plan Task 8).
+//
+// detected_by and confidence are exposed verbatim rather than hidden behind a
+// "verified" boolean — the UI shows them so a user can discount an action the
+// LLM invented (spec §7.4).
+type actionResponseItem struct {
+	IdentityKey     string     `json:"identity_key"`
+	DocumentID      string     `json:"document_id"`
+	ThreadKey       string     `json:"thread_key"`
+	Kind            string     `json:"kind"`
+	Summary         string     `json:"summary"`
+	CounterpartName string     `json:"counterpart_name"`
+	DueAt           *time.Time `json:"due_at"`
+	DetectedBy      string     `json:"detected_by"`
+	Confidence      float64    `json:"confidence"`
+	ObservedAt      time.Time  `json:"observed_at"`
+	State           string     `json:"state"`
+}
+
+type listActionsResponse struct {
+	Actions []actionResponseItem `json:"actions"`
+	Count   int                  `json:"count"`
+	// Truncated is true when the page came back exactly full, i.e. there may be
+	// more rows behind it. Without this flag a client cannot distinguish "50
+	// open actions" from "at least 50 open actions".
+	Truncated bool `json:"truncated"`
+}
+
+// WithActions wires the actions read and write dependencies. Both routes are
+// registered only when the corresponding dependency is non-nil, so leaving the
+// feature flag off means the routes do not exist (404) rather than existing and
+// erroring (500).
+func (s *Server) WithActions(lister ActionLister, setter ActionStateSetter) *Server {
+	s.actionLister = lister
+	s.actionSetter = setter
+	return s
+}
+
+// parseActionFilter converts query parameters into a store.ActionFilter.
+//
+// The returned message is a fixed string chosen from this function; it never
+// interpolates the submitted value, because a counterpart filter can contain a
+// real person's name and error bodies are logged by intermediaries.
+func parseActionFilter(r *http.Request) (store.ActionFilter, string) {
+	q := r.URL.Query()
+	f := store.ActionFilter{}
+
+	for _, raw := range q["kind"] {
+		k := model.ActionKind(raw)
+		if !model.IsValidActionKind(k) {
+			return f, "invalid kind filter"
+		}
+		f.Kinds = append(f.Kinds, k)
+	}
+
+	f.Counterpart = q.Get("counterpart")
+
+	if v := q.Get("due_before"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return f, "invalid due_before filter (want RFC3339)"
+		}
+		f.DueBefore = &t
+	}
+
+	if v := q.Get("min_confidence"); v != "" {
+		c, err := strconv.ParseFloat(v, 64)
+		if err != nil || c < 0 || c > 1 {
+			return f, "invalid min_confidence filter (want 0..1)"
+		}
+		f.MinConfidence = c
+	}
+
+	switch v := q.Get("sort"); v {
+	case "":
+		f.Sort = "due"
+	case "due", "confidence":
+		f.Sort = v
+	default:
+		return f, "invalid sort filter"
+	}
+
+	f.Limit = actionsDefaultLimit
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 || n > actionsMaxLimit {
+			return f, "invalid limit filter"
+		}
+		f.Limit = n
+	}
+
+	f.IncludeArchived = q.Get("include_archived") == "true"
+
+	return f, ""
+}
+
+// listActionsHandler handles GET /api/v1/actions.
+func (s *Server) listActionsHandler(w http.ResponseWriter, r *http.Request) {
+	f, msg := parseActionFilter(r)
+	if msg != "" {
+		writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+
+	items, err := s.actionLister.ListOpenActions(r.Context(), f)
+	if err != nil {
+		// The error is logged, not returned: a pgx error can quote row values.
+		slog.Error("actions: list failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	out := make([]actionResponseItem, 0, len(items))
+	for _, it := range items {
+		out = append(out, actionResponseItem{
+			IdentityKey:     it.IdentityKey,
+			DocumentID:      it.DocumentID.String(),
+			ThreadKey:       it.ThreadKey,
+			Kind:            string(it.Kind),
+			Summary:         it.Summary,
+			CounterpartName: it.CounterpartName,
+			DueAt:           it.DueAt,
+			DetectedBy:      string(it.DetectedBy),
+			Confidence:      it.Confidence,
+			ObservedAt:      it.ObservedAt,
+			State:           string(it.State),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, listActionsResponse{
+		Actions:   out,
+		Count:     len(out),
+		Truncated: len(out) == f.Limit,
+	})
+}
+
+// actionIdentityKeyRE matches the shape produced by action.BuildIdentityKey
+// ("action:" + 16 hex chars). The handler validates the SHAPE only: the value
+// is a deterministic hash that action_status rows already point at, so
+// recomputing or normalising it would break the link between an action and the
+// user's earlier decision about it (spec §5.5).
+var actionIdentityKeyRE = regexp.MustCompile(`^action:[0-9a-f]{16}$`)
+
+// actionNoteMaxLen bounds the free-text note. It is user-visible data, never
+// logged, and exists only to be shown back to the same user.
+const actionNoteMaxLen = 500
+
+type setActionStateRequest struct {
+	State string `json:"state"`
+	Note  string `json:"note"`
+}
+
+type setActionStateResponse struct {
+	IdentityKey string `json:"identity_key"`
+	State       string `json:"state"`
+}
+
+// setActionStateHandler handles POST /api/v1/actions/{identity_key}/status.
+//
+// The endpoint is idempotent: the same request replayed produces the same
+// status code, the same body, and the same database row (see
+// ActionQueryStore.SetActionState).
+func (s *Server) setActionStateHandler(w http.ResponseWriter, r *http.Request) {
+	key := chi.URLParam(r, "identity_key")
+	if !actionIdentityKeyRE.MatchString(key) {
+		writeError(w, http.StatusBadRequest, "invalid action key")
+		return
+	}
+
+	var req setActionStateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		// The decoder error can quote the request body, which may contain a
+		// note; only the fixed message goes out and nothing is logged.
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	state := model.ActionState(req.State)
+	switch state {
+	case model.StateOpen, model.StateDone, model.StateIgnored:
+	default:
+		writeError(w, http.StatusBadRequest, "invalid state")
+		return
+	}
+
+	// Truncate by runes, not bytes: notes are Korean in practice, and cutting a
+	// multi-byte rune in half would hand PostgreSQL invalid UTF-8.
+	note := req.Note
+	if runes := []rune(note); len(runes) > actionNoteMaxLen {
+		note = string(runes[:actionNoteMaxLen])
+	}
+
+	found, err := s.actionSetter.SetActionState(r.Context(), key, state, note)
+	if err != nil {
+		slog.Error("actions: set state failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "action not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, setActionStateResponse{IdentityKey: key, State: string(state)})
+}

--- a/internal/api/actions_test.go
+++ b/internal/api/actions_test.go
@@ -1,0 +1,321 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// stubActionLister records the filter it was handed so the tests can assert on
+// query-parameter parsing without a database.
+type stubActionLister struct {
+	got   store.ActionFilter
+	calls int
+	items []store.ActionListItem
+	err   error
+}
+
+func (s *stubActionLister) ListOpenActions(_ context.Context, f store.ActionFilter) ([]store.ActionListItem, error) {
+	s.got = f
+	s.calls++
+	return s.items, s.err
+}
+
+// stubActionSetter records the (key, state, note) triple and returns an
+// injected found/err pair.
+type stubActionSetter struct {
+	gotKey   string
+	gotState model.ActionState
+	gotNote  string
+	calls    int
+	found    bool
+	err      error
+}
+
+func (s *stubActionSetter) SetActionState(_ context.Context, identityKey string, state model.ActionState, note string) (bool, error) {
+	s.gotKey, s.gotState, s.gotNote = identityKey, state, note
+	s.calls++
+	return s.found, s.err
+}
+
+func newActionsTestServer(lister ActionLister, setter ActionStateSetter) *Server {
+	return NewServer(nil, nil, nil, nil, nil, "", "").WithActions(lister, setter)
+}
+
+func dummyActionItem() store.ActionListItem {
+	return store.ActionListItem{
+		Action: model.Action{
+			IdentityKey: "action:0123456789abcdef",
+			DocumentID:  uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			ThreadKey:   "zz-dummy-thread",
+			Kind:        model.KindMyCommitment,
+			Summary:     "dummy summary",
+			DetectedBy:  model.DetectedStructural,
+			Confidence:  0.9,
+			ObservedAt:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		},
+		State:           model.StateOpen,
+		CounterpartName: "zz-dummy-counterpart",
+	}
+}
+
+// TestListActionsHandlerParsesFilters pins the query-parameter contract: each
+// supported parameter must reach the store as a typed filter field, and a
+// repeated kind parameter must accumulate rather than overwrite.
+func TestListActionsHandlerParsesFilters(t *testing.T) {
+	lister := &stubActionLister{items: []store.ActionListItem{dummyActionItem()}}
+	srv := newActionsTestServer(lister, nil)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/actions?kind=my_commitment&kind=scheduled&sort=confidence&limit=10&min_confidence=0.5&include_archived=true&counterpart=zz-dummy", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(lister.got.Kinds) != 2 {
+		t.Fatalf("Kinds = %v, want both repeated kind values", lister.got.Kinds)
+	}
+	if lister.got.Sort != "confidence" {
+		t.Errorf("Sort = %q, want %q", lister.got.Sort, "confidence")
+	}
+	if lister.got.Limit != 10 {
+		t.Errorf("Limit = %d, want 10", lister.got.Limit)
+	}
+	if lister.got.MinConfidence != 0.5 {
+		t.Errorf("MinConfidence = %v, want 0.5", lister.got.MinConfidence)
+	}
+	if !lister.got.IncludeArchived {
+		t.Error("IncludeArchived = false, want true")
+	}
+	if lister.got.Counterpart != "zz-dummy" {
+		t.Errorf("Counterpart = %q, want %q", lister.got.Counterpart, "zz-dummy")
+	}
+
+	var body struct {
+		Actions []struct {
+			IdentityKey string `json:"identity_key"`
+			Summary     string `json:"summary"`
+			State       string `json:"state"`
+			DetectedBy  string `json:"detected_by"`
+		} `json:"actions"`
+		Count     int  `json:"count"`
+		Truncated bool `json:"truncated"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Count != 1 || len(body.Actions) != 1 {
+		t.Fatalf("count=%d actions=%d, want 1/1", body.Count, len(body.Actions))
+	}
+	if body.Truncated {
+		t.Error("truncated = true, want false (1 row < limit 10)")
+	}
+	if body.Actions[0].DetectedBy != string(model.DetectedStructural) {
+		t.Errorf("detected_by = %q, want it exposed verbatim (hallucination defence)", body.Actions[0].DetectedBy)
+	}
+}
+
+// TestListActionsHandlerTruncatedFlag pins that a full page is reported as
+// truncated, so the caller can tell "50 results" from "at least 50 results".
+func TestListActionsHandlerTruncatedFlag(t *testing.T) {
+	items := make([]store.ActionListItem, 3)
+	for i := range items {
+		items[i] = dummyActionItem()
+	}
+	lister := &stubActionLister{items: items}
+	srv := newActionsTestServer(lister, nil)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/actions?limit=3", nil))
+
+	var body struct {
+		Truncated bool `json:"truncated"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Truncated {
+		t.Fatal("truncated = false when the page is exactly full; caller cannot tell there may be more")
+	}
+}
+
+// TestListActionsHandlerRejectsInvalidInput pins that closed-vocabulary and
+// range violations are 400s, and that the error body never echoes user input
+// (a counterpart filter can carry a real person's name).
+func TestListActionsHandlerRejectsInvalidInput(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"invented kind", "?kind=invent_a_kind"},
+		{"confidence above range", "?min_confidence=1.5"},
+		{"confidence below range", "?min_confidence=-0.1"},
+		{"unparsable confidence", "?min_confidence=abc"},
+		{"bad due_before", "?due_before=not-a-time"},
+		{"limit over cap", "?limit=201"},
+		{"limit zero", "?limit=0"},
+		{"unknown sort", "?sort=summary"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lister := &stubActionLister{}
+			srv := newActionsTestServer(lister, nil)
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/actions"+tc.query, nil))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400 (body=%s)", rec.Code, rec.Body.String())
+			}
+			if lister.calls != 0 {
+				t.Errorf("store was queried %d times despite invalid input", lister.calls)
+			}
+			if strings.Contains(rec.Body.String(), "invent_a_kind") {
+				t.Error("error body echoed the user's input back")
+			}
+		})
+	}
+}
+
+// TestSetActionStateHandlerMarksDone pins the happy path: the path key and the
+// requested state reach the store untouched. The handler must never recompute
+// or normalise identity_key — that value is the cross-re-extraction handle for
+// the user's decision, and rewriting it would orphan the decision.
+func TestSetActionStateHandlerMarksDone(t *testing.T) {
+	setter := &stubActionSetter{found: true}
+	srv := newActionsTestServer(&stubActionLister{}, setter)
+
+	const key = "action:0123456789abcdef"
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/actions/"+key+"/status",
+		strings.NewReader(`{"state":"done","note":"dummy note"}`))
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if setter.gotKey != key {
+		t.Errorf("setter got key %q, want %q verbatim", setter.gotKey, key)
+	}
+	if setter.gotState != model.StateDone {
+		t.Errorf("setter got state %q, want %q", setter.gotState, model.StateDone)
+	}
+	if setter.gotNote != "dummy note" {
+		t.Errorf("setter got note %q, want it passed through", setter.gotNote)
+	}
+
+	var body struct {
+		IdentityKey string `json:"identity_key"`
+		State       string `json:"state"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.IdentityKey != key || body.State != string(model.StateDone) {
+		t.Fatalf("response = %+v, want the key and state echoed", body)
+	}
+}
+
+// TestSetActionStateHandlerIsIdempotent pins the HTTP-level half of the
+// idempotence contract: a replayed request produces the same status code and
+// the same body. (The database half — resolved_at not moving — is pinned by
+// TestSetActionStateIsIdempotent in internal/store.)
+func TestSetActionStateHandlerIsIdempotent(t *testing.T) {
+	setter := &stubActionSetter{found: true}
+	srv := newActionsTestServer(&stubActionLister{}, setter)
+
+	const key = "action:0123456789abcdef"
+	var codes []int
+	var bodies []string
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost,
+			"/api/v1/actions/"+key+"/status", strings.NewReader(`{"state":"done"}`)))
+		codes = append(codes, rec.Code)
+		bodies = append(bodies, rec.Body.String())
+	}
+	if codes[0] != codes[1] || bodies[0] != bodies[1] {
+		t.Fatalf("replayed request differed: %d %q vs %d %q", codes[0], bodies[0], codes[1], bodies[1])
+	}
+	if setter.calls != 2 {
+		t.Fatalf("setter called %d times, want 2 (the handler must not dedupe; the store is what guarantees idempotence)", setter.calls)
+	}
+}
+
+// TestSetActionStateHandlerNotFound pins that found=false becomes a 404.
+func TestSetActionStateHandlerNotFound(t *testing.T) {
+	setter := &stubActionSetter{found: false}
+	srv := newActionsTestServer(&stubActionLister{}, setter)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost,
+		"/api/v1/actions/action:0123456789abcdef/status", strings.NewReader(`{"state":"done"}`)))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 for an unknown identity_key (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSetActionStateHandlerRejectsBadInput pins shape validation on the path
+// key and closed-vocabulary validation on the state, and that neither reaches
+// the store.
+func TestSetActionStateHandlerRejectsBadInput(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		body string
+	}{
+		{"malformed key", "not-an-action-key", `{"state":"done"}`},
+		{"key with wrong hex length", "action:0123", `{"state":"done"}`},
+		{"key with non-hex", "action:zzzzzzzzzzzzzzzz", `{"state":"done"}`},
+		{"state outside vocabulary", "action:0123456789abcdef", `{"state":"archived"}`},
+		{"empty state", "action:0123456789abcdef", `{"state":""}`},
+		{"malformed json", "action:0123456789abcdef", `{`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setter := &stubActionSetter{found: true}
+			srv := newActionsTestServer(&stubActionLister{}, setter)
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost,
+				"/api/v1/actions/"+tc.key+"/status", strings.NewReader(tc.body)))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400 (body=%s)", rec.Code, rec.Body.String())
+			}
+			if setter.calls != 0 {
+				t.Errorf("store was called %d times despite invalid input", setter.calls)
+			}
+		})
+	}
+}
+
+// TestSetActionStateHandlerNotRegisteredWithoutSetter pins that the write route
+// is absent when only the read side is wired.
+func TestSetActionStateHandlerNotRegisteredWithoutSetter(t *testing.T) {
+	srv := newActionsTestServer(&stubActionLister{}, nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodPost,
+		"/api/v1/actions/action:0123456789abcdef/status", strings.NewReader(`{"state":"done"}`)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 when the setter is not wired", rec.Code)
+	}
+}
+
+// TestListActionsHandlerNotRegisteredWithoutDependency pins the rollback
+// contract: with the feature flag off, WithActions is never called and the route
+// must not exist at all (404), rather than existing and failing with a 500.
+func TestListActionsHandlerNotRegisteredWithoutDependency(t *testing.T) {
+	srv := NewServer(nil, nil, nil, nil, nil, "", "")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/actions", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 when the actions feature is not wired", rec.Code)
+	}
+}

--- a/internal/api/briefing.go
+++ b/internal/api/briefing.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/briefing"
+	"github.com/baekenough/second-brain/internal/store"
+)
+
+// briefingTimeout bounds one briefing request. On expiry briefing.Generate
+// degrades to the deterministic aggregate rather than failing the request: a
+// slow model must not turn into an error page over data the server already has.
+const briefingTimeout = 30 * time.Second
+
+type briefingResponse struct {
+	Sentences []briefing.Sentence `json:"sentences"`
+	Degraded  bool                `json:"degraded"`
+	// DroppedCount is how many model sentences failed evidence validation. It is
+	// deliberately part of the public response: it lets the user see that the
+	// server checks the model's claims instead of forwarding them.
+	DroppedCount int       `json:"dropped_count"`
+	ActionCount  int       `json:"action_count"`
+	Cached       bool      `json:"cached"`
+	GeneratedAt  time.Time `json:"generated_at"`
+}
+
+// WithBriefing enables GET /api/v1/briefing. The route is registered only when
+// an action lister and an LLM client are also present, so the feature flag being
+// off means the route does not exist (404).
+//
+// maxActions bounds how many open actions feed one briefing; <= 0 falls back to
+// the package default.
+func (s *Server) WithBriefing(cache *briefing.Cache, maxActions int) *Server {
+	s.briefingCache = cache
+	if maxActions <= 0 {
+		maxActions = defaultBriefingMaxActions
+	}
+	s.briefingMaxActions = maxActions
+	// The model name participates in the cache key so that swapping models does
+	// not serve the previous model's sentences. llm.Completer does not expose
+	// the model, and the flag-wiring signature is fixed, so it is read from the
+	// same environment variable the LLM client is configured from. An empty
+	// value is harmless — it just makes the model a constant in the key.
+	s.briefingModel = os.Getenv("LLM_MODEL")
+	return s
+}
+
+const defaultBriefingMaxActions = 40
+
+// briefingHandler handles GET /api/v1/briefing.
+//
+// The open action set is re-read on every request: it IS the cache key, so
+// there is no way to know whether a cached briefing is still valid without it.
+// The LLM call is what the cache protects, not the query.
+func (s *Server) briefingHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), briefingTimeout)
+	defer cancel()
+
+	items, err := s.actionLister.ListOpenActions(ctx, store.ActionFilter{
+		Limit: s.briefingMaxActions,
+		Sort:  "due",
+	})
+	if err != nil {
+		slog.Error("briefing: listing open actions failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	if len(items) == 0 {
+		writeJSON(w, http.StatusOK, briefingResponse{
+			Sentences:   []briefing.Sentence{},
+			ActionCount: 0,
+			GeneratedAt: time.Now().UTC(),
+		})
+		return
+	}
+
+	in := briefing.Input{
+		Actions: make([]briefing.InputAction, 0, len(items)),
+		Model:   s.briefingModel,
+	}
+	for _, it := range items {
+		in.Actions = append(in.Actions, briefing.InputAction{
+			IdentityKey:     it.IdentityKey,
+			Kind:            string(it.Kind),
+			Summary:         it.Summary,
+			CounterpartName: it.CounterpartName,
+			DocumentID:      it.DocumentID.String(),
+			DetectedBy:      string(it.DetectedBy),
+			DueAt:           it.DueAt,
+			Confidence:      it.Confidence,
+		})
+		// "Latest document time" is the newest observation among the actions
+		// themselves. Querying documents separately would also invalidate the
+		// cache for documents that produced no action — which is precisely when
+		// the briefing has no reason to change.
+		if it.ObservedAt.After(in.LatestDocumentAt) {
+			in.LatestDocumentAt = it.ObservedAt
+		}
+	}
+
+	key := in.CacheKey()
+	if cached, ok := s.briefingCache.Get(key); ok {
+		writeJSON(w, http.StatusOK, briefingResponse{
+			Sentences:    cached.Sentences,
+			Degraded:     cached.Degraded,
+			DroppedCount: cached.DroppedCount,
+			ActionCount:  len(items),
+			Cached:       true,
+			GeneratedAt:  cached.GeneratedAt,
+		})
+		return
+	}
+
+	started := time.Now()
+	// Generate never returns an error for an LLM failure; it degrades.
+	result, _ := briefing.Generate(ctx, s.llmClient, in)
+	s.briefingCache.Put(key, result)
+
+	// Only content-free fields are logged: counts, a duration, the cache key
+	// hash (computed from identity keys alone), and a truncated key prefix. No
+	// summary, name, sentence, prompt, or raw model output.
+	slog.Info("briefing generated",
+		append(briefing.SafeLogFields(in, result),
+			// The cache key is a hash of identity keys and timestamps only, so
+			// it carries no personal data (see Input.CacheKey).
+			"cache_key", key,
+			"duration_ms", time.Since(started).Milliseconds())...)
+
+	writeJSON(w, http.StatusOK, briefingResponse{
+		Sentences:    result.Sentences,
+		Degraded:     result.Degraded,
+		DroppedCount: result.DroppedCount,
+		ActionCount:  len(items),
+		GeneratedAt:  result.GeneratedAt,
+	})
+}

--- a/internal/api/briefing_test.go
+++ b/internal/api/briefing_test.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/briefing"
+	"github.com/baekenough/second-brain/internal/llm"
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+const briefingTestDocID = "11111111-1111-1111-1111-111111111111"
+
+// countingCompleter records how many times the model was actually called, which
+// is how the cache tests tell a hit from a miss.
+type countingCompleter struct {
+	calls int
+	reply string
+}
+
+func (c *countingCompleter) Enabled() bool { return true }
+
+func (c *countingCompleter) CompleteWithMessages(_ context.Context, _ string, _ []llm.Message) (string, error) {
+	c.calls++
+	return c.reply, nil
+}
+
+func briefingTestItem() store.ActionListItem {
+	return store.ActionListItem{
+		Action: model.Action{
+			IdentityKey: "action:aaaaaaaaaaaaaaaa",
+			DocumentID:  uuid.MustParse(briefingTestDocID),
+			ThreadKey:   "zz-dummy-thread",
+			Kind:        model.KindMyCommitment,
+			Summary:     "더미 요약",
+			DetectedBy:  model.DetectedStructural,
+			Confidence:  1.0,
+			ObservedAt:  time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		},
+		State: model.StateOpen,
+	}
+}
+
+func newBriefingTestServer(lister ActionLister, c llm.Completer) *Server {
+	return NewServer(nil, nil, nil, nil, c, "", "").
+		WithActions(lister, nil).
+		WithBriefing(briefing.NewCache(4), 40)
+}
+
+// TestBriefingHandlerSkipsLLMWhenNoOpenActions pins that an empty open set is
+// answered without calling the model. A summary request with nothing to
+// summarise produces invention, and it also costs money for no reason.
+func TestBriefingHandlerSkipsLLMWhenNoOpenActions(t *testing.T) {
+	llmStub := &countingCompleter{reply: `{"sentences":[]}`}
+	srv := newBriefingTestServer(&stubActionLister{}, llmStub)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/briefing", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if llmStub.calls != 0 {
+		t.Fatalf("LLM called %d times for an empty action set, want 0", llmStub.calls)
+	}
+
+	var body struct {
+		Sentences   []briefing.Sentence `json:"sentences"`
+		Degraded    bool                `json:"degraded"`
+		ActionCount int                 `json:"action_count"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Sentences) != 0 || body.Degraded || body.ActionCount != 0 {
+		t.Fatalf("body = %+v, want an empty, non-degraded briefing", body)
+	}
+}
+
+// TestBriefingHandlerCachesOnIdenticalInput pins the cost control: the same open
+// action set must not be summarised twice.
+func TestBriefingHandlerCachesOnIdenticalInput(t *testing.T) {
+	llmStub := &countingCompleter{
+		reply: `{"sentences":[{"text":"근거 있는 문장.","document_ids":["` + briefingTestDocID + `"],"identity_keys":["action:aaaaaaaaaaaaaaaa"]}]}`,
+	}
+	lister := &stubActionLister{items: []store.ActionListItem{briefingTestItem()}}
+	srv := newBriefingTestServer(lister, llmStub)
+
+	var bodies []string
+	var cachedFlags []bool
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/briefing", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status=%d body=%s", i, rec.Code, rec.Body.String())
+		}
+		var body struct {
+			Sentences []briefing.Sentence `json:"sentences"`
+			Cached    bool                `json:"cached"`
+		}
+		if err := json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		bodies = append(bodies, rec.Body.String())
+		cachedFlags = append(cachedFlags, body.Cached)
+		if len(body.Sentences) != 1 {
+			t.Fatalf("request %d returned %d sentences, want 1", i, len(body.Sentences))
+		}
+	}
+
+	if llmStub.calls != 1 {
+		t.Fatalf("LLM called %d times, want 1 (second call must hit the cache)", llmStub.calls)
+	}
+	if cachedFlags[0] || !cachedFlags[1] {
+		t.Fatalf("cached flags = %v, want [false true]", cachedFlags)
+	}
+	if lister.calls != 2 {
+		t.Fatalf("store queried %d times, want 2 (the cache key depends on the current open set, so it must be re-read)", lister.calls)
+	}
+}
+
+// TestBriefingHandlerReportsDroppedSentences pins that the discard count reaches
+// the client. It is a trust signal, not debug output: the user should be able to
+// see that the server is checking the model's claims.
+func TestBriefingHandlerReportsDroppedSentences(t *testing.T) {
+	llmStub := &countingCompleter{
+		reply: `{"sentences":[
+			{"text":"근거 있는 문장.","document_ids":["` + briefingTestDocID + `"]},
+			{"text":"환각 문장.","document_ids":["99999999-9999-9999-9999-999999999999"]}
+		]}`,
+	}
+	srv := newBriefingTestServer(&stubActionLister{items: []store.ActionListItem{briefingTestItem()}}, llmStub)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/briefing", nil))
+
+	var body struct {
+		Sentences    []briefing.Sentence `json:"sentences"`
+		DroppedCount int                 `json:"dropped_count"`
+		ActionCount  int                 `json:"action_count"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Sentences) != 1 {
+		t.Fatalf("sentences = %+v, want only the grounded one", body.Sentences)
+	}
+	if body.DroppedCount != 1 {
+		t.Fatalf("dropped_count = %d, want 1", body.DroppedCount)
+	}
+	if body.ActionCount != 1 {
+		t.Fatalf("action_count = %d, want 1", body.ActionCount)
+	}
+}
+
+// TestBriefingHandlerNotRegisteredWithoutDependencies pins the rollback
+// contract: the route must be absent unless both the LLM client and the action
+// lister are wired.
+func TestBriefingHandlerNotRegisteredWithoutDependencies(t *testing.T) {
+	cases := map[string]*Server{
+		"no briefing cache": NewServer(nil, nil, nil, nil, &countingCompleter{}, "", "").
+			WithActions(&stubActionLister{}, nil),
+		"no action lister": NewServer(nil, nil, nil, nil, &countingCompleter{}, "", "").
+			WithBriefing(briefing.NewCache(4), 40),
+		"no llm client": NewServer(nil, nil, nil, nil, nil, "", "").
+			WithActions(&stubActionLister{}, nil).
+			WithBriefing(briefing.NewCache(4), 40),
+	}
+	for name, srv := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/briefing", nil))
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status=%d, want 404", rec.Code)
+			}
+		})
+	}
+}
+
+// TestBriefingHandlerStoreFailure pins that a failed action query is a 500 with
+// a fixed message — not a body carrying database text.
+func TestBriefingHandlerStoreFailure(t *testing.T) {
+	lister := &stubActionLister{err: context.DeadlineExceeded}
+	srv := newBriefingTestServer(lister, &countingCompleter{})
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/briefing", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d, want 500", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "deadline") {
+		t.Fatalf("error body leaked the underlying error: %s", rec.Body.String())
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/baekenough/second-brain/internal/briefing"
 	"github.com/baekenough/second-brain/internal/intent"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/model"
@@ -148,6 +149,24 @@ type Server struct {
 	// Metadata["number"] so it stays searchable. Set via
 	// WithPIINumberHashing before calling Handler().
 	piiNumberHashingEnabled bool
+
+	// actionLister and actionSetter are optional. When actionLister is non-nil
+	// the GET /api/v1/actions route is registered; when actionSetter is non-nil
+	// the POST /api/v1/actions/{identity_key}/status route is. Set via
+	// WithActions before calling Handler(). nil (the default) means the routes
+	// do not exist in the router at all — that missing route, answering 404, is
+	// exactly what the ACTIONS_API_ENABLED rollback switch buys.
+	actionLister ActionLister
+	actionSetter ActionStateSetter
+
+	// briefingCache, briefingMaxActions, and briefingModel are optional. When
+	// briefingCache is non-nil AND both actionLister and llmClient are present,
+	// the GET /api/v1/briefing route is registered. Set via WithBriefing before
+	// calling Handler(). The briefing depends on the actions read path, so
+	// turning the actions feature off turns the briefing off with it.
+	briefingCache      *briefing.Cache
+	briefingMaxActions int
+	briefingModel      string
 
 	// handlerOnce ensures buildHandler is called exactly once per Server so
 	// that the graphql-go schema (and its package-level type objects) are
@@ -324,6 +343,15 @@ func (s *Server) buildHandler() http.Handler {
 			r.Get("/api/v1/graph/expand", s.graphExpandHandler)
 			r.Get("/api/v1/graph/evidence", s.graphEvidenceHandler)
 			r.Get("/api/v1/graph/entities", s.graphEntitiesHandler)
+		}
+		if s.actionLister != nil {
+			r.Get("/api/v1/actions", s.listActionsHandler)
+		}
+		if s.actionSetter != nil {
+			r.Post("/api/v1/actions/{identity_key}/status", s.setActionStateHandler)
+		}
+		if s.briefingCache != nil && s.actionLister != nil && s.llmClient != nil {
+			r.Get("/api/v1/briefing", s.briefingHandler)
 		}
 		if s.notesUpserter != nil {
 			r.Post("/api/v1/notes", s.createNoteHandler)

--- a/internal/briefing/cache.go
+++ b/internal/briefing/cache.go
@@ -1,0 +1,63 @@
+package briefing
+
+import "sync"
+
+// defaultCacheCapacity is used when NewCache is given a non-positive capacity.
+// A cache that never hits would silently double LLM spend, so a misconfigured
+// value degrades to a working default rather than to a no-op.
+const defaultCacheCapacity = 8
+
+// Cache is a tiny in-process, capacity-bounded briefing cache keyed by
+// Input.CacheKey.
+//
+// It is intentionally a map plus an insertion-order slice rather than a real
+// LRU: the capacity is single digits and there is one user, so the eviction
+// policy barely matters, while an extra data structure would be code to
+// maintain for no gain. Entries are lost on restart, which costs exactly one
+// extra LLM call after a deploy.
+type Cache struct {
+	mu       sync.Mutex
+	capacity int
+	entries  map[string]Result
+	order    []string // insertion order; order[0] is the next eviction victim
+}
+
+// NewCache returns a Cache holding at most capacity briefings.
+func NewCache(capacity int) *Cache {
+	if capacity <= 0 {
+		capacity = defaultCacheCapacity
+	}
+	return &Cache{
+		capacity: capacity,
+		entries:  make(map[string]Result, capacity),
+		order:    make([]string, 0, capacity),
+	}
+}
+
+// Get returns the cached briefing for key, if present.
+func (c *Cache) Get(key string) (Result, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	r, ok := c.entries[key]
+	return r, ok
+}
+
+// Put stores r under key, evicting the oldest entry when full. Re-putting an
+// existing key overwrites in place and does not consume a second slot.
+func (c *Cache) Put(key string, r Result) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.entries[key]; exists {
+		c.entries[key] = r
+		return
+	}
+
+	if len(c.order) >= c.capacity {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		delete(c.entries, oldest)
+	}
+	c.entries[key] = r
+	c.order = append(c.order, key)
+}

--- a/internal/briefing/cache_test.go
+++ b/internal/briefing/cache_test.go
@@ -1,0 +1,88 @@
+package briefing
+
+import (
+	"sync"
+	"testing"
+)
+
+func dummyResult(text string) Result {
+	return Result{Sentences: []Sentence{{Text: text, DocumentIDs: []string{"11111111-1111-1111-1111-111111111111"}}}}
+}
+
+// TestCacheEvictsOldest pins the bounded-memory property: a long-running server
+// must not accumulate one cached briefing per distinct open-action set forever.
+func TestCacheEvictsOldest(t *testing.T) {
+	c := NewCache(2)
+	c.Put("k1", dummyResult("one"))
+	c.Put("k2", dummyResult("two"))
+	c.Put("k3", dummyResult("three"))
+
+	if _, ok := c.Get("k1"); ok {
+		t.Fatal("k1 survived past capacity 2; the oldest entry must be evicted")
+	}
+	if _, ok := c.Get("k2"); !ok {
+		t.Fatal("k2 was evicted too early")
+	}
+	if _, ok := c.Get("k3"); !ok {
+		t.Fatal("k3 missing right after Put")
+	}
+}
+
+// TestCacheGetMissAndHit pins the basic contract, including that a miss returns
+// the zero Result rather than a partially populated one.
+func TestCacheGetMissAndHit(t *testing.T) {
+	c := NewCache(4)
+	if got, ok := c.Get("absent"); ok || len(got.Sentences) != 0 {
+		t.Fatalf("miss returned ok=%v result=%+v", ok, got)
+	}
+	c.Put("present", dummyResult("hello"))
+	got, ok := c.Get("present")
+	if !ok || len(got.Sentences) != 1 || got.Sentences[0].Text != "hello" {
+		t.Fatalf("hit returned ok=%v result=%+v", ok, got)
+	}
+}
+
+// TestCacheOverwriteKeepsOneEntry pins that re-Putting a known key replaces the
+// value instead of appending a second entry that would push a live key out.
+func TestCacheOverwriteKeepsOneEntry(t *testing.T) {
+	c := NewCache(2)
+	c.Put("k1", dummyResult("first"))
+	c.Put("k1", dummyResult("second"))
+	c.Put("k2", dummyResult("two"))
+
+	got, ok := c.Get("k1")
+	if !ok {
+		t.Fatal("k1 evicted after being overwritten; overwrite must not consume a second slot")
+	}
+	if got.Sentences[0].Text != "second" {
+		t.Fatalf("k1 = %q, want the overwritten value", got.Sentences[0].Text)
+	}
+}
+
+// TestCacheZeroCapacity pins that a misconfigured capacity degrades to a usable
+// default rather than to a cache that never hits (which would silently double
+// LLM spend).
+func TestCacheZeroCapacity(t *testing.T) {
+	c := NewCache(0)
+	c.Put("k1", dummyResult("one"))
+	if _, ok := c.Get("k1"); !ok {
+		t.Fatal("NewCache(0) produced a cache that never hits")
+	}
+}
+
+// TestCacheIsConcurrencySafe pins the mutex. Two browser tabs hitting the
+// briefing route at once is the ordinary case, not an exotic one.
+func TestCacheIsConcurrencySafe(t *testing.T) {
+	c := NewCache(8)
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := string(rune('a' + i%8))
+			c.Put(key, dummyResult(key))
+			c.Get(key)
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/briefing/doc.go
+++ b/internal/briefing/doc.go
@@ -1,0 +1,37 @@
+// Package briefing turns a set of open actions into a short, evidence-backed
+// summary.
+//
+// # The contract
+//
+// Every sentence a briefing shows carries the document ids it is derived from,
+// and the server discards any sentence whose ids it did not itself put in the
+// prompt (see Validate). This is the reason the package exists: a system that
+// says "reply to this" without being able to show which message says so is
+// asking for trust it has not earned. The check is mechanical, not a request in
+// the prompt — the prompt states the rule only because stating it improves
+// compliance.
+//
+// When nothing survives validation, the result is a deterministic count of the
+// open actions by kind, flagged Degraded so the UI can say "aggregate only".
+// The fallback carries evidence too; the rule has no exceptions.
+//
+// # Cost
+//
+// Briefings are cached on a hash of (prompt version, model, newest observation
+// time, sorted set of open identity keys). Invalidation is implicit: any change
+// to those inputs changes the key. Summary text is deliberately not part of the
+// key — the same identity_key is the same real-world action even if a
+// re-extraction reworded it.
+//
+// # Privacy
+//
+// Action summaries, counterpart names, notes, prompts, and raw model output are
+// never logged (issue #194): all of them are restatements of the user's private
+// conversations. Log lines are built from SafeLogFields, which can only emit
+// counts, flags, and a truncated key prefix. Parse failures are reported with
+// lengths and offsets — never with err.Error(), because encoding/json quotes the
+// offending input in its message.
+//
+// The package has no database or HTTP dependency; the API layer converts store
+// rows into Input and Result into a response.
+package briefing

--- a/internal/briefing/generate.go
+++ b/internal/briefing/generate.go
@@ -1,0 +1,63 @@
+package briefing
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/baekenough/second-brain/internal/llm"
+)
+
+// Generate produces a briefing for in.
+//
+// It never returns an error for an LLM failure. A briefing is an aid on top of
+// the action list; if the model is down, slow, disabled, or returns something
+// unusable, the caller still gets a usable Result — the deterministic
+// count-only fallback, flagged Degraded so the UI can say so. Propagating the
+// error instead would let a summarisation failure take down the page whose data
+// is already in hand.
+//
+// A truncated reply (llm.ErrTruncated: generation stopped on the token budget)
+// is treated as a failure, not as content. Its JSON is incomplete by
+// definition, and salvaging a partial answer is precisely how a sentence with
+// no evidence behind it reaches the user.
+//
+// An empty action set never reaches the model: asking for a summary of nothing
+// reliably produces invention.
+func Generate(ctx context.Context, c llm.Completer, in Input) (Result, error) {
+	if len(in.Actions) == 0 {
+		return fallbackResult(in), nil
+	}
+	if c == nil || !c.Enabled() {
+		slog.Info("briefing: llm unavailable, returning aggregate only",
+			"action_count", len(in.Actions), "reason", "disabled")
+		return fallbackResult(in), nil
+	}
+
+	raw, err := c.CompleteWithMessages(ctx, systemPrompt, []llm.Message{
+		{Role: "user", Content: buildUserMessage(in)},
+	})
+	if err != nil {
+		// Only a closed-vocabulary reason is logged. Neither the prompt (which
+		// contains action summaries) nor the reply (which restates the user's
+		// conversations) may appear in logs.
+		reason := "error"
+		if errors.Is(err, llm.ErrTruncated) {
+			reason = "truncated"
+		} else if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			reason = "timeout"
+		}
+		slog.Warn("briefing: llm call failed, returning aggregate only",
+			"action_count", len(in.Actions), "reason", reason)
+		return fallbackResult(in), nil
+	}
+
+	result, err := Validate(raw, in)
+	if err != nil {
+		// err here is already content-free by construction (decodePayload builds
+		// it from lengths and offsets only), so it is safe to log as-is.
+		slog.Warn("briefing: reply could not be decoded, returning aggregate only",
+			"action_count", len(in.Actions), "error", err)
+	}
+	return result, nil
+}

--- a/internal/briefing/generate_test.go
+++ b/internal/briefing/generate_test.go
@@ -1,0 +1,161 @@
+package briefing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/llm"
+)
+
+// stubCompleter adapts a function to llm.Completer and records what it was
+// asked. The prompt is captured so tests can assert on what the model is shown;
+// it is never logged by production code.
+type stubCompleter struct {
+	enabled    bool
+	calls      int
+	gotSystem  string
+	gotMessage string
+	reply      string
+	err        error
+}
+
+func (s *stubCompleter) Enabled() bool { return s.enabled }
+
+func (s *stubCompleter) CompleteWithMessages(_ context.Context, system string, msgs []llm.Message) (string, error) {
+	s.calls++
+	s.gotSystem = system
+	if len(msgs) > 0 {
+		s.gotMessage = msgs[len(msgs)-1].Content
+	}
+	return s.reply, s.err
+}
+
+// TestGenerateReturnsGroundedSentences pins the happy path end to end.
+func TestGenerateReturnsGroundedSentences(t *testing.T) {
+	c := &stubCompleter{
+		enabled: true,
+		reply:   `{"sentences":[{"text":"근거 있는 문장.","document_ids":["` + docA + `"],"identity_keys":["` + keyA + `"]}]}`,
+	}
+
+	got, err := Generate(context.Background(), c, testInput())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got.Degraded || len(got.Sentences) != 1 {
+		t.Fatalf("result = %+v, want one grounded sentence", got)
+	}
+	if got.GeneratedAt.IsZero() {
+		t.Error("GeneratedAt is zero")
+	}
+}
+
+// TestGenerateFallsBackOnLLMFailure pins that no LLM failure mode can turn into
+// an error for the caller: a briefing is a convenience surface, and failing it
+// must not take the actions page down with it.
+func TestGenerateFallsBackOnLLMFailure(t *testing.T) {
+	cases := map[string]error{
+		"transport error":  errors.New("dummy transport failure"),
+		"context canceled": context.Canceled,
+		// A response cut off by the token budget is the dangerous case: its JSON
+		// is syntactically incomplete, and treating a partial answer as a whole
+		// one is exactly how an unfounded sentence reaches the user.
+		"truncated by token budget": fmt.Errorf("wrapped: %w", llm.ErrTruncated),
+	}
+	for name, injected := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &stubCompleter{enabled: true, err: injected, reply: `{"sentences":[{"text":"잘린 문장`}
+
+			got, err := Generate(context.Background(), c, testInput())
+			if err != nil {
+				t.Fatalf("Generate returned an error instead of degrading: %v", err)
+			}
+			if !got.Degraded {
+				t.Fatal("Degraded = false after an LLM failure")
+			}
+			if len(got.Sentences) != 1 || len(got.Sentences[0].DocumentIDs) == 0 {
+				t.Fatalf("fallback = %+v, want one grounded count sentence", got.Sentences)
+			}
+			if strings.Contains(got.Sentences[0].Text, "잘린 문장") {
+				t.Fatal("partial model output leaked into the result")
+			}
+		})
+	}
+}
+
+// TestGenerateSkipsDisabledClient pins that a server with no LLM configured
+// returns the deterministic aggregate instead of calling out.
+func TestGenerateSkipsDisabledClient(t *testing.T) {
+	c := &stubCompleter{enabled: false, reply: `{"sentences":[]}`}
+
+	got, err := Generate(context.Background(), c, testInput())
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if c.calls != 0 {
+		t.Fatalf("disabled client was called %d times", c.calls)
+	}
+	if !got.Degraded {
+		t.Fatal("Degraded = false with no LLM available")
+	}
+}
+
+// TestGenerateWithNoActions pins that an empty open set never reaches the model.
+// Asking for a summary of nothing is a guaranteed hallucination.
+func TestGenerateWithNoActions(t *testing.T) {
+	c := &stubCompleter{enabled: true, reply: `{"sentences":[{"text":"없는 일을 지어냄.","document_ids":["` + docA + `"]}]}`}
+
+	got, err := Generate(context.Background(), c, Input{Model: "dummy-model"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if c.calls != 0 {
+		t.Fatalf("LLM called %d times for an empty action set", c.calls)
+	}
+	if len(got.Sentences) != 0 || got.Degraded {
+		t.Fatalf("result = %+v, want an empty non-degraded briefing", got)
+	}
+}
+
+// TestPromptCarriesWhitelistAndRule pins the two things the prompt must contain:
+// the document ids the model is allowed to cite, and an explicit statement of
+// the discard rule (stating the rule measurably improves compliance, and the
+// server enforces it regardless).
+func TestPromptCarriesWhitelistAndRule(t *testing.T) {
+	c := &stubCompleter{enabled: true, reply: `{"sentences":[]}`}
+	if _, err := Generate(context.Background(), c, testInput()); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if !strings.Contains(c.gotMessage, docA) || !strings.Contains(c.gotMessage, docB) {
+		t.Fatal("prompt does not carry the action document ids the model must copy")
+	}
+	if !strings.Contains(c.gotSystem, "document_ids") {
+		t.Fatal("system prompt does not state the required output schema")
+	}
+	if !strings.Contains(c.gotSystem, "폐기") {
+		t.Fatal("system prompt does not state that ungrounded sentences are discarded")
+	}
+}
+
+// TestPromptCapsActionCount pins that an unbounded open set cannot blow up the
+// prompt (and its cost).
+func TestPromptCapsActionCount(t *testing.T) {
+	in := testInput()
+	base := in.Actions[0]
+	for i := 0; i < maxPromptActions+10; i++ {
+		a := base
+		a.IdentityKey = fmt.Sprintf("action:%016x", i)
+		in.Actions = append(in.Actions, a)
+	}
+
+	c := &stubCompleter{enabled: true, reply: `{"sentences":[]}`}
+	if _, err := Generate(context.Background(), c, in); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got := strings.Count(c.gotMessage, `"identity_key"`); got > maxPromptActions {
+		t.Fatalf("prompt carried %d actions, want at most %d", got, maxPromptActions)
+	}
+}

--- a/internal/briefing/input.go
+++ b/internal/briefing/input.go
@@ -1,0 +1,99 @@
+package briefing
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PromptVersion identifies the prompt this package sends to the model. It is
+// part of the cache key, so bumping it after editing prompt.go invalidates every
+// cached briefing. Without that, a prompt fix would keep serving sentences
+// produced by the previous prompt until the open action set happened to change.
+const PromptVersion = "briefing-v1"
+
+// InputAction is one open action as handed to the briefing generator. It is a
+// flat, store-free struct on purpose: this package does no database or HTTP
+// work, so it can be exercised entirely with table-driven tests.
+type InputAction struct {
+	IdentityKey     string
+	Kind            string
+	Summary         string
+	CounterpartName string
+	DocumentID      string
+	DetectedBy      string
+	DueAt           *time.Time
+	Confidence      float64
+}
+
+// Input is everything a briefing is derived from.
+type Input struct {
+	Actions []InputAction
+	// LatestDocumentAt is the newest observed_at among Actions. It advances
+	// whenever an action is re-observed, which is the signal that the briefing's
+	// underlying facts moved.
+	LatestDocumentAt time.Time
+	// Model is the LLM model name. Swapping models must not serve the previous
+	// model's sentences from cache.
+	Model string
+}
+
+// Sentence is one briefing sentence together with the evidence that justifies
+// it. DocumentIDs is never empty for a sentence that survived validation — a
+// sentence with no evidence is discarded, not shown.
+type Sentence struct {
+	Text         string   `json:"text"`
+	DocumentIDs  []string `json:"document_ids"`
+	IdentityKeys []string `json:"identity_keys"`
+}
+
+// Result is a generated briefing.
+type Result struct {
+	Sentences []Sentence
+	// Degraded is true when the sentences are the deterministic count-only
+	// fallback rather than model output. The UI surfaces this so a user never
+	// mistakes an aggregate for a summary.
+	Degraded bool
+	// DroppedCount is how many model sentences failed evidence validation. It is
+	// shown to the user as a trust signal, not hidden as debug output.
+	DroppedCount int
+	GeneratedAt  time.Time
+}
+
+// CacheKey is the content hash of everything that can change a briefing:
+// the prompt version, the model, the newest observation time, and the SET of
+// open identity keys.
+//
+// Invalidation is entirely implicit — there is no TTL and no explicit purge.
+// A new action, a resolved action, a re-observation, a prompt edit, or a model
+// swap each change the key on its own.
+//
+// Summary text is deliberately absent. The same identity_key denotes the same
+// real-world action (spec §5.5), so a reworded re-extraction is not a reason to
+// regenerate. The useful side effect is that no personal data enters the hash
+// input, which is why the resulting key is safe to write to logs.
+func (in Input) CacheKey() string { return cacheKeyWithVersion(in, PromptVersion) }
+
+func cacheKeyWithVersion(in Input, version string) string {
+	keys := make([]string, 0, len(in.Actions))
+	for _, a := range in.Actions {
+		keys = append(keys, a.IdentityKey)
+	}
+	// Sorting is required, not cosmetic: PostgreSQL makes no ordering promise
+	// beyond the ORDER BY, and an order-sensitive key would miss constantly.
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString(version)
+	b.WriteString("|")
+	b.WriteString(in.Model)
+	b.WriteString("|")
+	b.WriteString(in.LatestDocumentAt.UTC().Format(time.RFC3339))
+	b.WriteString("|")
+	b.WriteString(strings.Join(keys, "\n"))
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/briefing/input_test.go
+++ b/internal/briefing/input_test.go
@@ -1,0 +1,139 @@
+package briefing
+
+import (
+	"testing"
+	"time"
+)
+
+func fixedTime() time.Time { return time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC) }
+
+// twoActionInput is the shared fixture. Every value is a synthetic dummy: no
+// real name, number, or message text appears anywhere in this package's tests.
+func twoActionInput() Input {
+	return Input{
+		Model:            "dummy-model",
+		LatestDocumentAt: fixedTime(),
+		Actions: []InputAction{
+			{
+				IdentityKey:     "action:aaaaaaaaaaaaaaaa",
+				DocumentID:      "11111111-1111-1111-1111-111111111111",
+				Kind:            "my_commitment",
+				Summary:         "dummy summary one",
+				CounterpartName: "zz-dummy-counterpart",
+				DetectedBy:      "structural",
+				Confidence:      1.0,
+			},
+			{
+				IdentityKey:     "action:bbbbbbbbbbbbbbbb",
+				DocumentID:      "22222222-2222-2222-2222-222222222222",
+				Kind:            "scheduled",
+				Summary:         "dummy summary two",
+				CounterpartName: "zz-dummy-counterpart",
+				DetectedBy:      "llm",
+				Confidence:      0.6,
+			},
+		},
+	}
+}
+
+// TestCacheKeyIgnoresRowOrder pins that the key is computed over a SORTED set of
+// identity keys. Row order out of PostgreSQL is not guaranteed to be stable
+// across plans; if it leaked into the key, the cache would miss on nearly every
+// request and each miss costs an LLM call.
+func TestCacheKeyIgnoresRowOrder(t *testing.T) {
+	a := twoActionInput()
+	b := twoActionInput()
+	b.Actions[0], b.Actions[1] = b.Actions[1], b.Actions[0]
+
+	if a.CacheKey() != b.CacheKey() {
+		t.Fatal("cache key depends on row order; sort identity_keys before hashing")
+	}
+}
+
+// TestCacheKeyIgnoresSummaryText pins that summary text is NOT part of the key.
+// The same identity_key is by definition the same real-world action, so a
+// re-extraction that reworded the summary is not a reason to pay for a new
+// briefing. The side effect matters too: with summaries excluded, no personal
+// data feeds the hash, which is what makes the key safe to log.
+func TestCacheKeyIgnoresSummaryText(t *testing.T) {
+	a := twoActionInput()
+	b := twoActionInput()
+	b.Actions[0].Summary = "an entirely different dummy wording"
+	b.Actions[1].CounterpartName = "zz-other-dummy"
+
+	if a.CacheKey() != b.CacheKey() {
+		t.Fatal("cache key changed when only summary/counterpart text changed; it must depend on identity keys alone")
+	}
+}
+
+// TestCacheKeyChangesOnRealInputChange pins every documented invalidation
+// trigger. Each of these events must produce a different key, otherwise a stale
+// briefing is served.
+func TestCacheKeyChangesOnRealInputChange(t *testing.T) {
+	base := twoActionInput()
+
+	t.Run("new open action", func(t *testing.T) {
+		got := twoActionInput()
+		got.Actions = append(got.Actions, InputAction{
+			IdentityKey: "action:cccccccccccccccc",
+			DocumentID:  "33333333-3333-3333-3333-333333333333",
+			Kind:        "their_commitment",
+		})
+		if got.CacheKey() == base.CacheKey() {
+			t.Fatal("key unchanged after a new action entered the open set")
+		}
+	})
+
+	t.Run("action resolved by the user", func(t *testing.T) {
+		got := twoActionInput()
+		got.Actions = got.Actions[:1]
+		if got.CacheKey() == base.CacheKey() {
+			t.Fatal("key unchanged after an action left the open set")
+		}
+	})
+
+	t.Run("latest document time advanced", func(t *testing.T) {
+		got := twoActionInput()
+		got.LatestDocumentAt = fixedTime().Add(time.Hour)
+		if got.CacheKey() == base.CacheKey() {
+			t.Fatal("key unchanged after LatestDocumentAt advanced")
+		}
+	})
+
+	t.Run("model swapped", func(t *testing.T) {
+		got := twoActionInput()
+		got.Model = "other-dummy-model"
+		if got.CacheKey() == base.CacheKey() {
+			t.Fatal("key unchanged after the model changed; a redeploy on a new model would serve the old model's sentences")
+		}
+	})
+}
+
+// TestCacheKeyIncludesPromptVersion pins that the prompt version participates in
+// the key. Without it, editing the prompt and redeploying keeps serving
+// sentences produced by the previous prompt until the open set happens to
+// change.
+func TestCacheKeyIncludesPromptVersion(t *testing.T) {
+	in := twoActionInput()
+	got := in.CacheKey()
+
+	// Recompute with a different prompt version by going through the same
+	// helper the exported method uses.
+	other := cacheKeyWithVersion(in, PromptVersion+"-modified")
+	if got == other {
+		t.Fatal("cache key does not depend on PromptVersion; a prompt change would not invalidate cached briefings")
+	}
+}
+
+// TestCacheKeyIsTimezoneStable pins that the timestamp is normalised to UTC
+// before hashing, so the same instant read back in a different location does not
+// produce a different key.
+func TestCacheKeyIsTimezoneStable(t *testing.T) {
+	a := twoActionInput()
+	b := twoActionInput()
+	b.LatestDocumentAt = a.LatestDocumentAt.In(time.FixedZone("KST", 9*60*60))
+
+	if a.CacheKey() != b.CacheKey() {
+		t.Fatal("cache key depends on the timestamp's location; normalise to UTC before hashing")
+	}
+}

--- a/internal/briefing/prompt.go
+++ b/internal/briefing/prompt.go
@@ -1,0 +1,115 @@
+package briefing
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+// maxPromptActions bounds how many actions are shown to the model. Every action
+// in the prompt is input tokens paid for on each cache miss, and a briefing
+// built from more than a few dozen items stops being readable anyway. When the
+// open set is larger, the soonest-due actions win.
+const maxPromptActions = 40
+
+// maxSentences is the ceiling on returned sentences. It is enforced on the
+// server rather than trusted to the prompt.
+const maxSentences = 6
+
+// systemPrompt states the output schema and the discard rule.
+//
+// The rule is stated to the model even though the server enforces it
+// mechanically: telling a model the check that will be applied measurably
+// raises compliance, and a discarded sentence is a wasted generation. The
+// enforcement in validate.go is what actually guarantees the property.
+const systemPrompt = `당신은 사용자의 열린 액션 목록을 한국어로 요약하는 비서다.
+
+반드시 아래 JSON 객체 하나만 출력한다. 코드 펜스, 머리말, 설명 문장을 붙이지 않는다.
+
+{"sentences":[{"text":"문장","document_ids":["문서 id"],"identity_keys":["액션 키"]}]}
+
+규칙:
+- 각 문장은 제공된 액션에서만 유래해야 한다. 제공되지 않은 사실을 쓰지 않는다.
+- document_ids에는 그 문장이 근거로 삼은 액션의 document_id를 그대로 복사한다.
+- 새 id를 만들지 않는다. 목록에 없는 id를 쓰면 그 문장은 서버에서 폐기된다.
+- document_ids가 비어 있는 문장도 폐기된다.
+- identity_keys에는 그 문장이 다루는 액션의 identity_key를 복사한다.
+- 문장은 최대 6개, 각 문장은 400자 이내의 한 문장으로 쓴다.
+- 우선순위: 기한이 임박한 것 > awaiting_my_reply > my_commitment > 나머지.`
+
+// promptAction is the per-action shape sent to the model. Field names are
+// snake_case so they match the vocabulary used in the system prompt.
+type promptAction struct {
+	IdentityKey string  `json:"identity_key"`
+	Kind        string  `json:"kind"`
+	DueAt       string  `json:"due_at,omitempty"`
+	Confidence  float64 `json:"confidence"`
+	DetectedBy  string  `json:"detected_by"`
+	Summary     string  `json:"summary"`
+	DocumentID  string  `json:"document_id"`
+	Counterpart string  `json:"counterpart,omitempty"`
+}
+
+// selectPromptActions returns at most maxPromptActions actions, soonest due
+// first with undated actions last. It copies before sorting: the caller's slice
+// order is also the order the API layer reports to the user.
+func selectPromptActions(actions []InputAction) []InputAction {
+	sorted := make([]InputAction, len(actions))
+	copy(sorted, actions)
+
+	sort.SliceStable(sorted, func(i, j int) bool {
+		a, b := sorted[i].DueAt, sorted[j].DueAt
+		switch {
+		case a != nil && b != nil:
+			return a.Before(*b)
+		case a != nil:
+			return true // dated sorts before undated
+		case b != nil:
+			return false
+		default:
+			return false
+		}
+	})
+
+	if len(sorted) > maxPromptActions {
+		sorted = sorted[:maxPromptActions]
+	}
+	return sorted
+}
+
+// buildUserMessage renders the action list the model summarises.
+func buildUserMessage(in Input) string {
+	selected := selectPromptActions(in.Actions)
+
+	items := make([]promptAction, 0, len(selected))
+	for _, a := range selected {
+		item := promptAction{
+			IdentityKey: a.IdentityKey,
+			Kind:        a.Kind,
+			Confidence:  a.Confidence,
+			DetectedBy:  a.DetectedBy,
+			Summary:     a.Summary,
+			DocumentID:  a.DocumentID,
+			Counterpart: a.CounterpartName,
+		}
+		if a.DueAt != nil {
+			item.DueAt = a.DueAt.UTC().Format(time.RFC3339)
+		}
+		items = append(items, item)
+	}
+
+	encoded, err := json.Marshal(items)
+	if err != nil {
+		// json.Marshal of a slice of plain structs cannot fail; degrade to an
+		// empty list rather than propagating an impossible error.
+		encoded = []byte("[]")
+	}
+
+	var b strings.Builder
+	b.WriteString("현재 시각: ")
+	b.WriteString(in.LatestDocumentAt.UTC().Format(time.RFC3339))
+	b.WriteString("\n열린 액션 목록:\n")
+	b.Write(encoded)
+	return b.String()
+}

--- a/internal/briefing/redact.go
+++ b/internal/briefing/redact.go
@@ -1,0 +1,51 @@
+package briefing
+
+// keyPrefixRunes is how much of an identity_key is safe to log: enough to
+// correlate two log lines about the same action, not enough to be a stable
+// handle for anything else. "action:" + 4 hex characters.
+const keyPrefixRunes = len("action:") + 4
+
+// KeyPrefix truncates an identity_key for logging.
+//
+// The full key is a deterministic hash and is not itself personal data, but it
+// is the join handle to a row whose summary is. Logging only a prefix keeps log
+// lines correlatable without making the log a usable index into the actions
+// table.
+//
+// Truncation is rune-based so a non-hex value cannot be cut mid-rune and turn
+// into invalid UTF-8 in the log stream.
+func KeyPrefix(identityKey string) string {
+	runes := []rune(identityKey)
+	if len(runes) <= keyPrefixRunes {
+		return identityKey
+	}
+	return string(runes[:keyPrefixRunes])
+}
+
+// SafeLogFields returns slog key/value pairs describing a briefing generation
+// with no personal data in them.
+//
+// The rule this enforces (issue #194): action summaries, counterpart names,
+// resolution notes, prompts, and raw model output must never reach the logs.
+// A briefing's text is a restatement of the user's own conversations, so a
+// single well-meant "log the response we failed to parse" turns the container
+// log — and every log collector behind it — into a copy of the user's private
+// messages.
+//
+// What is left is enough to operate the feature: how many actions went in, how
+// many sentences came out, how many were discarded for lacking evidence,
+// whether the result was the degraded aggregate, and a truncated key prefix for
+// correlation. Nothing here is free text.
+func SafeLogFields(in Input, r Result) []any {
+	fields := []any{
+		"action_count", len(in.Actions),
+		"sentence_count", len(r.Sentences),
+		"dropped_count", r.DroppedCount,
+		"degraded", r.Degraded,
+		"model", in.Model,
+	}
+	if len(in.Actions) > 0 {
+		fields = append(fields, "first_action", KeyPrefix(in.Actions[0].IdentityKey))
+	}
+	return fields
+}

--- a/internal/briefing/redact_test.go
+++ b/internal/briefing/redact_test.go
@@ -1,0 +1,103 @@
+package briefing
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSafeLogFieldsLeaksNothing is the guard on issue #194's failure mode. The
+// briefing's inputs and outputs are restatements of the user's own
+// conversations, so anything this function emits ends up in container logs and
+// whatever collects them. It must therefore be structurally incapable of
+// carrying text — only counts, flags, and a truncated key prefix.
+func TestSafeLogFieldsLeaksNothing(t *testing.T) {
+	in := Input{
+		Model:            "dummy-model",
+		LatestDocumentAt: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+		Actions: []InputAction{{
+			IdentityKey:     "action:0123456789abcdef",
+			DocumentID:      "11111111-1111-1111-1111-111111111111",
+			Kind:            "my_commitment",
+			Summary:         "SENSITIVE_SUMMARY_TOKEN",
+			CounterpartName: "SENSITIVE_NAME_TOKEN",
+			DetectedBy:      "structural",
+		}},
+	}
+	res := Result{
+		Sentences: []Sentence{{
+			Text:         "SENSITIVE_SENTENCE_TOKEN",
+			DocumentIDs:  []string{"11111111-1111-1111-1111-111111111111"},
+			IdentityKeys: []string{"action:0123456789abcdef"},
+		}},
+		DroppedCount: 2,
+	}
+
+	joined := fmt.Sprint(SafeLogFields(in, res)...)
+
+	for _, banned := range []string{"SENSITIVE_SUMMARY_TOKEN", "SENSITIVE_NAME_TOKEN", "SENSITIVE_SENTENCE_TOKEN"} {
+		if strings.Contains(joined, banned) {
+			t.Fatalf("log fields leaked %q", banned)
+		}
+	}
+	if !strings.Contains(joined, "action:0123") {
+		t.Fatalf("expected truncated key prefix for correlation, got: %s", joined)
+	}
+	if strings.Contains(joined, "0123456789abcdef") {
+		t.Fatalf("full identity key must be truncated, got: %s", joined)
+	}
+	if !strings.Contains(joined, "2") {
+		t.Fatalf("dropped count is missing from the log fields: %s", joined)
+	}
+}
+
+// TestSafeLogFieldsIsEvenLength pins that the result is usable as slog's
+// alternating key/value varargs. An odd length makes slog emit a "!BADKEY"
+// record, which in the worst case is the one record that would have explained a
+// production failure.
+func TestSafeLogFieldsIsEvenLength(t *testing.T) {
+	got := SafeLogFields(Input{}, Result{})
+	if len(got)%2 != 0 {
+		t.Fatalf("SafeLogFields returned %d values; slog needs key/value pairs", len(got))
+	}
+}
+
+func TestKeyPrefix(t *testing.T) {
+	cases := map[string]string{
+		"action:0123456789abcdef": "action:0123",
+		// Shorter than the prefix budget: nothing to truncate.
+		"action:ff": "action:ff",
+		"":          "",
+		"malformed": "malformed",
+		// Anything longer is cut to the same 11-character budget, whatever its
+		// shape, so a malformed key cannot log more than a well-formed one.
+		"malformed-but-long": "malformed-b",
+	}
+	for in, want := range cases {
+		if got := KeyPrefix(in); got != want {
+			t.Errorf("KeyPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestKeyPrefixHandlesMultibyte pins that truncation is rune-safe. Slicing bytes
+// out of a multi-byte value would produce invalid UTF-8 in the log stream.
+func TestKeyPrefixHandlesMultibyte(t *testing.T) {
+	got := KeyPrefix("액션키입니다")
+	if !strings.ContainsRune(got, '액') && got != "" {
+		t.Fatalf("KeyPrefix mangled a multi-byte value: %q", got)
+	}
+	if !isValidUTF8(got) {
+		t.Fatalf("KeyPrefix produced invalid UTF-8: %q", got)
+	}
+}
+
+func isValidUTF8(s string) bool {
+	for _, r := range s {
+		if r == '�' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/briefing/validate.go
+++ b/internal/briefing/validate.go
@@ -1,0 +1,231 @@
+package briefing
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// maxSentenceRunes bounds one sentence. A model that returns a whole paragraph
+// in a single "sentence" has ignored the schema, and a paragraph cannot be
+// honestly attributed to one set of documents.
+const maxSentenceRunes = 400
+
+// llmSentence is the wire shape of one sentence in the model's reply.
+type llmSentence struct {
+	Text         string   `json:"text"`
+	DocumentIDs  []string `json:"document_ids"`
+	IdentityKeys []string `json:"identity_keys"`
+}
+
+type llmPayload struct {
+	Sentences []llmSentence `json:"sentences"`
+}
+
+// Validate turns a raw model reply into a Result, discarding every sentence
+// that is not backed by a document the server actually put in the prompt.
+//
+// This is the whole point of the feature. A briefing that says "call the
+// plumber back" without being able to show which message says so is worse than
+// no briefing: it is a confident claim with nothing behind it. So the check is
+// mechanical rather than a request in the prompt — the server owns the set of
+// ids it showed the model, and anything outside that set is a fabrication by
+// definition.
+//
+// Discarding is per sentence, not per response: one bad sentence must not take
+// the valid ones with it, or the briefing would be empty in practice.
+//
+// A non-nil error means the reply could not be decoded at all. The returned
+// Result is still usable (the deterministic fallback), so callers can report the
+// failure without having to invent a response.
+func Validate(raw string, in Input) (Result, error) {
+	payload, err := decodePayload(raw)
+	if err != nil {
+		r := fallbackResult(in)
+		return r, err
+	}
+
+	allowedDocs := make(map[string]bool, len(in.Actions))
+	allowedKeys := make(map[string]bool, len(in.Actions))
+	for _, a := range in.Actions {
+		if a.DocumentID != "" {
+			allowedDocs[a.DocumentID] = true
+		}
+		if a.IdentityKey != "" {
+			allowedKeys[a.IdentityKey] = true
+		}
+	}
+
+	kept := make([]Sentence, 0, len(payload.Sentences))
+	dropped := 0
+	for _, s := range payload.Sentences {
+		text := strings.TrimSpace(s.Text)
+		if text == "" || utf8.RuneCountInString(text) > maxSentenceRunes {
+			dropped++
+			continue
+		}
+		if len(s.DocumentIDs) == 0 {
+			dropped++
+			continue
+		}
+		grounded := true
+		for _, id := range s.DocumentIDs {
+			if !allowedDocs[id] {
+				grounded = false
+				break
+			}
+		}
+		if !grounded {
+			dropped++
+			continue
+		}
+
+		// An invented identity_key is dropped on its own: the sentence's
+		// evidence is its document ids, and those are still valid.
+		keys := make([]string, 0, len(s.IdentityKeys))
+		for _, k := range s.IdentityKeys {
+			if allowedKeys[k] {
+				keys = append(keys, k)
+			}
+		}
+
+		kept = append(kept, Sentence{
+			Text:         text,
+			DocumentIDs:  s.DocumentIDs,
+			IdentityKeys: keys,
+		})
+		if len(kept) == maxSentences {
+			break
+		}
+	}
+
+	if len(kept) == 0 {
+		r := fallbackResult(in)
+		r.DroppedCount = dropped
+		return r, nil
+	}
+
+	return Result{
+		Sentences:    kept,
+		DroppedCount: dropped,
+		GeneratedAt:  time.Now().UTC(),
+	}, nil
+}
+
+// decodePayload extracts the JSON object from a reply that may be wrapped in a
+// code fence or surrounded by prose. Both habits have been observed from this
+// project's model in production.
+//
+// The failure path deliberately carries no fragment of raw: the reply is a
+// restatement of the user's own conversations, so quoting it in an error (which
+// ends up in logs) would leak personal data. Only content-free measurements are
+// reported.
+func decodePayload(raw string) (llmPayload, error) {
+	trimmed := strings.TrimSpace(raw)
+
+	if strings.HasPrefix(trimmed, "```") {
+		if idx := strings.Index(trimmed, "\n"); idx != -1 {
+			trimmed = trimmed[idx+1:]
+		}
+		trimmed = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(trimmed), "```"))
+	}
+
+	start, end := strings.Index(trimmed, "{"), strings.LastIndex(trimmed, "}")
+	if start < 0 || end <= start {
+		return llmPayload{}, fmt.Errorf("briefing: reply carries no JSON object (len=%d, first_brace=%d, last_brace=%d)",
+			len(raw), start, end)
+	}
+	trimmed = trimmed[start : end+1]
+
+	var payload llmPayload
+	if err := json.NewDecoder(strings.NewReader(trimmed)).Decode(&payload); err != nil {
+		// err.Error() is NOT included: encoding/json quotes the offending input
+		// in its message. Only the offset is content-free enough to keep.
+		var syntaxErr *json.SyntaxError
+		offset := int64(-1)
+		if errors.As(err, &syntaxErr) {
+			offset = syntaxErr.Offset
+		}
+		return llmPayload{}, fmt.Errorf("briefing: reply is not valid JSON (len=%d, offset=%d)", len(raw), offset)
+	}
+	return payload, nil
+}
+
+// kindLabels renders the closed action vocabulary in Korean for the fallback
+// sentence. The order is the order they are counted in.
+var kindLabels = []struct {
+	kind  string
+	label string
+}{
+	{"awaiting_my_reply", "응답 대기"},
+	{"my_commitment", "내 약속"},
+	{"their_commitment", "상대 약속"},
+	{"scheduled", "예정"},
+}
+
+// fallbackResult builds the deterministic, LLM-free briefing used whenever the
+// model's output cannot be trusted.
+//
+// It is a count, not prose: "응답 대기 3건, 내 약속 2건." states only what the
+// server itself computed, so it cannot be unfounded. It still carries the
+// document ids of the counted actions, because the evidence rule has no
+// exceptions — including for the fallback that exists to enforce it.
+//
+// With no actions at all there is nothing to count and nothing to warn about,
+// so the result is empty and NOT marked degraded.
+func fallbackResult(in Input) Result {
+	if len(in.Actions) == 0 {
+		return Result{Sentences: []Sentence{}, GeneratedAt: time.Now().UTC()}
+	}
+
+	counts := make(map[string]int, len(kindLabels))
+	other := 0
+	docSeen := make(map[string]bool, len(in.Actions))
+	docIDs := make([]string, 0, len(in.Actions))
+	keys := make([]string, 0, len(in.Actions))
+
+	known := make(map[string]bool, len(kindLabels))
+	for _, kl := range kindLabels {
+		known[kl.kind] = true
+	}
+
+	for _, a := range in.Actions {
+		if known[a.Kind] {
+			counts[a.Kind]++
+		} else {
+			other++
+		}
+		if a.DocumentID != "" && !docSeen[a.DocumentID] {
+			docSeen[a.DocumentID] = true
+			docIDs = append(docIDs, a.DocumentID)
+		}
+		if a.IdentityKey != "" {
+			keys = append(keys, a.IdentityKey)
+		}
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(kindLabels)+1)
+	for _, kl := range kindLabels {
+		if n := counts[kl.kind]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%s %d건", kl.label, n))
+		}
+	}
+	if other > 0 {
+		parts = append(parts, fmt.Sprintf("기타 %d건", other))
+	}
+
+	return Result{
+		Sentences: []Sentence{{
+			Text:         strings.Join(parts, ", ") + ".",
+			DocumentIDs:  docIDs,
+			IdentityKeys: keys,
+		}},
+		Degraded:    true,
+		GeneratedAt: time.Now().UTC(),
+	}
+}

--- a/internal/briefing/validate_test.go
+++ b/internal/briefing/validate_test.go
@@ -1,0 +1,202 @@
+package briefing
+
+import (
+	"strings"
+	"testing"
+)
+
+// testInput is the whitelist fixture: two synthetic actions whose document ids
+// are the ONLY ids a sentence may cite.
+func testInput() Input { return twoActionInput() }
+
+const (
+	docA = "11111111-1111-1111-1111-111111111111"
+	docB = "22222222-2222-2222-2222-222222222222"
+	keyA = "action:aaaaaaaaaaaaaaaa"
+	keyB = "action:bbbbbbbbbbbbbbbb"
+)
+
+// TestValidateDropsSentenceWithUnknownDocumentID is the central test of this
+// feature. A document id that never appeared in the prompt cannot have been
+// read by the model, so a sentence citing one is unfounded by construction and
+// must be discarded rather than shown with a broken link.
+func TestValidateDropsSentenceWithUnknownDocumentID(t *testing.T) {
+	raw := `{"sentences":[
+		{"text":"근거 있는 문장.","document_ids":["` + docA + `"],"identity_keys":["` + keyA + `"]},
+		{"text":"환각 문장.","document_ids":["99999999-9999-9999-9999-999999999999"],"identity_keys":[]}
+	]}`
+
+	got, err := Validate(raw, testInput())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(got.Sentences) != 1 {
+		t.Fatalf("sentences = %+v, want only the grounded one", got.Sentences)
+	}
+	if got.Sentences[0].Text != "근거 있는 문장." {
+		t.Fatalf("kept the wrong sentence: %q", got.Sentences[0].Text)
+	}
+	if got.DroppedCount != 1 {
+		t.Fatalf("DroppedCount = %d, want 1", got.DroppedCount)
+	}
+	if got.Degraded {
+		t.Error("Degraded = true although one valid sentence survived")
+	}
+}
+
+// TestValidateDropsUngroundedSentences pins the remaining discard rules. Each
+// case is a way a model can produce a sentence that cannot be traced back to a
+// document the server actually showed it.
+func TestValidateDropsUngroundedSentences(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"no document_ids field", `{"sentences":[{"text":"근거 없는 주장."}]}`},
+		{"empty document_ids", `{"sentences":[{"text":"근거 없는 주장.","document_ids":[]}]}`},
+		{"blank text", `{"sentences":[{"text":"   ","document_ids":["` + docA + `"]}]}`},
+		{"paragraph instead of sentence", `{"sentences":[{"text":"` + strings.Repeat("가", 401) + `","document_ids":["` + docA + `"]}]}`},
+		{"one bad id among good ones", `{"sentences":[{"text":"일부만 근거 있음.","document_ids":["` + docA + `","99999999-9999-9999-9999-999999999999"]}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Validate(tc.raw, testInput())
+			if err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			for _, s := range got.Sentences {
+				if !got.Degraded {
+					t.Fatalf("ungrounded sentence survived: %+v", s)
+				}
+			}
+			if !got.Degraded {
+				t.Fatal("every sentence was discarded but Degraded = false; the UI would present an empty briefing as a real one")
+			}
+			if got.DroppedCount != 1 {
+				t.Fatalf("DroppedCount = %d, want 1", got.DroppedCount)
+			}
+		})
+	}
+}
+
+// TestValidateFallbackIsItselfGrounded pins that the degraded fallback obeys the
+// same rule it protects: even a pure count sentence must carry evidence.
+func TestValidateFallbackIsItselfGrounded(t *testing.T) {
+	got, err := Validate(`{"sentences":[]}`, testInput())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if !got.Degraded {
+		t.Fatal("Degraded = false for an empty sentence list")
+	}
+	if len(got.Sentences) != 1 {
+		t.Fatalf("fallback produced %d sentences, want 1", len(got.Sentences))
+	}
+	if len(got.Sentences[0].DocumentIDs) == 0 {
+		t.Fatal("fallback sentence has no DocumentIDs; the evidence rule has no exceptions")
+	}
+	for _, id := range got.Sentences[0].DocumentIDs {
+		if id != docA && id != docB {
+			t.Fatalf("fallback cited an id outside the input: %q", id)
+		}
+	}
+	// The fallback is a count, not prose: it must not invent a claim.
+	if !strings.Contains(got.Sentences[0].Text, "건") {
+		t.Fatalf("fallback text = %q, want a count-only sentence", got.Sentences[0].Text)
+	}
+}
+
+// TestValidateStripsUnknownIdentityKeys pins the one non-fatal violation: an
+// invented identity_key is removed, but the sentence survives because its
+// DOCUMENT evidence is what grounds it. Dropping the whole sentence here would
+// throw away a valid statement over a broken cross-reference.
+func TestValidateStripsUnknownIdentityKeys(t *testing.T) {
+	raw := `{"sentences":[{"text":"근거 있는 문장.","document_ids":["` + docA + `"],"identity_keys":["` + keyA + `","action:ffffffffffffffff"]}]}`
+
+	got, err := Validate(raw, testInput())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(got.Sentences) != 1 {
+		t.Fatalf("sentences = %+v, want the sentence kept", got.Sentences)
+	}
+	if len(got.Sentences[0].IdentityKeys) != 1 || got.Sentences[0].IdentityKeys[0] != keyA {
+		t.Fatalf("IdentityKeys = %v, want only the known key", got.Sentences[0].IdentityKeys)
+	}
+	if got.DroppedCount != 0 {
+		t.Fatalf("DroppedCount = %d, want 0 (no sentence was discarded)", got.DroppedCount)
+	}
+}
+
+// TestValidateDecodesDecoratedJSON pins tolerance for the two output habits this
+// project has already observed in production: fenced code blocks and a
+// conversational preamble around the JSON.
+func TestValidateDecodesDecoratedJSON(t *testing.T) {
+	body := `{"sentences":[{"text":"근거 있는 문장.","document_ids":["` + docA + `"]}]}`
+	cases := map[string]string{
+		"fenced":            "```json\n" + body + "\n```",
+		"preamble":          "다음은 요청하신 브리핑입니다:\n" + body,
+		"preamble and tail": "설명:\n" + body + "\n이상입니다.",
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := Validate(raw, testInput())
+			if err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			if got.Degraded || len(got.Sentences) != 1 {
+				t.Fatalf("decorated JSON was not decoded: %+v", got)
+			}
+		})
+	}
+}
+
+// TestValidateUndecodableFallsBack pins that garbage produces the deterministic
+// fallback plus a reportable error, never a partially-parsed briefing.
+func TestValidateUndecodableFallsBack(t *testing.T) {
+	got, err := Validate("this is not json at all", testInput())
+	if err == nil {
+		t.Fatal("Validate returned nil error for undecodable output; the caller cannot record the failure")
+	}
+	if !got.Degraded || len(got.Sentences) != 1 {
+		t.Fatalf("result = %+v, want the degraded fallback", got)
+	}
+}
+
+// TestValidateNoActionsProducesNothing pins that an empty open set yields an
+// empty, non-degraded result: there is nothing to summarise and nothing to warn
+// about.
+func TestValidateNoActionsProducesNothing(t *testing.T) {
+	got, err := Validate(`{"sentences":[]}`, Input{Model: "dummy-model"})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(got.Sentences) != 0 {
+		t.Fatalf("sentences = %+v, want none", got.Sentences)
+	}
+	if got.Degraded {
+		t.Error("Degraded = true with no actions at all; there is no failure to report")
+	}
+}
+
+// TestValidateCapsSentenceCount pins the response-size bound on the model's
+// side of the contract.
+func TestValidateCapsSentenceCount(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"sentences":[`)
+	for i := 0; i < 20; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"text":"근거 있는 문장.","document_ids":["` + docA + `"]}`)
+	}
+	b.WriteString(`]}`)
+
+	got, err := Validate(b.String(), testInput())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(got.Sentences) > maxSentences {
+		t.Fatalf("kept %d sentences, want at most %d", len(got.Sentences), maxSentences)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -475,6 +475,25 @@ type Config struct {
 	// LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY env vars.
 	LangfusePublicKey string
 	LangfuseSecretKey string
+
+	// Actions & Briefing feature flags (Part C, plan Task 12). Both default
+	// false so a fresh deploy exposes neither route until explicitly
+	// switched on — the route not existing (404) IS the rollback mechanism,
+	// not a branch inside the handler. See cmd/server/main.go wiring.
+	//
+	// ACTIONS_API_ENABLED: set "true" to register GET /api/v1/actions and
+	// POST /api/v1/actions/{identity_key}/status.
+	ActionsAPIEnabled bool
+	// BRIEFING_ENABLED: set "true" to register GET /api/v1/briefing. Only
+	// takes effect when ActionsAPIEnabled is also true (the briefing reads
+	// through the actions query path); it is also skipped when the LLM
+	// client is not configured, since a briefing without a model has
+	// nothing to summarise with. Both conditions are enforced in
+	// cmd/server/main.go, not here.
+	BriefingEnabled bool
+	// BRIEFING_MAX_ACTIONS: caps how many open actions feed a single
+	// briefing request. Default 40. Invalid values use the default.
+	BriefingMaxActions int
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -733,6 +752,11 @@ func Load() (*Config, error) {
 		LangfuseOTLPEndpoint: os.Getenv("LANGFUSE_OTLP_ENDPOINT"),
 		LangfusePublicKey:    os.Getenv("LANGFUSE_PUBLIC_KEY"),
 		LangfuseSecretKey:    os.Getenv("LANGFUSE_SECRET_KEY"),
+
+		// Task 12 feature flags — default false (see doc comments above).
+		ActionsAPIEnabled:  os.Getenv("ACTIONS_API_ENABLED") == "true",
+		BriefingEnabled:    os.Getenv("BRIEFING_ENABLED") == "true",
+		BriefingMaxActions: briefingMaxActions(),
 	}, nil
 }
 
@@ -1206,6 +1230,25 @@ func retiredSources() []string {
 		return []string{"secretary"}
 	}
 	return splitCSV(raw)
+}
+
+// briefingMaxActions parses BRIEFING_MAX_ACTIONS from the environment.
+// Default is 40. Invalid values are ignored and the default is used.
+func briefingMaxActions() int {
+	const defaultMax = 40
+	v := os.Getenv("BRIEFING_MAX_ACTIONS")
+	if v == "" {
+		return defaultMax
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		slog.Warn("config: BRIEFING_MAX_ACTIONS is invalid; using default 40",
+			"value", v,
+			"error", err,
+		)
+		return defaultMax
+	}
+	return n
 }
 
 // normalizeExts ensures every extension starts with a leading dot and is lowercase.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,10 +39,10 @@ func TestLoad_SummarizerBackfillEnabled(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name    string
-		envVal  string
-		unset   bool
-		want    bool
+		name   string
+		envVal string
+		unset  bool
+		want   bool
 	}{
 		{name: "default_when_unset", unset: true, want: true},
 		{name: "explicit_true", envVal: "true", want: true},
@@ -336,7 +336,7 @@ func TestLoad_CollectorCutover(t *testing.T) {
 		name    string
 		envVal  string
 		unset   bool
-		wantNil bool   // true when we expect zero time
+		wantNil bool // true when we expect zero time
 		want    time.Time
 	}{
 		{name: "unset_returns_zero", unset: true, wantNil: true},
@@ -484,6 +484,119 @@ func TestLoad_PIINumberHashingEnabled(t *testing.T) {
 			}
 			if cfg.PIINumberHashingEnabled != tc.want {
 				t.Errorf("PIINumberHashingEnabled = %v, want %v", cfg.PIINumberHashingEnabled, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_ActionsAPIEnabled verifies ACTIONS_API_ENABLED parsing (Task 12 —
+// feature flag default MUST be false, since the missing route (404) IS the
+// rollback mechanism for the actions/briefing feature).
+func TestLoad_ActionsAPIEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   bool
+	}{
+		{name: "default_when_unset", unset: true, want: false},
+		{name: "explicit_true", envVal: "true", want: true},
+		{name: "explicit_false", envVal: "false", want: false},
+		{name: "invalid_value_disabled", envVal: "1", want: false}, // only literal "true" enables
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "ACTIONS_API_ENABLED")
+			} else {
+				setenv(t, "ACTIONS_API_ENABLED", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.ActionsAPIEnabled != tc.want {
+				t.Errorf("ActionsAPIEnabled = %v, want %v", cfg.ActionsAPIEnabled, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_BriefingEnabled verifies BRIEFING_ENABLED parsing (Task 12 —
+// default false; whether it takes effect also depends on ActionsAPIEnabled,
+// which is wired in cmd/server/main.go, not here).
+func TestLoad_BriefingEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   bool
+	}{
+		{name: "default_when_unset", unset: true, want: false},
+		{name: "explicit_true", envVal: "true", want: true},
+		{name: "explicit_false", envVal: "false", want: false},
+		{name: "invalid_value_disabled", envVal: "yes", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "BRIEFING_ENABLED")
+			} else {
+				setenv(t, "BRIEFING_ENABLED", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.BriefingEnabled != tc.want {
+				t.Errorf("BriefingEnabled = %v, want %v", cfg.BriefingEnabled, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_BriefingMaxActions verifies BRIEFING_MAX_ACTIONS parsing.
+func TestLoad_BriefingMaxActions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   int
+	}{
+		{name: "default_when_unset", unset: true, want: 40},
+		{name: "explicit_100", envVal: "100", want: 100},
+		{name: "invalid_string_uses_default", envVal: "notanumber", want: 40},
+		{name: "zero_uses_default", envVal: "0", want: 40},
+		{name: "negative_uses_default", envVal: "-1", want: 40},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "BRIEFING_MAX_ACTIONS")
+			} else {
+				setenv(t, "BRIEFING_MAX_ACTIONS", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.BriefingMaxActions != tc.want {
+				t.Errorf("BriefingMaxActions = %d, want %d", cfg.BriefingMaxActions, tc.want)
 			}
 		})
 	}

--- a/internal/store/actions_query.go
+++ b/internal/store/actions_query.go
@@ -1,0 +1,231 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Response-size bounds for ListOpenActions. These are enforced in the store,
+// not only in the HTTP handler: a future caller (worker, CLI, briefing
+// generator) that forgets to pass a sane Limit must still be unable to pull an
+// unbounded result set into memory.
+const (
+	defaultActionListLimit = 50
+	maxActionListLimit     = 200
+)
+
+// actionArchiveWindow is the "recent" window used when
+// ActionFilter.IncludeArchived is false. Spec §7.4 resolves unbounded
+// accumulation by filtering at query time rather than by introducing a fourth
+// action_status.state value, which would change the meaning of existing rows
+// and require a data migration (schema changes are out of scope for Part C).
+const actionArchiveWindow = "90 days"
+
+// ActionFilter narrows ListOpenActions. The zero value is valid and means
+// "open actions observed in the last 90 days, newest-due first, at most 50".
+type ActionFilter struct {
+	// Kinds restricts to the given action kinds. Empty means all kinds.
+	Kinds []model.ActionKind
+	// Counterpart is a case-insensitive substring match against the joined
+	// entity's normalized_name. Empty disables the filter.
+	Counterpart string
+	// DueBefore keeps only actions with a non-NULL due_at at or before it.
+	DueBefore *time.Time
+	// MinConfidence is an inclusive lower bound on actions.confidence (0–1).
+	// Zero (the default) applies no bound — production's confidence
+	// distribution is not yet known, and a non-zero default could silently
+	// hide every LLM-detected action.
+	MinConfidence float64
+	// IncludeArchived disables the 90-day observed_at window.
+	IncludeArchived bool
+	// Sort is "due" or "confidence". Anything else falls back to "due".
+	Sort string
+	// Limit is clamped to [1, 200]; <= 0 means the 50-row default.
+	Limit int
+}
+
+// ActionListItem is one row of ListOpenActions: the action itself plus the two
+// values that only exist after the joins (its effective state and a display
+// name for the counterpart entity).
+type ActionListItem struct {
+	model.Action
+	State           model.ActionState
+	CounterpartName string
+}
+
+// ActionQueryStore holds the read path and the user-driven state transition for
+// actions. It is deliberately separate from ActionStore (the extraction
+// worker's write path) so the two can be edited independently.
+type ActionQueryStore struct {
+	pg *Postgres
+}
+
+// NewActionQueryStore returns an ActionQueryStore backed by pg.
+func NewActionQueryStore(pg *Postgres) *ActionQueryStore {
+	return &ActionQueryStore{pg: pg}
+}
+
+// actionSortClauses is the whitelist of ORDER BY fragments. User input never
+// reaches the SQL string: a request's sort parameter selects a key in this map
+// and nothing else, so an unknown value degrades to the default instead of
+// being interpolated.
+var actionSortClauses = map[string]string{
+	"due":        "a.due_at ASC NULLS LAST, a.observed_at DESC",
+	"confidence": "a.confidence DESC, a.observed_at DESC",
+}
+
+const defaultActionSort = "due"
+
+// clampActionLimit maps any caller-supplied limit into [1, 200].
+func clampActionLimit(limit int) int {
+	switch {
+	case limit <= 0:
+		return defaultActionListLimit
+	case limit > maxActionListLimit:
+		return maxActionListLimit
+	default:
+		return limit
+	}
+}
+
+// ListOpenActions returns the open actions matching f.
+//
+// "Open" is COALESCE(action_status.state, 'open'): the join to action_status is
+// a LEFT JOIN because an action row can exist without a status row (the
+// extraction worker writes the two in separate statements), and an INNER JOIN
+// would make such an action permanently invisible. The same reasoning applies
+// to the entities join — counterpart_entity_id is nullable.
+func (s *ActionQueryStore) ListOpenActions(ctx context.Context, f ActionFilter) ([]ActionListItem, error) {
+	orderBy, ok := actionSortClauses[f.Sort]
+	if !ok {
+		orderBy = actionSortClauses[defaultActionSort]
+	}
+	limit := clampActionLimit(f.Limit)
+
+	var kinds []string
+	if len(f.Kinds) > 0 {
+		kinds = make([]string, 0, len(f.Kinds))
+		for _, k := range f.Kinds {
+			kinds = append(kinds, string(k))
+		}
+	}
+
+	// orderBy and the interval literal are the only interpolated fragments and
+	// both come from package constants, never from a request.
+	q := `
+		SELECT a.identity_key, a.document_id, a.thread_key, a.kind, a.summary,
+		       a.counterpart_entity_id, a.due_at, a.detected_by, a.confidence, a.observed_at,
+		       COALESCE(st.state, 'open') AS state,
+		       COALESCE(e.normalized_name, '') AS counterpart_name
+		FROM actions a
+		LEFT JOIN action_status st ON st.identity_key = a.identity_key
+		LEFT JOIN entities e       ON e.id = a.counterpart_entity_id
+		WHERE COALESCE(st.state, 'open') = 'open'
+		  AND ($1::boolean OR a.observed_at > now() - interval '` + actionArchiveWindow + `')
+		  AND ($2::text[] IS NULL OR a.kind = ANY($2::text[]))
+		  AND ($3::text = '' OR COALESCE(e.normalized_name, '') ILIKE '%' || $3 || '%')
+		  AND ($4::timestamptz IS NULL OR (a.due_at IS NOT NULL AND a.due_at <= $4))
+		  AND a.confidence >= $5::numeric
+		ORDER BY ` + orderBy + `
+		LIMIT $6`
+
+	rows, err := s.pg.pool.Query(ctx, q,
+		f.IncludeArchived, kinds, f.Counterpart, f.DueBefore, f.MinConfidence, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list open actions: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]ActionListItem, 0, limit)
+	for rows.Next() {
+		var (
+			it    ActionListItem
+			kind  string
+			by    string
+			state string
+		)
+		if err := rows.Scan(
+			&it.IdentityKey, &it.DocumentID, &it.ThreadKey, &kind, &it.Summary,
+			&it.CounterpartEntityID, &it.DueAt, &by, &it.Confidence, &it.ObservedAt,
+			&state, &it.CounterpartName,
+		); err != nil {
+			return nil, fmt.Errorf("scan action row: %w", err)
+		}
+		it.Kind = model.ActionKind(kind)
+		it.DetectedBy = model.DetectedBy(by)
+		it.State = model.ActionState(state)
+		items = append(items, it)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate action rows: %w", err)
+	}
+	return items, nil
+}
+
+// pgForeignKeyViolation is SQLSTATE 23503. Inserting an action_status row for
+// an identity_key that has no action raises it.
+const pgForeignKeyViolation = "23503"
+
+// validActionStates is the closed set SetActionState accepts. 'open' is
+// included on purpose: a user who marks the wrong action done must be able to
+// put it back, and the alternative (deleting the action_status row) would
+// destroy the audit trail the rollback procedure depends on.
+var validActionStates = map[model.ActionState]bool{
+	model.StateOpen:    true,
+	model.StateDone:    true,
+	model.StateIgnored: true,
+}
+
+// SetActionState records the user's decision about identityKey.
+//
+// It is idempotent in the strict sense: replaying the same request leaves the
+// row unchanged, including resolved_at. The obvious "DO UPDATE SET resolved_at
+// = now()" is not — it rewrites the timestamp on every duplicate delivery, and
+// resolved_at is the only column that can isolate a batch of actions resolved
+// during a given incident window. resolved_at therefore advances only when the
+// state actually changes.
+//
+// The write targets action_status.identity_key, never actions.id: identity_key
+// is the handle that survives re-extraction, which is what makes a user's
+// done/ignored decision outlive the row that prompted it (spec §5.5).
+//
+// found=false with a nil error means "no such action". That case arrives as a
+// foreign-key violation, which would otherwise reach the user as a 500.
+func (s *ActionQueryStore) SetActionState(ctx context.Context, identityKey string, state model.ActionState, note string) (bool, error) {
+	if !validActionStates[state] {
+		return false, fmt.Errorf("invalid action state %q", state)
+	}
+
+	// EXCLUDED appears only in SET expressions here. Referencing it in the
+	// RETURNING clause is a runtime error in PostgreSQL — a trap this project
+	// has already hit once — so RETURNING lists a plain column.
+	const q = `
+		INSERT INTO action_status (identity_key, state, resolved_by, resolved_at, note)
+		VALUES ($1, $2, 'user', now(), NULLIF($3, ''))
+		ON CONFLICT (identity_key) DO UPDATE SET
+			state       = EXCLUDED.state,
+			resolved_by = EXCLUDED.resolved_by,
+			note        = COALESCE(EXCLUDED.note, action_status.note),
+			resolved_at = CASE WHEN action_status.state IS DISTINCT FROM EXCLUDED.state
+			                   THEN EXCLUDED.resolved_at ELSE action_status.resolved_at END
+		RETURNING identity_key`
+
+	var returned string
+	err := s.pg.pool.QueryRow(ctx, q, identityKey, string(state), note).Scan(&returned)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgForeignKeyViolation {
+			return false, nil
+		}
+		// The identity_key is a deterministic hash, not personal data, so it is
+		// safe to name here; note and summary never appear in errors.
+		return false, fmt.Errorf("set action state %s: %w", identityKey, err)
+	}
+	return true, nil
+}

--- a/internal/store/actions_query_test.go
+++ b/internal/store/actions_query_test.go
@@ -1,0 +1,386 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Action query store — real-database tests.
+//
+// This package has no SQL stub harness, and pure-function tests cannot prove a
+// query is valid: this project already paid for that lesson once (referencing
+// EXCLUDED inside a RETURNING clause compiled, passed stub tests, and failed at
+// runtime in production). Everything below therefore runs against a real
+// PostgreSQL instance addressed by TEST_DATABASE_URL and is skipped when that
+// variable is unset, so `go test ./...` stays green on a machine with no
+// database.
+//
+// TEST_DATABASE_URL must NEVER point at production. Every row these tests write
+// is prefixed with the sentinel below and removed in t.Cleanup.
+// ---------------------------------------------------------------------------
+
+const (
+	// actionTestKeyPrefix scopes both the seeded rows and the cleanup DELETE.
+	actionTestKeyPrefix = "action:test-"
+	// actionTestCounterpart is the normalized_name of the throwaway entity every
+	// seeded action points at. Queries filter on it so that unrelated rows that
+	// happen to live in the test database cannot influence an assertion.
+	// Deliberately a nonsense token — no real person's name appears in tests.
+	actionTestCounterpart = "zz-dummy-counterpart"
+	// actionTestSourceID prefixes the throwaway documents seeded actions
+	// reference (actions.document_id has an FK to documents.id).
+	actionTestSourceID = "zz-dummy-action-test"
+)
+
+// actionTestDB connects to TEST_DATABASE_URL or skips the calling test.
+func actionTestDB(t *testing.T) *Postgres {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping real-database action query test")
+	}
+	pg, err := NewPostgres(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect to TEST_DATABASE_URL: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	return pg
+}
+
+// seedActionFixtures inserts one throwaway document + one throwaway entity and
+// registers the cleanup that removes every row this test file creates. Deleting
+// the documents cascades to actions, which cascades to action_status.
+func seedActionFixtures(t *testing.T, pg *Postgres) (uuid.UUID, int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	docID := uuid.New()
+	_, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, collected_at)
+		VALUES ($1, 'filesystem', $2, 'dummy title', 'dummy content', now())`,
+		docID, actionTestSourceID+"-"+docID.String(),
+	)
+	if err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+
+	var entityID int64
+	err = pg.pool.QueryRow(ctx, `
+		INSERT INTO entities (name, type, normalized_name)
+		VALUES ('dummy counterpart', 'person', $1)
+		ON CONFLICT (normalized_name, type) DO UPDATE SET name = entities.name
+		RETURNING id`,
+		actionTestCounterpart,
+	).Scan(&entityID)
+	if err != nil {
+		t.Fatalf("seed entity: %v", err)
+	}
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		if _, err := pg.pool.Exec(cleanupCtx,
+			`DELETE FROM actions WHERE identity_key LIKE $1`, actionTestKeyPrefix+"%"); err != nil {
+			t.Errorf("cleanup actions: %v", err)
+		}
+		if _, err := pg.pool.Exec(cleanupCtx,
+			`DELETE FROM documents WHERE source_id LIKE $1`, actionTestSourceID+"%"); err != nil {
+			t.Errorf("cleanup documents: %v", err)
+		}
+		if _, err := pg.pool.Exec(cleanupCtx,
+			`DELETE FROM entities WHERE normalized_name = $1`, actionTestCounterpart); err != nil {
+			t.Errorf("cleanup entities: %v", err)
+		}
+	})
+
+	return docID, entityID
+}
+
+// insertTestAction writes one action row. summary/counterpart are dummy tokens.
+func insertTestAction(t *testing.T, pg *Postgres, docID uuid.UUID, entityID int64, key string, kind model.ActionKind, confidence float64, observedAt time.Time) {
+	t.Helper()
+	_, err := pg.pool.Exec(context.Background(), `
+		INSERT INTO actions (identity_key, document_id, thread_key, kind, summary,
+		                     counterpart_entity_id, due_at, detected_by, confidence, observed_at)
+		VALUES ($1, $2, 'zz-dummy-thread', $3, 'dummy summary', $4, '1990-01-01T00:00:00Z', 'structural', $5, $6)`,
+		key, docID, string(kind), entityID, confidence, observedAt,
+	)
+	if err != nil {
+		t.Fatalf("insert action %s: %v", key, err)
+	}
+}
+
+func insertTestStatus(t *testing.T, pg *Postgres, key string, state model.ActionState) {
+	t.Helper()
+	_, err := pg.pool.Exec(context.Background(),
+		`INSERT INTO action_status (identity_key, state) VALUES ($1, $2)`, key, string(state))
+	if err != nil {
+		t.Fatalf("insert action_status %s: %v", key, err)
+	}
+}
+
+// keysWithTestPrefix narrows a result set to rows this file seeded.
+func keysWithTestPrefix(items []ActionListItem) []ActionListItem {
+	out := make([]ActionListItem, 0, len(items))
+	for _, it := range items {
+		if strings.HasPrefix(it.IdentityKey, actionTestKeyPrefix) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// TestListOpenActionsExcludesResolved pins the default behaviour: only actions
+// whose effective state is 'open' are returned. An INNER JOIN on action_status
+// would silently drop actions that have no status row at all, so the query must
+// LEFT JOIN and COALESCE the missing state to 'open'.
+func TestListOpenActionsExcludesResolved(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	docID, entityID := seedActionFixtures(t, pg)
+
+	now := time.Now().UTC()
+	insertTestAction(t, pg, docID, entityID, actionTestKeyPrefix+"open", model.KindMyCommitment, 1.00, now)
+	insertTestStatus(t, pg, actionTestKeyPrefix+"open", model.StateOpen)
+	insertTestAction(t, pg, docID, entityID, actionTestKeyPrefix+"done", model.KindMyCommitment, 1.00, now)
+	insertTestStatus(t, pg, actionTestKeyPrefix+"done", model.StateDone)
+	insertTestAction(t, pg, docID, entityID, actionTestKeyPrefix+"ignored", model.KindMyCommitment, 1.00, now)
+	insertTestStatus(t, pg, actionTestKeyPrefix+"ignored", model.StateIgnored)
+
+	got, err := NewActionQueryStore(pg).ListOpenActions(ctx, ActionFilter{Counterpart: actionTestCounterpart})
+	if err != nil {
+		t.Fatalf("ListOpenActions: %v", err)
+	}
+	mine := keysWithTestPrefix(got)
+	if len(mine) != 1 {
+		t.Fatalf("want only the open action, got %d rows: %v", len(mine), identityKeysOf(mine))
+	}
+	if mine[0].IdentityKey != actionTestKeyPrefix+"open" {
+		t.Fatalf("returned key = %q, want %q", mine[0].IdentityKey, actionTestKeyPrefix+"open")
+	}
+	if mine[0].State != model.StateOpen {
+		t.Fatalf("State = %q, want %q", mine[0].State, model.StateOpen)
+	}
+	if mine[0].CounterpartName != actionTestCounterpart {
+		t.Fatalf("CounterpartName = %q, want the joined entity name %q", mine[0].CounterpartName, actionTestCounterpart)
+	}
+}
+
+// TestListOpenActionsKeepsStatuslessAction pins that an action with NO
+// action_status row survives. Part A inserts the status row separately from the
+// action row, so a crash between the two writes leaves exactly this shape; an
+// INNER JOIN would make such an action invisible forever.
+func TestListOpenActionsKeepsStatuslessAction(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	docID, entityID := seedActionFixtures(t, pg)
+
+	key := actionTestKeyPrefix + "nostatus"
+	insertTestAction(t, pg, docID, entityID, key, model.KindScheduled, 0.80, time.Now().UTC())
+
+	got, err := NewActionQueryStore(pg).ListOpenActions(ctx, ActionFilter{Counterpart: actionTestCounterpart})
+	if err != nil {
+		t.Fatalf("ListOpenActions: %v", err)
+	}
+	mine := keysWithTestPrefix(got)
+	if len(mine) != 1 {
+		t.Fatalf("action without an action_status row disappeared: got %v", identityKeysOf(mine))
+	}
+	if mine[0].State != model.StateOpen {
+		t.Fatalf("State = %q, want %q for a row with no action_status", mine[0].State, model.StateOpen)
+	}
+}
+
+// TestListOpenActionsClampsLimit pins that the response-size cap lives in the
+// store, not only in the handler. A caller that asks for 100000 rows must not be
+// able to pull the whole table into memory.
+func TestListOpenActionsClampsLimit(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	docID, entityID := seedActionFixtures(t, pg)
+
+	const seeded = 205
+	now := time.Now().UTC()
+	for i := 0; i < seeded; i++ {
+		insertTestAction(t, pg, docID, entityID,
+			fmt.Sprintf("%sbulk-%03d", actionTestKeyPrefix, i),
+			model.KindTheirCommitment, 1.00, now)
+	}
+
+	got, err := NewActionQueryStore(pg).ListOpenActions(ctx, ActionFilter{
+		Counterpart: actionTestCounterpart,
+		Limit:       100000,
+	})
+	if err != nil {
+		t.Fatalf("ListOpenActions: %v", err)
+	}
+	if len(got) > 200 {
+		t.Fatalf("Limit=100000 returned %d rows; store must clamp to 200", len(got))
+	}
+	if len(got) != 200 {
+		t.Fatalf("returned %d rows, want exactly the 200-row clamp (seeded %d matching rows)", len(got), seeded)
+	}
+
+	// A zero Limit must fall back to the 50-row default rather than to "no limit".
+	def, err := NewActionQueryStore(pg).ListOpenActions(ctx, ActionFilter{Counterpart: actionTestCounterpart})
+	if err != nil {
+		t.Fatalf("ListOpenActions (default limit): %v", err)
+	}
+	if len(def) != 50 {
+		t.Fatalf("zero Limit returned %d rows, want the 50-row default", len(def))
+	}
+}
+
+// readResolvedAt returns action_status.resolved_at for key, or the zero time
+// when the column is NULL.
+func readResolvedAt(t *testing.T, pg *Postgres, key string) time.Time {
+	t.Helper()
+	var at *time.Time
+	err := pg.pool.QueryRow(context.Background(),
+		`SELECT resolved_at FROM action_status WHERE identity_key = $1`, key).Scan(&at)
+	if err != nil {
+		t.Fatalf("read resolved_at for %s: %v", key, err)
+	}
+	if at == nil {
+		return time.Time{}
+	}
+	return *at
+}
+
+func readActionState(t *testing.T, pg *Postgres, key string) string {
+	t.Helper()
+	var state string
+	err := pg.pool.QueryRow(context.Background(),
+		`SELECT state FROM action_status WHERE identity_key = $1`, key).Scan(&state)
+	if err != nil {
+		t.Fatalf("read state for %s: %v", key, err)
+	}
+	return state
+}
+
+// TestSetActionStateIsIdempotent pins the exact meaning of idempotence here:
+// repeating a request must leave the database byte-for-byte identical.
+// "ON CONFLICT DO UPDATE SET resolved_at = now()" would pass a naive
+// same-state-after check while silently rewriting the timestamp on every call —
+// and that timestamp is the only handle a recovery UPDATE has for isolating a
+// batch of wrongly-resolved actions (see the plan's rollback section).
+func TestSetActionStateIsIdempotent(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	docID, entityID := seedActionFixtures(t, pg)
+	s := NewActionQueryStore(pg)
+
+	key := actionTestKeyPrefix + "idempotent"
+	insertTestAction(t, pg, docID, entityID, key, model.KindMyCommitment, 1.00, time.Now().UTC())
+
+	found, err := s.SetActionState(ctx, key, model.StateDone, "")
+	if err != nil || !found {
+		t.Fatalf("first SetActionState: found=%v err=%v", found, err)
+	}
+	if got := readActionState(t, pg, key); got != string(model.StateDone) {
+		t.Fatalf("state = %q after first call, want %q", got, model.StateDone)
+	}
+	first := readResolvedAt(t, pg, key)
+	if first.IsZero() {
+		t.Fatal("resolved_at is NULL after a state transition; recovery UPDATEs would have nothing to filter on")
+	}
+
+	// The repeat call carries the same state — nothing about the row may move.
+	time.Sleep(10 * time.Millisecond)
+	found, err = s.SetActionState(ctx, key, model.StateDone, "")
+	if err != nil || !found {
+		t.Fatalf("repeat SetActionState: found=%v err=%v", found, err)
+	}
+	if second := readResolvedAt(t, pg, key); !second.Equal(first) {
+		t.Fatalf("resolved_at moved on repeat call: %v -> %v (not idempotent)", first, second)
+	}
+
+	// A genuine transition, on the other hand, must advance resolved_at.
+	time.Sleep(10 * time.Millisecond)
+	if _, err := s.SetActionState(ctx, key, model.StateIgnored, ""); err != nil {
+		t.Fatalf("transition to ignored: %v", err)
+	}
+	if got := readActionState(t, pg, key); got != string(model.StateIgnored) {
+		t.Fatalf("state = %q, want %q", got, model.StateIgnored)
+	}
+	if third := readResolvedAt(t, pg, key); !third.After(first) {
+		t.Fatalf("resolved_at did not advance on a real transition: %v -> %v", first, third)
+	}
+}
+
+// TestSetActionStateReopen pins that 'open' is an accepted target state: a user
+// who marks the wrong action done must be able to undo it.
+func TestSetActionStateReopen(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	docID, entityID := seedActionFixtures(t, pg)
+	s := NewActionQueryStore(pg)
+
+	key := actionTestKeyPrefix + "reopen"
+	insertTestAction(t, pg, docID, entityID, key, model.KindScheduled, 1.00, time.Now().UTC())
+
+	if _, err := s.SetActionState(ctx, key, model.StateDone, ""); err != nil {
+		t.Fatalf("mark done: %v", err)
+	}
+	if _, err := s.SetActionState(ctx, key, model.StateOpen, ""); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+
+	got, err := s.ListOpenActions(ctx, ActionFilter{Counterpart: actionTestCounterpart})
+	if err != nil {
+		t.Fatalf("ListOpenActions: %v", err)
+	}
+	if len(keysWithTestPrefix(got)) != 1 {
+		t.Fatalf("reopened action is not listed as open: %v", identityKeysOf(got))
+	}
+}
+
+// TestSetActionStateUnknownKey pins that a key with no matching action row is
+// reported as not-found rather than as an error. The INSERT violates
+// action_status' foreign key (SQLSTATE 23503); left unhandled that surfaces to
+// the user as a 500 for what is really a 404.
+func TestSetActionStateUnknownKey(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	seedActionFixtures(t, pg) // registers cleanup
+	s := NewActionQueryStore(pg)
+
+	found, err := s.SetActionState(ctx, actionTestKeyPrefix+"does-not-exist", model.StateDone, "")
+	if err != nil {
+		t.Fatalf("unknown key returned an error instead of found=false: %v", err)
+	}
+	if found {
+		t.Fatal("found = true for a key that was never inserted")
+	}
+}
+
+// TestSetActionStateRejectsUnknownState pins that validation happens in the
+// store too, not only in the handler.
+func TestSetActionStateRejectsUnknownState(t *testing.T) {
+	pg := actionTestDB(t)
+	ctx := context.Background()
+	docID, entityID := seedActionFixtures(t, pg)
+	s := NewActionQueryStore(pg)
+
+	key := actionTestKeyPrefix + "badstate"
+	insertTestAction(t, pg, docID, entityID, key, model.KindScheduled, 1.00, time.Now().UTC())
+
+	if _, err := s.SetActionState(ctx, key, model.ActionState("archived"), ""); err == nil {
+		t.Fatal("store accepted a state outside the closed vocabulary")
+	}
+}
+
+func identityKeysOf(items []ActionListItem) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.IdentityKey)
+	}
+	return out
+}

--- a/web/src/app/actions/ActionList.tsx
+++ b/web/src/app/actions/ActionList.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import Link from "next/link";
+import { Badge, Button, Card } from "@/components/ui";
+import type { ActionDetectedBy, ActionItem, ActionKind } from "@/lib/types";
+
+/** Korean labels for the closed `kind` vocabulary (internal/model/action.go).
+ * Exported because the filter bar on the page renders the same four words. */
+export const ACTION_KIND_LABELS: Record<ActionKind, string> = {
+  awaiting_my_reply: "응답 대기",
+  my_commitment: "내 약속",
+  their_commitment: "상대 약속",
+  scheduled: "예정",
+};
+
+/** `detected_by` is shown verbatim rather than hidden behind a "verified"
+ * flag: it is the user's only handle on an action the LLM invented (spec
+ * §7.4). */
+const DETECTED_BY_LABELS: Record<ActionDetectedBy, string> = {
+  structural: "구조 신호",
+  llm: "LLM 추출",
+  both: "구조+LLM",
+};
+
+const KIND_BADGE_VARIANT: Record<ActionKind, "default" | "accent" | "warning"> = {
+  awaiting_my_reply: "warning",
+  my_commitment: "accent",
+  their_commitment: "default",
+  scheduled: "default",
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Renders a due date as a relative phrase. Returns null when there is no due
+ * date, which is the common case for `awaiting_my_reply`. */
+export function formatDueLabel(dueAt: string | null, now: Date = new Date()): string | null {
+  if (!dueAt) return null;
+  const due = new Date(dueAt);
+  if (Number.isNaN(due.getTime())) return null;
+  // Compare calendar days, not instants: "1일 남음" should not flip to
+  // "오늘 마감" because of a few hours' difference.
+  const startOfDue = Date.UTC(due.getFullYear(), due.getMonth(), due.getDate());
+  const startOfNow = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  const days = Math.round((startOfDue - startOfNow) / MS_PER_DAY);
+  if (days === 0) return "오늘 마감";
+  if (days > 0) return `${days}일 남음`;
+  return `${-days}일 지남`;
+}
+
+function DueBadge({ dueAt }: { dueAt: string | null }) {
+  const label = formatDueLabel(dueAt);
+  if (!label) return null;
+  const overdue = label.endsWith("지남");
+  const today = label === "오늘 마감";
+  return (
+    <Badge variant={overdue ? "danger" : today ? "warning" : "default"} size="sm">
+      {label}
+    </Badge>
+  );
+}
+
+export interface ActionListProps {
+  items: ActionItem[];
+  onResolve: (key: string, state: "done" | "ignored") => void;
+  /** Keys whose last state change failed. The card keeps its place and offers
+   * a retry — the endpoint is idempotent, so retrying costs nothing. */
+  failedKeys?: ReadonlySet<string>;
+  /** Keys with a state change still in flight, used to disable the buttons. */
+  pendingKeys?: ReadonlySet<string>;
+}
+
+const EMPTY_KEYS: ReadonlySet<string> = new Set();
+
+export function ActionList({
+  items,
+  onResolve,
+  failedKeys = EMPTY_KEYS,
+  pendingKeys = EMPTY_KEYS,
+}: ActionListProps) {
+  return (
+    <ul className="space-y-3">
+      {items.map((item) => {
+        const failed = failedKeys.has(item.identity_key);
+        const pending = pendingKeys.has(item.identity_key);
+        return (
+          <li key={item.identity_key}>
+            {/* The identity key lives in a data attribute only — never in the
+                page URL and never in a log line (plan Task 8). */}
+            <Card padding="none" data-action-key={item.identity_key}>
+              {failed && (
+                <p
+                  role="alert"
+                  className="border-b border-border bg-[--status-danger-light] px-4 py-2 text-xs text-danger"
+                >
+                  처리에 실패했습니다. 다시 시도해 주세요.
+                </p>
+              )}
+              <div className="space-y-3 p-4">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <Badge variant={KIND_BADGE_VARIANT[item.kind]} size="sm">
+                    {ACTION_KIND_LABELS[item.kind]}
+                  </Badge>
+                  <DueBadge dueAt={item.due_at} />
+                  <Badge size="sm">{DETECTED_BY_LABELS[item.detected_by]}</Badge>
+                  <span className="text-xs text-foreground-subtle">
+                    신뢰도 {Math.round(item.confidence * 100)}%
+                  </span>
+                </div>
+
+                <p className="text-sm leading-relaxed font-semibold text-foreground">
+                  {item.summary || ACTION_KIND_LABELS[item.kind]}
+                </p>
+
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-foreground-muted">
+                  {item.counterpart_name && <span>{item.counterpart_name}</span>}
+                  <Link
+                    href={`/documents/${item.document_id}`}
+                    className="text-text-accent underline-offset-2 hover:underline"
+                  >
+                    근거 문서
+                  </Link>
+                </div>
+
+                {/* Buttons stay inside the card. A fixed bottom bar would sit
+                    under the mobile tab bar — this project has shipped that
+                    bug before. */}
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    disabled={pending}
+                    onClick={() => onResolve(item.identity_key, "done")}
+                  >
+                    완료
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    disabled={pending}
+                    onClick={() => onResolve(item.identity_key, "ignored")}
+                  >
+                    무시
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/app/actions/BriefingPanel.tsx
+++ b/web/src/app/actions/BriefingPanel.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import Link from "next/link";
+import { Badge, Card, Spinner } from "@/components/ui";
+import { getBriefing } from "@/lib/api";
+import type { BriefingResponse } from "@/lib/types";
+
+export interface BriefingPanelProps {
+  /** Bumped by the page after a successful done/ignore. The open action set is
+   * the server's cache key, so a refetch after a state change returns freshly
+   * generated sentences rather than the cached ones. */
+  refreshKey: number;
+}
+
+/** Assigns a stable footnote number to each distinct evidence document, in the
+ * order the sentences reference them. Numbers are the only link text: a title
+ * or a snippet would put document content back into this response, which is
+ * exactly what the document_id-only contract avoids (plan Task 8). */
+function numberEvidence(data: BriefingResponse): {
+  sentences: { text: string; refs: { id: string; n: number }[] }[];
+} {
+  const numbers = new Map<string, number>();
+  const sentences = data.sentences.map((s) => ({
+    text: s.text,
+    refs: s.document_ids.map((id) => {
+      let n = numbers.get(id);
+      if (n === undefined) {
+        n = numbers.size + 1;
+        numbers.set(id, n);
+      }
+      return { id, n };
+    }),
+  }));
+  return { sentences };
+}
+
+export function BriefingPanel({ refreshKey }: BriefingPanelProps) {
+  const [data, setData] = useState<BriefingResponse | null>(null);
+  // React 19 transition rather than a setState in the effect body (project
+  // lint rule react-hooks/set-state-in-effect).
+  const [loading, startLoad] = useTransition();
+
+  useEffect(() => {
+    let cancelled = false;
+    startLoad(async () => {
+      try {
+        const res = await getBriefing();
+        if (!cancelled) setData(res);
+      } catch {
+        // A failed briefing must not get in the way of the action list, so the
+        // panel simply disappears. The error is not logged: the message would
+        // carry the request context and the body is personal data.
+        if (!cancelled) setData(null);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey, startLoad]);
+
+  const numbered = useMemo(() => (data ? numberEvidence(data) : null), [data]);
+
+  if (loading && !data) {
+    return (
+      <Card padding="md" variant="subtle">
+        <div className="flex items-center gap-2 text-sm text-foreground-muted">
+          <Spinner size="sm" />
+          브리핑 생성 중…
+        </div>
+      </Card>
+    );
+  }
+
+  // No data, or nothing to brief on: the panel is not part of the page.
+  if (!data || !numbered || data.action_count === 0) return null;
+
+  return (
+    <Card padding="md" variant="subtle" aria-busy={loading}>
+      <section aria-label="브리핑" className="space-y-2">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <h2 className="text-xs font-semibold tracking-wide text-foreground-muted uppercase">
+            브리핑
+          </h2>
+          {data.degraded && (
+            // The single purpose of this badge is to stop the user reading a
+            // deterministic aggregate as a written summary.
+            <Badge variant="warning" size="sm">
+              요약 생성 실패 — 집계만 표시
+            </Badge>
+          )}
+          {data.cached && (
+            <Badge size="sm" title="열린 액션이 바뀌면 자동으로 다시 생성됩니다">
+              캐시됨
+            </Badge>
+          )}
+        </div>
+
+        <p className="text-sm leading-relaxed text-foreground">
+          {numbered.sentences.map((s, i) => (
+            <span key={i}>
+              {s.text}
+              {s.refs.map((ref) => (
+                <sup key={ref.id} className="ml-0.5">
+                  <Link
+                    href={`/documents/${ref.id}`}
+                    aria-label={`근거 문서 ${ref.n}`}
+                    className="text-text-accent underline-offset-2 hover:underline"
+                  >
+                    [{ref.n}]
+                  </Link>
+                </sup>
+              ))}{" "}
+            </span>
+          ))}
+        </p>
+
+        {data.dropped_count > 0 && (
+          // A trust signal, not debug output: the user should be able to see
+          // that unsupported sentences were thrown away rather than shown.
+          <p className="text-xs text-foreground-subtle">
+            근거 없는 문장 {data.dropped_count}개 폐기됨 — 이 요약은 완전하지 않을 수 있습니다.
+          </p>
+        )}
+      </section>
+    </Card>
+  );
+}

--- a/web/src/app/actions/page.tsx
+++ b/web/src/app/actions/page.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ActionList, ACTION_KIND_LABELS } from "./ActionList";
+import { BriefingPanel } from "./BriefingPanel";
+import { ActionsDisabledError, listActions, setActionState } from "@/lib/api";
+import { ACTION_KINDS, type ActionItem, type ActionKind } from "@/lib/types";
+import { Button, Spinner } from "@/components/ui";
+
+type SortMode = "due" | "confidence";
+type LoadStatus = "ok" | "disabled" | "error";
+
+const DEFAULT_SORT: SortMode = "due";
+/** No confidence floor by default. The production confidence distribution is
+ * unknown, and an arbitrary floor would silently hide every LLM-detected
+ * action (plan §확정 판단). */
+const DEFAULT_MIN_CONFIDENCE = 0;
+
+function parseKinds(raw: string | null): ActionKind[] {
+  if (!raw) return [];
+  const allowed = new Set<string>(ACTION_KINDS);
+  return raw.split(",").filter((k): k is ActionKind => allowed.has(k));
+}
+
+function parseSort(raw: string | null): SortMode {
+  return raw === "confidence" ? "confidence" : DEFAULT_SORT;
+}
+
+function parseConfidence(raw: string | null): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) return DEFAULT_MIN_CONFIDENCE;
+  return n;
+}
+
+function ActionsPageInner() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Filters live in the query string so a view survives a refresh and can be
+  // shared — except the counterpart filter, which is a person's name and
+  // therefore stays in component state only (plan Task 8: no names in URLs).
+  const [kinds, setKinds] = useState<ActionKind[]>(() => parseKinds(searchParams.get("kind")));
+  const [sort, setSort] = useState<SortMode>(() => parseSort(searchParams.get("sort")));
+  const [minConfidence, setMinConfidence] = useState(() =>
+    parseConfidence(searchParams.get("minconf")),
+  );
+  const [includeArchived, setIncludeArchived] = useState(
+    () => searchParams.get("archived") === "true",
+  );
+  const [counterpartInput, setCounterpartInput] = useState("");
+  const [counterpart, setCounterpart] = useState("");
+
+  const [items, setItems] = useState<ActionItem[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const [status, setStatus] = useState<LoadStatus>("ok");
+  const [loading, startLoad] = useTransition();
+
+  const [failedKeys, setFailedKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(() => new Set());
+
+  // Bumped after every successful state change: it re-runs the list query and
+  // is handed to the briefing panel, whose server-side cache key changes with
+  // the open action set.
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // ── URL sync (no names) ───────────────────────────────────────────────
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (kinds.length > 0) params.set("kind", kinds.join(","));
+    if (sort !== DEFAULT_SORT) params.set("sort", sort);
+    if (minConfidence !== DEFAULT_MIN_CONFIDENCE) params.set("minconf", String(minConfidence));
+    if (includeArchived) params.set("archived", "true");
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [kinds, sort, minConfidence, includeArchived, pathname, router]);
+
+  // ── Counterpart debounce ──────────────────────────────────────────────
+  useEffect(() => {
+    const timer = setTimeout(() => setCounterpart(counterpartInput.trim()), 300);
+    return () => clearTimeout(timer);
+  }, [counterpartInput]);
+
+  const params = useMemo(
+    () => ({
+      kinds,
+      sort,
+      minConfidence,
+      includeArchived,
+      counterpart: counterpart || undefined,
+    }),
+    [kinds, sort, minConfidence, includeArchived, counterpart],
+  );
+
+  // ── List query ────────────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    // A transition rather than a setState in the effect body (project lint
+    // rule react-hooks/set-state-in-effect).
+    startLoad(async () => {
+      try {
+        const res = await listActions(params);
+        if (cancelled) return;
+        setItems(res.actions ?? []);
+        setTruncated(res.truncated);
+        setStatus("ok");
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setItems([]);
+        setTruncated(false);
+        // No response body is logged here: summaries and names are personal
+        // data, so only the failure mode is distinguished.
+        setStatus(err instanceof ActionsDisabledError ? "disabled" : "error");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [params, refreshKey, startLoad]);
+
+  // ── Optimistic done / ignore ──────────────────────────────────────────
+  const handleResolve = useCallback(
+    (key: string, state: "done" | "ignored") => {
+      const index = items.findIndex((i) => i.identity_key === key);
+      const snapshot = items[index];
+      if (index < 0 || !snapshot) return;
+
+      setItems((prev) => prev.filter((i) => i.identity_key !== key));
+      setFailedKeys((prev) => {
+        if (!prev.has(key)) return prev;
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      setPendingKeys((prev) => new Set(prev).add(key));
+
+      setActionState(key, state)
+        .then(() => {
+          setPendingKeys((prev) => {
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          });
+          // Re-runs the list query and re-generates the briefing.
+          setRefreshKey((n) => n + 1);
+        })
+        .catch(() => {
+          // Roll the card back into its old position and flag it. The endpoint
+          // is idempotent, so pressing the button again is safe.
+          setItems((prev) => {
+            if (prev.some((i) => i.identity_key === key)) return prev;
+            const next = [...prev];
+            next.splice(Math.min(index, next.length), 0, snapshot);
+            return next;
+          });
+          setPendingKeys((prev) => {
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          });
+          setFailedKeys((prev) => new Set(prev).add(key));
+        });
+    },
+    [items],
+  );
+
+  const toggleKind = useCallback((kind: ActionKind) => {
+    setKinds((prev) => (prev.includes(kind) ? prev.filter((k) => k !== kind) : [...prev, kind]));
+  }, []);
+
+  return (
+    <main className="mx-auto w-full max-w-3xl space-y-4 px-4 py-6">
+      <header className="space-y-1">
+        <h1 className="text-xl font-semibold text-foreground">액션</h1>
+        <p className="text-sm text-foreground-muted">
+          응답이 필요한 대화와 아직 지키지 않은 약속입니다.
+        </p>
+      </header>
+
+      {status === "ok" && <BriefingPanel refreshKey={refreshKey} />}
+
+      {/* ── Filter bar ─────────────────────────────────────────────────── */}
+      <section aria-label="필터" className="space-y-3 rounded-lg border border-border p-3">
+        <div className="flex flex-wrap gap-1.5">
+          {ACTION_KINDS.map((kind) => {
+            const on = kinds.includes(kind);
+            return (
+              <Button
+                key={kind}
+                size="sm"
+                variant={on ? "primary" : "secondary"}
+                aria-pressed={on}
+                onClick={() => toggleKind(kind)}
+              >
+                {ACTION_KIND_LABELS[kind]}
+              </Button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex items-center gap-2 text-xs text-foreground-muted">
+            <span>상대방</span>
+            <input
+              type="text"
+              value={counterpartInput}
+              onChange={(e) => setCounterpartInput(e.target.value)}
+              placeholder="이름 일부"
+              className="h-8 w-40 rounded-md border border-border bg-surface px-2 text-sm text-foreground focus-visible:ring-2 focus-visible:ring-accent/50 focus-visible:outline-none"
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-xs text-foreground-muted">
+            <span>정렬</span>
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value === "confidence" ? "confidence" : "due")}
+              className="h-8 rounded-md border border-border bg-surface px-2 text-sm text-foreground"
+            >
+              <option value="due">기한순</option>
+              <option value="confidence">신뢰도순</option>
+            </select>
+          </label>
+
+          <label className="flex items-center gap-2 text-xs text-foreground-muted">
+            <span>신뢰도 {Math.round(minConfidence * 100)}% 이상</span>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.05}
+              value={minConfidence}
+              onChange={(e) => setMinConfidence(Number(e.target.value))}
+              className="w-32"
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-xs text-foreground-muted">
+            <input
+              type="checkbox"
+              checked={includeArchived}
+              onChange={(e) => setIncludeArchived(e.target.checked)}
+            />
+            <span>90일 이전 포함</span>
+          </label>
+        </div>
+      </section>
+
+      {/* ── Results ────────────────────────────────────────────────────── */}
+      {status === "disabled" && (
+        <p className="rounded-lg border border-border p-4 text-sm text-foreground-muted">
+          액션 기능이 비활성화되어 있습니다.
+        </p>
+      )}
+
+      {status === "error" && (
+        <p role="alert" className="rounded-lg border border-border p-4 text-sm text-danger">
+          액션을 불러오지 못했습니다.
+        </p>
+      )}
+
+      {status === "ok" && (
+        <>
+          {loading && items.length === 0 ? (
+            <div className="flex items-center gap-2 p-4 text-sm text-foreground-muted">
+              <Spinner size="sm" />
+              불러오는 중…
+            </div>
+          ) : items.length === 0 ? (
+            <p className="rounded-lg border border-border p-4 text-sm text-foreground-muted">
+              열린 액션이 없습니다.
+            </p>
+          ) : (
+            <div aria-busy={loading} className="space-y-3">
+              <ActionList
+                items={items}
+                onResolve={handleResolve}
+                failedKeys={failedKeys}
+                pendingKeys={pendingKeys}
+              />
+              {truncated && (
+                <p className="text-xs text-foreground-subtle">
+                  상위 {items.length}건만 표시됨 — 필터를 좁히세요.
+                </p>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  );
+}
+
+export default function ActionsPage() {
+  return (
+    <Suspense>
+      <ActionsPageInner />
+    </Suspense>
+  );
+}

--- a/web/src/app/api/actions/[key]/status/route.ts
+++ b/web/src/app/api/actions/[key]/status/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Actions proxy — POST /api/actions/{key}/status
+ *   → POST /api/v1/actions/{identity_key}/status
+ *
+ * The upstream endpoint is idempotent, so a replayed request is safe; the /actions
+ * screen relies on that when it retries a failed optimistic update.
+ *
+ * The request body can contain a user note and the response echoes the
+ * identity key, so neither is logged (plan Task 8).
+ */
+import { type NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+/** Shape of an identity key ("action:" + 16 hex), mirroring
+ * internal/api/actions.go. The value is a deterministic hash that
+ * action_status rows already point at: it is validated for SHAPE and passed
+ * through unchanged, never normalised or recomputed (spec §5.5). */
+const IDENTITY_KEY_RE = /^action:[0-9a-f]{16}$/;
+
+interface StatusBody {
+  state?: unknown;
+  note?: unknown;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ key: string }> },
+): Promise<NextResponse> {
+  // Next decodes the dynamic segment, so the "action:" colon arrives intact.
+  const { key } = await params;
+  if (!IDENTITY_KEY_RE.test(key)) {
+    return NextResponse.json({ error: "invalid action key" }, { status: 400 });
+  }
+
+  let body: StatusBody;
+  try {
+    body = (await request.json()) as StatusBody;
+  } catch {
+    // The parse error can quote the body, which may contain a note.
+    return NextResponse.json({ error: "invalid request body" }, { status: 400 });
+  }
+
+  const state = body.state;
+  if (state !== "open" && state !== "done" && state !== "ignored") {
+    return NextResponse.json({ error: "invalid state" }, { status: 400 });
+  }
+  const note = typeof body.note === "string" ? body.note : "";
+
+  try {
+    const upstream = await fetch(
+      `${BACKEND_URL}/api/v1/actions/${encodeURIComponent(key)}/status`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }),
+        },
+        body: JSON.stringify({ state, note }),
+      },
+    );
+    const text = await upstream.text();
+    return new NextResponse(text.length > 0 ? text : null, {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error: unknown) {
+    console.error(
+      "[api/actions/status] upstream request failed:",
+      error instanceof Error ? error.name : "unknown",
+    );
+    return NextResponse.json({ error: "upstream request failed" }, { status: 502 });
+  }
+}

--- a/web/src/app/api/actions/route.ts
+++ b/web/src/app/api/actions/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Actions proxy — GET /api/actions → GET /api/v1/actions
+ *
+ * Authentication is already handled upstream of this handler by
+ * web/src/proxy.ts (Cloudflare Access JWT); nothing auth-related belongs here.
+ *
+ * The response body carries action summaries and counterpart names, so it is
+ * never logged and never echoed into an error body — only the fact that a
+ * transport error happened (plan Task 8).
+ */
+import { type NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+/** Forwarded query parameters. The list is a whitelist rather than a
+ * pass-through of request.nextUrl.searchParams: forwarding everything turns a
+ * front-end typo into a backend 400 that the user sees as a broken screen. */
+const FORWARDED_PARAMS = [
+  "kind",
+  "counterpart",
+  "due_before",
+  "min_confidence",
+  "sort",
+  "limit",
+  "include_archived",
+] as const;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const incoming = request.nextUrl.searchParams;
+  const forwarded = new URLSearchParams();
+  for (const name of FORWARDED_PARAMS) {
+    // kind repeats; getAll covers both the repeated and the single case.
+    for (const value of incoming.getAll(name)) {
+      if (value !== "") forwarded.append(name, value);
+    }
+  }
+  const qs = forwarded.toString();
+
+  try {
+    const upstream = await fetch(`${BACKEND_URL}/api/v1/actions${qs ? `?${qs}` : ""}`, {
+      headers: { ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }) },
+      cache: "no-store",
+    });
+    const text = await upstream.text();
+    return new NextResponse(text.length > 0 ? text : null, {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error: unknown) {
+    // Only the error class name is logged. A fetch failure can quote the
+    // request URL, which carries the counterpart filter — a person's name.
+    console.error(
+      "[api/actions] upstream request failed:",
+      error instanceof Error ? error.name : "unknown",
+    );
+    return NextResponse.json({ error: "upstream request failed" }, { status: 502 });
+  }
+}

--- a/web/src/app/api/briefing/route.ts
+++ b/web/src/app/api/briefing/route.ts
@@ -1,0 +1,34 @@
+/**
+ * Briefing proxy — GET /api/briefing → GET /api/v1/briefing
+ *
+ * Takes no query parameters: the briefing's inputs are the open action set and
+ * the server-side cache key derived from it, not anything the client sends.
+ *
+ * The response body is a restatement of personal conversations, so it is never
+ * logged (plan Task 8 — the rule this project already broke once, #194).
+ */
+import { NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BRAIN_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9200";
+const API_KEY = process.env.API_KEY ?? "";
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const upstream = await fetch(`${BACKEND_URL}/api/v1/briefing`, {
+      headers: { ...(API_KEY && { Authorization: `Bearer ${API_KEY}` }) },
+      cache: "no-store",
+    });
+    const text = await upstream.text();
+    return new NextResponse(text.length > 0 ? text : null, {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error: unknown) {
+    console.error(
+      "[api/briefing] upstream request failed:",
+      error instanceof Error ? error.name : "unknown",
+    );
+    return NextResponse.json({ error: "upstream request failed" }, { status: 502 });
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,7 +1,11 @@
 import type {
+  ActionListParams,
+  ActionsResponse,
+  ActionState,
   AskConversationSummary,
   AskConversationTurn,
   BaselineStats,
+  BriefingResponse,
   CreateNoteResponse,
   DocumentDetail,
   DocumentsResponse,
@@ -275,6 +279,83 @@ export async function getGraphEvidence(
 export async function searchGraphEntities(q: string): Promise<GraphEntityHit[]> {
   const res = await fetchGraph<GraphEntitiesResponse>("entities", new URLSearchParams({ q }));
   return res.entities ?? [];
+}
+
+// ── Actions & briefing (Part C) ──────────────────────────────────────────
+//
+// Browser-only helpers: they hit the /api/actions and /api/briefing proxy
+// routes (web/src/app/api/actions/*, web/src/app/api/briefing), which forward
+// to the backend's /api/v1/*.
+//
+// No response body is ever logged — an action summary and a counterpart name
+// are personal data (plan Task 8).
+
+/** Thrown when the backend answers 404 for the actions list, which is what the
+ * ACTIONS_API_ENABLED flag being off looks like from here: the route is not
+ * registered at all. The screen says "feature disabled" instead of showing a
+ * generic failure. */
+export class ActionsDisabledError extends Error {
+  constructor() {
+    super("actions feature disabled");
+    this.name = "ActionsDisabledError";
+  }
+}
+
+export async function listActions(params: ActionListParams = {}): Promise<ActionsResponse> {
+  const qs = new URLSearchParams();
+  for (const kind of params.kinds ?? []) qs.append("kind", kind);
+  if (params.counterpart) qs.set("counterpart", params.counterpart);
+  if (params.dueBefore) qs.set("due_before", params.dueBefore);
+  // 0 is the documented "no floor" default; sending it would only add noise.
+  if (params.minConfidence !== undefined && params.minConfidence > 0) {
+    qs.set("min_confidence", String(params.minConfidence));
+  }
+  if (params.sort) qs.set("sort", params.sort);
+  if (params.limit !== undefined) qs.set("limit", String(params.limit));
+  if (params.includeArchived) qs.set("include_archived", "true");
+
+  const search = qs.toString();
+  const response = await fetch(`${getApiBase()}/actions${search ? `?${search}` : ""}`);
+  if (response.status === 404) {
+    throw new ActionsDisabledError();
+  }
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<ActionsResponse>;
+}
+
+/** Marks one action done or ignored. The backend is idempotent, so replaying
+ * this call after a failed attempt is safe — which is what makes the
+ * optimistic update on the /actions screen recoverable.
+ *
+ * A 404 here is NOT mapped to ActionsDisabledError: the backend answers 404
+ * both for an unregistered route and for an unknown identity_key, and the two
+ * are indistinguishable from the client. */
+export async function setActionState(
+  identityKey: string,
+  state: Extract<ActionState, "done" | "ignored">,
+  note?: string,
+): Promise<void> {
+  const response = await fetch(
+    `${getApiBase()}/actions/${encodeURIComponent(identityKey)}/status`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ state, ...(note ? { note } : {}) }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+}
+
+export async function getBriefing(): Promise<BriefingResponse> {
+  const response = await fetch(`${getApiBase()}/briefing`);
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<BriefingResponse>;
 }
 
 // ── File upload (Capture) ────────────────────────────────────────────────

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -302,3 +302,82 @@ export interface GraphEvidenceResponse {
 export interface GraphEntitiesResponse {
   entities: GraphEntityHit[];
 }
+
+// ── Actions & briefing (Part C) ───────────────────────────────────────────
+//
+// The three closed vocabularies below mirror internal/model/action.go. They
+// are written as const tuples so the filter bar can iterate them without a
+// second, drifting list of strings.
+
+export const ACTION_KINDS = [
+  "awaiting_my_reply",
+  "my_commitment",
+  "their_commitment",
+  "scheduled",
+] as const;
+export type ActionKind = (typeof ACTION_KINDS)[number];
+
+export const ACTION_DETECTED_BY = ["structural", "llm", "both"] as const;
+export type ActionDetectedBy = (typeof ACTION_DETECTED_BY)[number];
+
+export type ActionState = "open" | "done" | "ignored";
+
+/** One open action. Carries no document body — only a document_id, so the
+ * amount of personal data sitting in any proxy or cache along this path stays
+ * at a one-line summary (plan Task 8). */
+export interface ActionItem {
+  identity_key: string;
+  document_id: string;
+  thread_key: string;
+  kind: ActionKind;
+  summary: string;
+  counterpart_name: string;
+  due_at: string | null;
+  detected_by: ActionDetectedBy;
+  confidence: number;
+  observed_at: string;
+  state: ActionState;
+}
+
+export interface ActionsResponse {
+  actions: ActionItem[];
+  count: number;
+  /** True when the page came back exactly full — there may be more rows
+   * behind it. Without this a client cannot tell "50 actions" from "at least
+   * 50 actions". */
+  truncated: boolean;
+}
+
+/** Filter arguments for listActions. `counterpart` is a person's name and is
+ * therefore never written into the page URL (see /actions page). */
+export interface ActionListParams {
+  kinds?: ActionKind[];
+  counterpart?: string;
+  dueBefore?: string;
+  minConfidence?: number;
+  sort?: "due" | "confidence";
+  limit?: number;
+  includeArchived?: boolean;
+}
+
+/** One briefing sentence with the evidence that justifies it. document_ids is
+ * never empty: a sentence the server could not tie to a real document is
+ * discarded before it reaches here (spec §7.3). */
+export interface BriefingSentence {
+  text: string;
+  document_ids: string[];
+  identity_keys: string[];
+}
+
+export interface BriefingResponse {
+  sentences: BriefingSentence[];
+  /** True when every model sentence failed validation and the response fell
+   * back to a deterministic aggregate. */
+  degraded: boolean;
+  /** How many model sentences were thrown away for lacking evidence. Shown to
+   * the user as a trust signal, not as debug output. */
+  dropped_count: number;
+  action_count: number;
+  cached: boolean;
+  generated_at: string;
+}


### PR DESCRIPTION
## 개요

추출 파이프라인이 만든 actions(875건)를 조회·처리하는 API/화면과, "지금 뭘 해야 하는지"를 근거 문서 강제 첨부 방식으로 요약하는 브리핑 기능을 추가한다.

## 설계 요약

- **액션 조회/상태 변경**: 상태는 `actions` 테이블이 아니라 `action_status`에 `identity_key`로 붙는다. 재추출로 `actions` 행이 새로 만들어져도 사용자의 완료/무시 판단이 살아남는다. 상태 변경은 SQL 레벨에서 멱등.
- **브리핑**: 입력 해시 기반 캐시 + 모든 문장에 근거 document id를 강제한다. 근거 없는 문장은 폐기하고 폐기 수를 `dropped_count`로 응답에 노출한다. 전부 폐기되면 `degraded` 폴백을 내되, 그 폴백 문장도 근거를 갖는다.
- `llm.TruncatedError` 처리 — 잘린 LLM 응답을 정상 응답으로 취급하지 않는다.
- 로그에 LLM 원본 응답·액션 요약·상대방 이름을 남기지 않는다 (#194 규약 준수).
- 웹: `/actions` 화면(액션 목록 + 브리핑 패널), BFF 프록시 3종 (`/api/actions`, `/api/actions/[key]/status`, `/api/briefing`).
- 기능 플래그 3종(액션 API, 브리핑, 관련 LLM 기능) 전부 기본 off. `BRIEFING_ENABLED` 단독으로는 켜지지 않는다 — `ACTIONS_API_ENABLED` + LLM 활성이 전제.
- collector의 `llm.Config`에 Thinking 배선 추가 (Closes #204).

## 검증

- lint / type-check 통과
- 기존 유닛테스트 + 신규 유닛테스트(스토어/API/브리핑 각 계층) 통과
- 프로덕션 빌드 통과, 라우트 등록 확인

## 미검증 항목

**브라우저 렌더 전무.** `web/src/proxy.ts`가 fail-closed라 Access 설정 없이는 503이고, 로컬 백엔드도 준비하지 않았다. 확인된 것은 lint·type-check·기존 유닛테스트·프로덕션 빌드와 라우트 등록뿐이다.

미검증 목록:
- `/actions` 화면 렌더와 카드 레이아웃
- 모바일 폭에서 버튼 가림 여부
- 완료 버튼 → 카드 제거 → 새로고침 후 상태 유지
- 실패 시 롤백과 인라인 재시도
- 브리핑 문단 렌더와 위첨자 각주 링크
- `degraded` 배지 · `dropped_count` 표시 · `캐시됨` 배지
- BFF 프록시 업스트림 왕복
- 필터 URL 복원
- 다크모드 대비

실 DB end-to-end(`/api/v1/actions` 200 확인)도 미검증. 스토어 테스트는 `TEST_DATABASE_URL`이 없으면 SKIP 되므로 **CI 그린이 SQL 검증을 뜻하지 않는다.**

## 알려진 위험

- 상태 변경 404가 "플래그 off"와 "액션 없음"을 구분하지 않는다.
- 브리핑 실패를 화면에서 조용히 삼킨다(패널만 숨김). 서버 로그로만 감지된다.
- `counterpart_entity_id` NULL 비율 미측정. 높으면 상대방 필터가 무용해진다.
- `LLM_MODEL` 미설정 시 캐시 키의 모델명이 상수가 되어, 모델만 바꾸면 프로세스 재시작 전까지 캐시가 무효화되지 않는다.

## 배포 후 확인사항

- 플래그 3종은 기본 off다. 켜는 것은 별도 조작이며 `ACTIONS_API_ENABLED=true` 없이는 브리핑도 켜지지 않는다.
- 켠 뒤 `counterpart_entity_id` NULL 비율을 실측할 것.
- Task 8의 로그 감사(액션 요약·상대방 이름이 로그에 없는지)를 프로덕션 로그로 수행할 것.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>