### PR TITLE
fix(actions): 액션 카드 구분 불가 + 브리핑 타임아웃 수정

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -130,3 +130,21 @@ ACTIONS_API_ENABLED=false
 BRIEFING_ENABLED=false
 # 브리핑 한 번에 반영할 최대 open action 개수
 BRIEFING_MAX_ACTIONS=40
+# 브리핑 한 번의 제한 시간(초). 기본 120.
+# 이전에는 코드에 30초가 박혀 있었고, 실제 LLM 호출이 그보다 오래 걸려
+# 매 요청이 degraded=true(집계 전용 폴백, 문장 1개)로 떨어졌다.
+# 0/음수/잘못된 값은 기본값으로 대체된다(무제한 설정은 없다).
+BRIEFING_TIMEOUT_SECONDS=120
+
+# --- 근거 단위 피드백 (Part D) ---
+# 기본 false: 라우트가 아예 등록되지 않는 것(404)이 롤백 수단이다.
+# 참값 표기: 1 / true / yes / on (대소문자 무시)
+FEEDBACK_EVIDENCE_ENABLED=false
+
+# --- HTTP 서버 ---
+# 응답 쓰기 제한 시간(초). 기본 90. 느린 클라이언트가 연결을 붙잡는 것을
+# 막는 안전장치이므로 유한하게 유지한다(0/음수는 기본값으로 대체).
+# 브리핑은 요청마다 자기 write deadline 을 따로 연장하므로 이 값을
+# BRIEFING_TIMEOUT_SECONDS 에 맞춰 올릴 필요는 없다.
+# 반드시 ASK_TIMEOUT_SECONDS(기본 60) 보다 커야 /ask SSE 응답이 잘리지 않는다.
+HTTP_WRITE_TIMEOUT_SECONDS=90

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -161,6 +161,11 @@ func run() error {
 	actionStore := store.NewActionQueryStore(pg)
 	srv = wireActionsAndBriefing(srv, cfg, actionStore, actionStore, llmClient.Enabled())
 
+	// --- Per-evidence feedback (Part D, feature-flagged off) ---
+	// The votes live in the same feedback store as the existing answer-level
+	// feedback, so no new connection or store is introduced here.
+	srv = wireEvidenceFeedback(srv, cfg, feedbackStore)
+
 	// --- Graph read API (Part B, optional) ---
 	// Wired only when both NEO4J_URI and NEO4J_PASSWORD are present. A
 	// connection failure logs a warning and leaves the graph routes
@@ -181,11 +186,27 @@ func run() error {
 		}
 	}
 
+	// WriteTimeout is the slow-client guard, so it stays finite and is NOT
+	// sized for the slowest endpoint. It is sized for the slowest ordinary
+	// one — /ask (ASK_TIMEOUT_SECONDS, default 60s, streamed as SSE) and a
+	// cold-start /search, whose first query after a container restart has been
+	// measured past the previous hardcoded 30s (issue #195, where that
+	// deadline turned a slow search into an empty response). The briefing,
+	// which can legitimately run for minutes, extends its own write deadline
+	// per request instead (internal/api/briefing.go), so this value does not
+	// have to grow with BRIEFING_TIMEOUT_SECONDS.
+	if writeTimeout := cfg.HTTPWriteTimeout; writeTimeout <= time.Duration(cfg.AskTimeoutSeconds)*time.Second {
+		slog.Warn("HTTP_WRITE_TIMEOUT_SECONDS is not above ASK_TIMEOUT_SECONDS — /ask responses may be truncated mid-stream",
+			"http_write_timeout", writeTimeout.String(),
+			"ask_timeout_seconds", cfg.AskTimeoutSeconds,
+		)
+	}
+
 	httpServer := &http.Server{
 		Addr:         ":" + cfg.Port,
 		Handler:      srv.Handler(),
 		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		WriteTimeout: cfg.HTTPWriteTimeout,
 		IdleTimeout:  60 * time.Second,
 	}
 
@@ -242,6 +263,30 @@ func wireActionsAndBriefing(srv *api.Server, cfg *config.Config, lister api.Acti
 		return srv
 	}
 	return srv.WithBriefing(briefing.NewCache(briefingCacheSize), cfg.BriefingMaxActions)
+}
+
+// wireEvidenceFeedback conditionally registers POST /api/v1/feedback/evidence
+// (Part D). Like wireActionsAndBriefing it is a pure function so the on/off
+// decision is unit-testable without a live Postgres connection.
+//
+// The flag defaults to false: an unset FEEDBACK_EVIDENCE_ENABLED leaves the
+// route out of the router entirely (404), which is the rollback mechanism.
+// A nil voter is also treated as "off" — turning the flag on without a store
+// must not register a route whose only possible outcome is a nil-pointer
+// panic.
+//
+// The api handler re-checks the same environment variable per request, so
+// this wiring is necessary but not sufficient to expose the endpoint; both
+// layers read the same truthy set (see config.envFlag).
+func wireEvidenceFeedback(srv *api.Server, cfg *config.Config, voter api.EvidenceVoter) *api.Server {
+	if !cfg.FeedbackEvidenceEnabled {
+		return srv
+	}
+	if voter == nil {
+		slog.Warn("evidence feedback disabled — no feedback store available despite FEEDBACK_EVIDENCE_ENABLED=true")
+		return srv
+	}
+	return srv.WithEvidenceFeedback(voter)
 }
 
 // migrationsPath returns the path to the migrations directory.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/baekenough/second-brain/internal/api"
 	"github.com/baekenough/second-brain/internal/config"
@@ -127,5 +129,86 @@ func TestWireActionsAndBriefing_LLMDisabledSkipsBriefing(t *testing.T) {
 	}
 	if code := getStatus(t, srv, http.MethodGet, "/api/v1/briefing"); code != http.StatusNotFound {
 		t.Errorf("GET /api/v1/briefing = %d, want 404 when the LLM client is not configured, even with BRIEFING_ENABLED=true", code)
+	}
+}
+
+// stubEvidenceVoter is a minimal api.EvidenceVoter fake. As with
+// stubActionStore, these tests assert route existence, not behaviour.
+type stubEvidenceVoter struct{}
+
+func (stubEvidenceVoter) UpsertEvidence(_ context.Context, _ store.EvidenceVote) (int64, int16, error) {
+	return 1, 1, nil
+}
+
+func postStatus(t *testing.T, srv *api.Server, path, body string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	return rr.Code
+}
+
+// TestWireEvidenceFeedback_DisabledByDefault pins the rollback story for
+// Part D: with FEEDBACK_EVIDENCE_ENABLED unset the route is never registered,
+// so the endpoint answers 404 rather than reaching a handler with a live
+// store behind it.
+func TestWireEvidenceFeedback_DisabledByDefault(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "")
+	cfg := &config.Config{} // FeedbackEvidenceEnabled == false
+
+	srv := wireEvidenceFeedback(newWiringTestServer(nil), cfg, stubEvidenceVoter{})
+
+	if code := postStatus(t, srv, "/api/v1/feedback/evidence", `{}`); code != http.StatusNotFound {
+		t.Errorf("POST /api/v1/feedback/evidence = %d, want 404 when FEEDBACK_EVIDENCE_ENABLED is unset", code)
+	}
+}
+
+// TestWireEvidenceFeedback_Enabled verifies the route is registered when the
+// flag is on. A registered route rejects an invalid body with 400; the
+// assertion is only "not 404", since 404 is what an unregistered route gives.
+func TestWireEvidenceFeedback_Enabled(t *testing.T) {
+	// The handler re-checks the same env var per request, so the wiring flag
+	// alone is not enough to observe the route.
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "true")
+	cfg := &config.Config{FeedbackEvidenceEnabled: true}
+
+	srv := wireEvidenceFeedback(newWiringTestServer(nil), cfg, stubEvidenceVoter{})
+
+	code := postStatus(t, srv, "/api/v1/feedback/evidence", `{`)
+	if code == http.StatusNotFound {
+		t.Errorf("POST /api/v1/feedback/evidence = 404, want the route registered when FEEDBACK_EVIDENCE_ENABLED=true")
+	}
+	if code != http.StatusBadRequest {
+		t.Errorf("POST /api/v1/feedback/evidence with a malformed body = %d, want 400", code)
+	}
+}
+
+// TestWireEvidenceFeedback_NilVoterStaysUnregistered guards the nil-store
+// case: an operator turning the flag on without a store must not produce a
+// route that can only panic.
+func TestWireEvidenceFeedback_NilVoterStaysUnregistered(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "true")
+	cfg := &config.Config{FeedbackEvidenceEnabled: true}
+
+	srv := wireEvidenceFeedback(newWiringTestServer(nil), cfg, nil)
+
+	if code := postStatus(t, srv, "/api/v1/feedback/evidence", `{}`); code != http.StatusNotFound {
+		t.Errorf("POST /api/v1/feedback/evidence = %d, want 404 when no evidence store is available", code)
+	}
+}
+
+// TestHTTPServerWriteTimeout_CoversAskAndSearch documents the relationship
+// the deployment depends on: the global write deadline must outlast the
+// slowest non-briefing request path (/ask, and a cold-start /search — see
+// issue #195), otherwise the response is truncated at the socket with a 200
+// already on the wire.
+func TestHTTPServerWriteTimeout_CoversAskAndSearch(t *testing.T) {
+	cfg := &config.Config{
+		HTTPWriteTimeout:  90 * time.Second,
+		AskTimeoutSeconds: 60,
+	}
+	if cfg.HTTPWriteTimeout <= time.Duration(cfg.AskTimeoutSeconds)*time.Second {
+		t.Fatalf("HTTPWriteTimeout %v must exceed the ask timeout %ds", cfg.HTTPWriteTimeout, cfg.AskTimeoutSeconds)
 	}
 }

--- a/internal/action/counterpart.go
+++ b/internal/action/counterpart.go
@@ -1,0 +1,97 @@
+package action
+
+import (
+	"net/mail"
+	"strings"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// CounterpartDisplay returns the label a HUMAN uses for the other side of a
+// conversation, together with the entities.type it should be filed under.
+//
+// This is deliberately NOT the same string as CounterpartIdentity: that one
+// feeds identity_key and must therefore stay byte-stable forever (it is the
+// raw From header, the contact_name, or a phone-number hash). This one is
+// rendered on an action card and stored in entities.name, so it prefers the
+// display name over the address and never returns a hash — a hash is not
+// something a user can act on.
+//
+// ok=false means "there is no label worth registering": an unnamed thread
+// whose only handle is a hashed number, or a source type that is not a
+// conversation. Callers must leave counterpart_entity_id NULL in that case
+// rather than inventing a placeholder entity — one shared "unknown" row that
+// every unnamed thread points at would merge unrelated callers in the entity
+// graph and make the /actions counterpart filter lie.
+//
+// Privacy note for the number fallback: metadata carries "number" only when
+// phone-number hashing is disabled (issue #164). With hashing enabled the key
+// is absent, so this function returns ok=false and no raw number ever reaches
+// the entities table — the policy flag is respected transitively, without this
+// package needing to read config.
+func CounterpartDisplay(doc *model.Document) (name string, entityType model.EntityType, ok bool) {
+	if doc == nil {
+		return "", "", false
+	}
+	switch doc.SourceType {
+	case model.SourceGmail:
+		display := displayNameFromAddressHeader(metadataString(doc, "from"))
+		if display == "" {
+			return "", "", false
+		}
+		return display, model.EntityTypePerson, true
+	case model.SourceSMS, model.SourceCallLog, model.SourceCallTranscript:
+		if contact := strings.TrimSpace(metadataString(doc, "contact_name")); contact != "" {
+			return contact, model.EntityTypePerson, true
+		}
+		// An unsaved number is still a handle the user can act on, but it is
+		// typed OTHER: a bare number must never dedup into the PERSON
+		// namespace an LLM-extracted name lives in.
+		if number := strings.TrimSpace(metadataString(doc, "number")); number != "" {
+			return number, model.EntityTypeOther, true
+		}
+		return "", "", false
+	default:
+		return "", "", false
+	}
+}
+
+// metadataString reads a string-valued metadata key, tolerating both a nil
+// map (documents.metadata is nullable JSONB) and a non-string value.
+func metadataString(doc *model.Document, key string) string {
+	if doc.Metadata == nil {
+		return ""
+	}
+	s, _ := doc.Metadata[key].(string)
+	return s
+}
+
+// displayNameFromAddressHeader extracts the human-facing part of an RFC 5322
+// From header: the display name when present, the bare address otherwise.
+// Returns "" for a blank or unusable header.
+//
+// mail.ParseAddress handles the quoted and RFC 2047-encoded forms; the manual
+// fallback covers headers it rejects outright (multiple mailboxes, unquoted
+// commas, mangled encodings), which are common enough in a real mailbox that
+// giving up on them would put the address-less "" label back on the card.
+func displayNameFromAddressHeader(from string) string {
+	from = strings.TrimSpace(from)
+	if from == "" {
+		return ""
+	}
+	if addr, err := mail.ParseAddress(from); err == nil {
+		if name := strings.TrimSpace(addr.Name); name != "" {
+			return name
+		}
+		return strings.TrimSpace(addr.Address)
+	}
+	if open := strings.LastIndex(from, "<"); open >= 0 {
+		if end := strings.Index(from[open:], ">"); end > 1 {
+			if name := strings.Trim(strings.TrimSpace(from[:open]), `"'`); name != "" {
+				return strings.TrimSpace(name)
+			}
+			return strings.TrimSpace(from[open+1 : open+end])
+		}
+	}
+	return strings.Trim(from, `"'`)
+}

--- a/internal/action/counterpart_test.go
+++ b/internal/action/counterpart_test.go
@@ -1,0 +1,140 @@
+package action_test
+
+import (
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/action"
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// The counterpart tests below use obviously fictional tokens only
+// (example.test is the RFC 2606 reserved TLD, and 010-0000-0000 is not an
+// assignable Korean number) — no real contact of the user's ever appears in
+// this repository.
+
+// TestCounterpartDisplay_GmailEncodedDisplayName pins the gmail path: the
+// From header is an RFC 5322 mailbox, and the part a human recognises is the
+// display name, not the address. Without this, every gmail action card would
+// be labelled with a raw address.
+func TestCounterpartDisplay_GmailEncodedDisplayName(t *testing.T) {
+	t.Parallel()
+	doc := &model.Document{
+		SourceType: model.SourceGmail,
+		Metadata:   map[string]any{"from": `"테스트발신자" <dummy@example.test>`},
+	}
+	name, typ, ok := action.CounterpartDisplay(doc)
+	if !ok {
+		t.Fatal("ok = false, want true (a From header with a display name is resolvable)")
+	}
+	if name != "테스트발신자" {
+		t.Errorf("name = %q, want %q (display name preferred over the address)", name, "테스트발신자")
+	}
+	if typ != model.EntityTypePerson {
+		t.Errorf("type = %q, want %q", typ, model.EntityTypePerson)
+	}
+}
+
+// TestCounterpartDisplay_GmailBareAddress covers the common case of a From
+// header carrying no display name: the address itself is the only label
+// available, and it is still far better than nothing on the card.
+func TestCounterpartDisplay_GmailBareAddress(t *testing.T) {
+	t.Parallel()
+	doc := &model.Document{
+		SourceType: model.SourceGmail,
+		Metadata:   map[string]any{"from": "dummy@example.test"},
+	}
+	name, typ, ok := action.CounterpartDisplay(doc)
+	if !ok || name != "dummy@example.test" || typ != model.EntityTypePerson {
+		t.Errorf("got (%q, %q, %v), want (%q, %q, true)", name, typ, ok, "dummy@example.test", model.EntityTypePerson)
+	}
+}
+
+// TestCounterpartDisplay_GmailEmptyFrom_NotResolvable guards the degenerate
+// header: an empty From must not create an entity named "".
+func TestCounterpartDisplay_GmailEmptyFrom_NotResolvable(t *testing.T) {
+	t.Parallel()
+	doc := &model.Document{SourceType: model.SourceGmail, Metadata: map[string]any{"from": "  "}}
+	if name, _, ok := action.CounterpartDisplay(doc); ok {
+		t.Errorf("ok = true (name %q), want false for a blank From header", name)
+	}
+}
+
+// TestCounterpartDisplay_SMSContactName is the highest-volume path: the phone
+// already resolved the number to a contact, so that name is what the user
+// recognises and what must dedup against LLM-extracted PERSON entities.
+func TestCounterpartDisplay_SMSContactName(t *testing.T) {
+	t.Parallel()
+	for _, src := range []model.SourceType{model.SourceSMS, model.SourceCallLog, model.SourceCallTranscript} {
+		doc := &model.Document{
+			SourceType: src,
+			Metadata:   map[string]any{"contact_name": "테스트연락처", "number": "010-0000-0000"},
+		}
+		name, typ, ok := action.CounterpartDisplay(doc)
+		if !ok || name != "테스트연락처" || typ != model.EntityTypePerson {
+			t.Errorf("%s: got (%q, %q, %v), want (%q, %q, true)", src, name, typ, ok, "테스트연락처", model.EntityTypePerson)
+		}
+	}
+}
+
+// TestCounterpartDisplay_SMSNumberOnly_UsesNumberAsOther covers the unsaved
+// contact: the number is the only handle the user has, so it becomes the
+// entity label — but typed OTHER, not PERSON, so a bare number can never be
+// silently merged with a real person's name in the entity graph.
+//
+// Note the policy coupling: metadata carries "number" ONLY when phone-number
+// hashing is disabled (issue #164). With hashing on, this branch never fires,
+// so no raw number reaches the entities table.
+func TestCounterpartDisplay_SMSNumberOnly_UsesNumberAsOther(t *testing.T) {
+	t.Parallel()
+	const number = "010-0000-0000"
+	doc := &model.Document{
+		SourceType: model.SourceSMS,
+		Metadata:   map[string]any{"contact_name": "", "number": number},
+	}
+	name, typ, ok := action.CounterpartDisplay(doc)
+	if !ok {
+		t.Fatal("ok = false, want true (an unsaved number is still a usable label)")
+	}
+	if name != number {
+		t.Errorf("name = %q, want %q", name, number)
+	}
+	if name == action.HashPhoneNumber(number) {
+		t.Error("name is the thread-key hash; a hash is not a label a human can act on")
+	}
+	if typ != model.EntityTypeOther {
+		t.Errorf("type = %q, want %q (a bare number is not a PERSON entity)", typ, model.EntityTypeOther)
+	}
+}
+
+// TestCounterpartDisplay_NoIdentifiers_NotResolvable pins the "unknown"
+// counterpart: CounterpartIdentity returns the literal "unknown" so the
+// identity_key stays computable, but there is nothing to name an entity
+// after — resolving one would create a shared junk row every unnamed thread
+// points at.
+func TestCounterpartDisplay_NoIdentifiers_NotResolvable(t *testing.T) {
+	t.Parallel()
+	doc := &model.Document{SourceType: model.SourceSMS, Metadata: map[string]any{"direction": "received"}}
+	if name, _, ok := action.CounterpartDisplay(doc); ok {
+		t.Errorf("ok = true (name %q), want false when neither contact_name nor number exists", name)
+	}
+}
+
+// TestCounterpartDisplay_UnsupportedSource_NotResolvable mirrors
+// CounterpartIdentity's contract for source types outside the four
+// conversation sources.
+func TestCounterpartDisplay_UnsupportedSource_NotResolvable(t *testing.T) {
+	t.Parallel()
+	doc := &model.Document{SourceType: model.SourceFilesystem, Metadata: map[string]any{"contact_name": "테스트연락처"}}
+	if _, _, ok := action.CounterpartDisplay(doc); ok {
+		t.Error("ok = true, want false for a non-conversation source type")
+	}
+}
+
+// TestCounterpartDisplay_NilMetadata_DoesNotPanic — the worker builds the
+// document from a JSONB column that can legitimately be NULL.
+func TestCounterpartDisplay_NilMetadata_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+	if _, _, ok := action.CounterpartDisplay(&model.Document{SourceType: model.SourceSMS}); ok {
+		t.Error("ok = true, want false for a document with no metadata")
+	}
+}

--- a/internal/action/summary.go
+++ b/internal/action/summary.go
@@ -1,0 +1,156 @@
+package action
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/timeutil"
+)
+
+// maxAwaitingSummaryRunes is the 80-character budget for a generated
+// awaiting_my_reply summary. It mirrors maxNormalizedSummaryLen's 80, but
+// counts RUNES rather than bytes: that constant bounds a string on its way
+// into a hash (where a byte cut is harmless), whereas this one bounds a string
+// on its way to a screen (where cutting a Korean syllable in half is not).
+const maxAwaitingSummaryRunes = 80
+
+// ellipsis marks a truncated fragment. One rune, so it costs one unit of the
+// budget above.
+const ellipsis = "…"
+
+// AwaitingReplySummary renders the one line an awaiting_my_reply action card
+// shows. It answers the two questions a fixed template could not: WHO is
+// waiting, and HOW LONG they have been waiting.
+//
+//	{상대방} · {채널}["{메일 제목}"] · {경과} 미응답
+//
+// counterpart is CounterpartDisplay's label (may be empty). now is injected so
+// the caller — not this package — decides the clock, which keeps the output
+// deterministic under test.
+//
+// Elapsed time is measured in KOREAN calendar days: the containers run as UTC
+// while the user reads the card in Korea, so a message that arrived at
+// 2026-08-17T23:00Z must read "오늘" (it is already the 18th in Seoul), not
+// "어제".
+//
+// This text is free to change on every tick. identity_key is NOT affected:
+// NormalizeSummary discards the summary entirely for this kind, precisely so
+// the structural candidate and the LLM candidate for one real event converge —
+// see its doc comment. Nothing here may be moved into the key.
+//
+// The mail subject is the only document-derived text quoted. The message body
+// is never included: this string is rendered in a list view and flows into
+// briefings, so it must stay at the "which conversation" level of detail.
+func AwaitingReplySummary(doc *model.Document, counterpart string, now time.Time) string {
+	who := strings.TrimSpace(counterpart)
+	if who == "" {
+		// The thread is still worth surfacing — the user can open it — so a
+		// missing label degrades to a marker rather than an empty card.
+		who = "상대방 미상"
+	}
+	who = collapseWhitespace(who)
+
+	tail := " · " + elapsedPhrase(doc, now)
+	budget := maxAwaitingSummaryRunes - utf8.RuneCountInString(tail)
+
+	head := who + " · " + channelLabel(doc)
+	if subject := collapseWhitespace(quotableSubject(doc)); subject != "" {
+		// 2 runes for the quotes + 1 for the leading space; only quote a
+		// subject if a useful fragment of it survives the budget.
+		const quoteOverhead = 3
+		room := budget - utf8.RuneCountInString(head) - quoteOverhead
+		if room >= 4 {
+			head += ` "` + clampRunes(subject, room) + `"`
+		}
+	}
+	return clampRunes(head, budget) + tail
+}
+
+// channelLabel names the medium, because "부재중 전화" and "문자" call for
+// different responses and the user decides which card to act on by scanning
+// this word.
+func channelLabel(doc *model.Document) string {
+	switch doc.SourceType {
+	case model.SourceGmail:
+		return "메일"
+	case model.SourceSMS:
+		return "문자"
+	case model.SourceCallTranscript:
+		return "통화 녹취"
+	case model.SourceCallLog:
+		switch metadataString(doc, "direction") {
+		case "missed":
+			return "부재중 전화"
+		case "voicemail":
+			return "음성 메시지"
+		default:
+			return "통화"
+		}
+	default:
+		return "메시지"
+	}
+}
+
+// quotableSubject returns the document title when it is a HUMAN-written
+// subject line. Only gmail qualifies: the sms/call collectors synthesise their
+// titles ("SMS received {contact}", "{direction} 통화 {contact}"), so quoting
+// one would repeat the counterpart and the channel the card already shows.
+func quotableSubject(doc *model.Document) string {
+	if doc.SourceType != model.SourceGmail {
+		return ""
+	}
+	return strings.TrimSpace(doc.Title)
+}
+
+// elapsedPhrase renders the age of the unanswered message. A document with no
+// event time still gets a card — just without an age.
+func elapsedPhrase(doc *model.Document, now time.Time) string {
+	if doc.OccurredAt == nil || doc.OccurredAt.IsZero() {
+		return "미응답"
+	}
+	switch days := koreanCalendarDaysBetween(*doc.OccurredAt, now); {
+	case days <= 0:
+		return "오늘부터 미응답"
+	case days == 1:
+		return "어제부터 미응답"
+	default:
+		return fmt.Sprintf("%d일째 미응답", days)
+	}
+}
+
+// koreanCalendarDaysBetween counts midnight boundaries crossed in Asia/Seoul,
+// not 24-hour periods: a message from 23:50 last night is "어제", however few
+// hours ago that was. Korea observes no DST, so the subtraction is exact.
+func koreanCalendarDaysBetween(from, to time.Time) int {
+	kst := timeutil.KST()
+	f, t := from.In(kst), to.In(kst)
+	fMidnight := time.Date(f.Year(), f.Month(), f.Day(), 0, 0, 0, 0, kst)
+	tMidnight := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, kst)
+	return int(tMidnight.Sub(fMidnight) / (24 * time.Hour))
+}
+
+// clampRunes truncates on a rune boundary and marks the cut, so a clipped
+// Korean subject degrades to readable text rather than to replacement
+// characters.
+func clampRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max == 1 {
+		return ellipsis
+	}
+	return strings.TrimRight(string(runes[:max-1]), " ") + ellipsis
+}
+
+// collapseWhitespace folds newlines and runs of spaces (a mail subject can
+// legally contain both) into single spaces so the card stays one line.
+func collapseWhitespace(s string) string {
+	return strings.TrimSpace(whitespaceRe.ReplaceAllString(s, " "))
+}

--- a/internal/action/summary_test.go
+++ b/internal/action/summary_test.go
@@ -1,0 +1,240 @@
+package action_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/baekenough/second-brain/internal/action"
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// legacyConstantSummary is the fixed string every awaiting_my_reply action
+// carried before this change. 434 rows shared it, which made the /actions
+// screen a list of 50 identical cards. No generated summary may equal it.
+const legacyConstantSummary = "마지막 메시지 이후 응답 없음"
+
+// All timestamps below are constructed in UTC on purpose: the server and
+// collector containers run as Etc/UTC while the user is in Korea, so a test
+// that leaned on the developer machine's local zone would pass here and
+// mis-render in production. The elapsed-day arithmetic under test must
+// resolve calendar days in KST regardless of the process zone.
+
+func mustDoc(src model.SourceType, title string, meta map[string]any, occurred time.Time) *model.Document {
+	d := &model.Document{SourceType: src, Title: title, Metadata: meta}
+	if !occurred.IsZero() {
+		t := occurred
+		d.OccurredAt = &t
+	}
+	return d
+}
+
+// TestAwaitingReplySummary_DistinctPerThread is the headline regression: the
+// whole defect was 50 cards reading identically. Distinct counterparts,
+// channels and ages must produce distinct text.
+func TestAwaitingReplySummary_DistinctPerThread(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC) // 12:00 KST
+
+	cases := []struct {
+		counterpart string
+		doc         *model.Document
+	}{
+		{"테스트발신자A", mustDoc(model.SourceGmail, "8월 정산 자료 요청", map[string]any{"from": "a@example.test"}, now.AddDate(0, 0, -3))},
+		{"테스트발신자B", mustDoc(model.SourceGmail, "계약서 검토 부탁", map[string]any{"from": "b@example.test"}, now.AddDate(0, 0, -3))},
+		{"테스트연락처C", mustDoc(model.SourceSMS, "SMS received C", map[string]any{"direction": "received"}, now.AddDate(0, 0, -1))},
+		{"테스트연락처C", mustDoc(model.SourceCallLog, "missed 통화 C", map[string]any{"direction": "missed"}, now.AddDate(0, 0, -1))},
+		{"테스트연락처D", mustDoc(model.SourceCallTranscript, "incoming 통화 D", map[string]any{"direction": "incoming"}, now.AddDate(0, 0, -9))},
+		{"테스트연락처D", mustDoc(model.SourceSMS, "SMS received D", map[string]any{"direction": "received"}, now)},
+	}
+
+	seen := make(map[string][]int, len(cases))
+	for i, c := range cases {
+		got := action.AwaitingReplySummary(c.doc, c.counterpart, now)
+		if got == legacyConstantSummary {
+			t.Errorf("case %d produced the legacy constant summary %q", i, got)
+		}
+		if got == "" {
+			t.Errorf("case %d produced an empty summary", i)
+		}
+		seen[got] = append(seen[got], i)
+	}
+	for text, idxs := range seen {
+		if len(idxs) > 1 {
+			t.Errorf("summary %q was produced by %d distinct threads (cases %v); cards must be distinguishable", text, len(idxs), idxs)
+		}
+	}
+}
+
+// TestAwaitingReplySummary_WithinRuneBudget pins the 80-character budget that
+// mirrors identity.go's maxNormalizedSummaryLen. Truncation must also be
+// rune-safe: slicing a Korean string by bytes produces replacement garbage on
+// the card.
+func TestAwaitingReplySummary_WithinRuneBudget(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+
+	longSubject := strings.Repeat("가나다라마바사아자차", 30) // 300 runes
+	longCounterpart := strings.Repeat("테스트발신자", 20) // 120 runes
+
+	for _, tc := range []struct {
+		name        string
+		counterpart string
+		doc         *model.Document
+	}{
+		{"long subject", "테스트발신자", mustDoc(model.SourceGmail, longSubject, map[string]any{"from": "a@example.test"}, now.AddDate(0, 0, -3))},
+		{"long counterpart", longCounterpart, mustDoc(model.SourceGmail, longSubject, map[string]any{"from": "a@example.test"}, now.AddDate(0, 0, -3))},
+		{"long counterpart, no subject", longCounterpart, mustDoc(model.SourceSMS, "", map[string]any{"direction": "received"}, now.AddDate(0, 0, -3))},
+	} {
+		got := action.AwaitingReplySummary(tc.doc, tc.counterpart, now)
+		if n := utf8.RuneCountInString(got); n > 80 {
+			t.Errorf("%s: summary is %d runes (%q), want <= 80", tc.name, n, got)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("%s: summary is not valid UTF-8: %q (byte-sliced a multi-byte rune?)", tc.name, got)
+		}
+	}
+}
+
+// TestAwaitingReplySummary_NamesCounterpartAndAge states the user-facing
+// contract directly: the card must answer "누구에게" and "얼마나 됐는지".
+func TestAwaitingReplySummary_NamesCounterpartAndAge(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC) // 12:00 KST
+	doc := mustDoc(model.SourceGmail, "8월 정산 자료 요청", map[string]any{"from": "a@example.test"}, now.AddDate(0, 0, -3))
+
+	got := action.AwaitingReplySummary(doc, "테스트발신자", now)
+	for _, want := range []string{"테스트발신자", "메일", "8월 정산 자료 요청", "3일째"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q does not contain %q", got, want)
+		}
+	}
+}
+
+// TestAwaitingReplySummary_ElapsedIsKSTCalendarDays uses the exact instant
+// pair that exposes the nine-hour trap: 2026-08-17T23:00Z is already
+// 2026-08-18 in Korea, so a message sent then is "오늘", not "어제", when the
+// user looks at 2026-08-18T01:00Z (10:00 KST).
+func TestAwaitingReplySummary_ElapsedIsKSTCalendarDays(t *testing.T) {
+	t.Parallel()
+	occurred := time.Date(2026, 8, 17, 23, 0, 0, 0, time.UTC) // 2026-08-18 08:00 KST
+	now := time.Date(2026, 8, 18, 1, 0, 0, 0, time.UTC)       // 2026-08-18 10:00 KST
+
+	got := action.AwaitingReplySummary(mustDoc(model.SourceSMS, "", map[string]any{"direction": "received"}, occurred), "테스트연락처", now)
+	if !strings.Contains(got, "오늘") {
+		t.Errorf("summary = %q, want it to report today (both instants fall on 2026-08-18 in KST)", got)
+	}
+
+	// The mirror case: 14:00Z on the 17th is 23:00 KST on the 17th — the
+	// previous Korean day.
+	yesterday := time.Date(2026, 8, 17, 14, 0, 0, 0, time.UTC)
+	got = action.AwaitingReplySummary(mustDoc(model.SourceSMS, "", map[string]any{"direction": "received"}, yesterday), "테스트연락처", now)
+	if !strings.Contains(got, "어제") {
+		t.Errorf("summary = %q, want it to report yesterday (2026-08-17 in KST)", got)
+	}
+}
+
+// TestAwaitingReplySummary_ChannelReflectsSource keeps the four conversation
+// sources visually distinguishable — "부재중 전화" and "문자" call for
+// different responses.
+func TestAwaitingReplySummary_ChannelReflectsSource(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		src       model.SourceType
+		direction string
+		want      string
+	}{
+		{model.SourceSMS, "received", "문자"},
+		{model.SourceCallLog, "missed", "부재중 전화"},
+		{model.SourceCallLog, "incoming", "통화"},
+		{model.SourceCallTranscript, "incoming", "통화 녹취"},
+		{model.SourceGmail, "", "메일"},
+	} {
+		doc := mustDoc(tc.src, "", map[string]any{"direction": tc.direction, "from": "a@example.test"}, now.AddDate(0, 0, -2))
+		got := action.AwaitingReplySummary(doc, "테스트연락처", now)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s/%s: summary = %q, want it to contain %q", tc.src, tc.direction, got, tc.want)
+		}
+	}
+}
+
+// TestAwaitingReplySummary_NeverLeaksBody is a privacy guard: the summary is
+// rendered in a list view and travels into briefings, so it may quote a mail
+// subject but never the message body.
+func TestAwaitingReplySummary_NeverLeaksBody(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+	doc := mustDoc(model.SourceSMS, "SMS received 테스트연락처", map[string]any{"direction": "received"}, now)
+	doc.Content = "계좌번호 0000-00-0000000 으로 보내주세요"
+
+	got := action.AwaitingReplySummary(doc, "테스트연락처", now)
+	if strings.Contains(got, "계좌번호") || strings.Contains(got, "0000-00-0000000") {
+		t.Errorf("summary %q leaked document content", got)
+	}
+	// The SMS/call title is a collector-generated label ("SMS received X"),
+	// not a human-written subject, so it must not be quoted either.
+	if strings.Contains(got, "SMS received") {
+		t.Errorf("summary %q quoted the synthetic SMS title", got)
+	}
+}
+
+// TestAwaitingReplySummary_UnknownOccurredAt degrades gracefully: a document
+// with no event time still gets a card naming the counterpart, just without
+// an age.
+func TestAwaitingReplySummary_UnknownOccurredAt(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+	doc := mustDoc(model.SourceSMS, "", map[string]any{"direction": "received"}, time.Time{})
+
+	got := action.AwaitingReplySummary(doc, "테스트연락처", now)
+	if !strings.Contains(got, "테스트연락처") || !strings.Contains(got, "미응답") {
+		t.Errorf("summary = %q, want counterpart + 미응답 even without an event time", got)
+	}
+	if got == legacyConstantSummary {
+		t.Errorf("summary fell back to the legacy constant %q", got)
+	}
+}
+
+// TestAwaitingReplySummary_UnknownCounterpart still produces a card rather
+// than an empty string — the thread exists and the user may want to open it.
+func TestAwaitingReplySummary_UnknownCounterpart(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+	doc := mustDoc(model.SourceSMS, "", map[string]any{"direction": "received"}, now.AddDate(0, 0, -5))
+
+	got := action.AwaitingReplySummary(doc, "", now)
+	if got == "" {
+		t.Fatal("summary is empty for an unnamed counterpart")
+	}
+	if !strings.Contains(got, "5일째") {
+		t.Errorf("summary = %q, want it to still report the age", got)
+	}
+}
+
+// TestAwaitingReplySummary_DoesNotAffectIdentityKey is the constraint this
+// change had to respect: NormalizeSummary returns "" for awaiting_my_reply
+// precisely so the structural and LLM candidates for one real event converge.
+// Enriching the text must not reintroduce a summary-dependent key.
+func TestAwaitingReplySummary_DoesNotAffectIdentityKey(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+	doc := mustDoc(model.SourceSMS, "", map[string]any{"direction": "received"}, now.AddDate(0, 0, -3))
+
+	today := action.AwaitingReplySummary(doc, "테스트연락처", now)
+	tomorrow := action.AwaitingReplySummary(doc, "테스트연락처", now.AddDate(0, 0, 1))
+	if today == tomorrow {
+		t.Fatal("summary did not change as the thread aged; the rest of this test would be vacuous")
+	}
+
+	kind := string(model.KindAwaitingMyReply)
+	keyToday := action.BuildIdentityKey("sms:테스트연락처", kind, "테스트연락처", today)
+	keyTomorrow := action.BuildIdentityKey("sms:테스트연락처", kind, "테스트연락처", tomorrow)
+	if keyToday != keyTomorrow {
+		t.Errorf("identity_key changed with the summary (%q vs %q); a user's done/ignored decision would be orphaned every day", keyToday, keyTomorrow)
+	}
+	if keyToday != action.BuildIdentityKey("sms:테스트연락처", kind, "테스트연락처", "") {
+		t.Error("identity_key no longer matches the empty-summary form the extraction worker computes")
+	}
+}

--- a/internal/api/briefing.go
+++ b/internal/api/briefing.go
@@ -2,19 +2,26 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/baekenough/second-brain/internal/briefing"
+	"github.com/baekenough/second-brain/internal/config"
 	"github.com/baekenough/second-brain/internal/store"
 )
 
-// briefingTimeout bounds one briefing request. On expiry briefing.Generate
-// degrades to the deterministic aggregate rather than failing the request: a
-// slow model must not turn into an error page over data the server already has.
-const briefingTimeout = 30 * time.Second
+// briefingWriteDeadlineMargin is added to the request timeout when this
+// handler extends its own socket write deadline (see briefingHandler).
+//
+// It covers the work that happens AFTER the context expires: briefing.Generate
+// falls back to the deterministic aggregate and the response is JSON-encoded
+// and written. Without the margin the write deadline and the context would
+// expire together and the degraded response — the whole point of the fallback
+// — would be the thing that gets truncated.
+const briefingWriteDeadlineMargin = 15 * time.Second
 
 type briefingResponse struct {
 	Sentences []briefing.Sentence `json:"sentences"`
@@ -57,7 +64,35 @@ const defaultBriefingMaxActions = 40
 // there is no way to know whether a cached briefing is still valid without it.
 // The LLM call is what the cache protects, not the query.
 func (s *Server) briefingHandler(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), briefingTimeout)
+	// Resolved per request from BRIEFING_TIMEOUT_SECONDS. This used to be a
+	// hardcoded 30s, which production latency exceeded on every call: the
+	// context expired mid-LLM-call, Generate degraded, and the endpoint
+	// returned 200 with degraded=true and a single sentence forever.
+	timeout := config.BriefingTimeout()
+
+	// The context bound above is useless on its own: http.Server.WriteTimeout
+	// puts a deadline on the socket that was armed when the request headers
+	// were read, so a briefing that legitimately runs longer than that global
+	// value gets its response cut off at the connection regardless of what
+	// this handler decides. Extending the deadline for THIS response only
+	// keeps the slow-client guard intact for every other route — raising the
+	// global WriteTimeout to fit the slowest endpoint would remove it for all
+	// of them.
+	//
+	// Failure is not fatal: without the extension the request still succeeds
+	// whenever it finishes inside the global WriteTimeout. errors.ErrUnsupported
+	// is the expected result under an httptest recorder and under any
+	// middleware that wraps the ResponseWriter without an Unwrap method, so it
+	// is logged at debug level; anything else is worth an operator's attention.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(timeout + briefingWriteDeadlineMargin)); err != nil {
+		if errors.Is(err, errors.ErrUnsupported) {
+			slog.Debug("briefing: write deadline not adjustable on this ResponseWriter", "error", err)
+		} else {
+			slog.Warn("briefing: could not extend the write deadline; a slow response may be truncated by the global WriteTimeout", "error", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
 
 	items, err := s.actionLister.ListOpenActions(ctx, store.ActionFilter{

--- a/internal/api/feedback_evidence.go
+++ b/internal/api/feedback_evidence.go
@@ -1,0 +1,165 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/baekenough/second-brain/internal/dataset"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// evidenceTracerName is the instrumentation scope for per-evidence feedback.
+// The tracer is looked up per call rather than cached at package init, because
+// the global provider is installed after package initialisation and a cached
+// tracer would be a permanent no-op.
+const evidenceTracerName = "github.com/baekenough/second-brain/internal/api/feedback_evidence"
+
+func evidenceTracer() oteltrace.Tracer { return otel.Tracer(evidenceTracerName) }
+
+// EvidenceVoter is the subset of store.FeedbackStore used by this handler.
+// It returns the row ID and the thumbs value the database settled on.
+type EvidenceVoter interface {
+	UpsertEvidence(ctx context.Context, v store.EvidenceVote) (int64, int16, error)
+}
+
+// EvidenceFeedbackRequest is the JSON body of POST /api/v1/feedback/evidence.
+//
+// Thumbs is a *int16 so that a missing field is distinguishable from an
+// explicit 0: 0 is a meaningful value here ("clear my vote"), and treating an
+// absent field as 0 would let a malformed client silently erase labels.
+type EvidenceFeedbackRequest struct {
+	ConversationID string `json:"conversation_id"`
+	Query          string `json:"query"`
+	DocumentID     string `json:"document_id"`
+	Thumbs         *int16 `json:"thumbs"`
+	Rank           int    `json:"rank"`
+	Layer          string `json:"layer"`
+}
+
+// EvidenceFeedbackResponse carries the vote state the server decided on.
+// The client renders this rather than its own optimistic guess, so that the
+// toggle rule lives in exactly one place.
+type EvidenceFeedbackResponse struct {
+	Thumbs int16 `json:"thumbs"`
+}
+
+// WithEvidenceFeedback wires the per-evidence feedback store. The
+// POST /api/v1/feedback/evidence route is registered only when this is called,
+// which is the rollback story: not calling it removes the endpoint entirely.
+func (s *Server) WithEvidenceFeedback(v EvidenceVoter) *Server {
+	s.evidenceVoter = v
+	return s
+}
+
+// feedbackEvidenceEnabled reports whether the feature flag is on.
+//
+// Read from the environment on each request rather than from
+// internal/config.Config: that file is under concurrent change, and this flag
+// has no other consumer. Default is OFF — an environment that says nothing
+// about this feature does not get it, so a deploy cannot switch it on by
+// arriving.
+func feedbackEvidenceEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("FEEDBACK_EVIDENCE_ENABLED"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// evidenceFeedbackHandler handles POST /api/v1/feedback/evidence.
+//
+// Authentication is not implemented here: /api/* is already behind the
+// Cloudflare Access JWT check in web/src/proxy.ts and, when API_KEY is set,
+// behind requireAPIKey in this router. The handler assumes an authenticated
+// caller.
+//
+// No user_id is recorded. This is a single-user system, so attaching an
+// identity to a relevance label buys nothing and stores one more personal
+// datum than necessary.
+func (s *Server) evidenceFeedbackHandler(w http.ResponseWriter, r *http.Request) {
+	// Flag check first, before reading the body: a disabled endpoint must be
+	// indistinguishable from an absent one, including in how much of the
+	// request it consumes.
+	if !feedbackEvidenceEnabled() {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	var req EvidenceFeedbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validation messages never quote the request. The query is the user's own
+	// words; the document ID identifies personal material. Both stay out of
+	// response bodies and out of logs.
+	if strings.TrimSpace(req.ConversationID) == "" {
+		writeError(w, http.StatusBadRequest, "conversation_id is required")
+		return
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		writeError(w, http.StatusBadRequest, "query is required")
+		return
+	}
+	if req.Thumbs == nil {
+		writeError(w, http.StatusBadRequest, "thumbs is required")
+		return
+	}
+	if *req.Thumbs < -1 || *req.Thumbs > 1 {
+		writeError(w, http.StatusBadRequest, "thumbs must be -1, 0, or 1")
+		return
+	}
+	// Parsed here rather than left to the database so that a malformed
+	// identifier is a 400 instead of a foreign-key violation dressed up as 500.
+	if _, err := uuid.Parse(req.DocumentID); err != nil {
+		writeError(w, http.StatusBadRequest, "document_id must be a UUID")
+		return
+	}
+
+	queryHash := dataset.QueryHash(req.Query)
+
+	ctx, span := evidenceTracer().Start(r.Context(), "feedback.evidence",
+		oteltrace.WithAttributes(
+			// query_hash, never the query itself: this span is exported to
+			// Langfuse and would otherwise carry the user's own speech.
+			attribute.String("feedback.query_hash", queryHash),
+			attribute.Int("feedback.thumbs", int(*req.Thumbs)),
+			attribute.Int("feedback.rank", req.Rank),
+			attribute.String("feedback.layer", req.Layer),
+			attribute.String("feedback.split", dataset.SplitOf(req.Query)),
+		))
+	defer span.End()
+
+	id, resolved, err := s.evidenceVoter.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID:  req.ConversationID,
+		Query:      req.Query,
+		DocumentID: req.DocumentID,
+		Thumbs:     *req.Thumbs,
+		// Rank is the card's position in the answer before layer grouping.
+		// Captured now because position bias cannot be corrected for later
+		// unless the position was recorded at the moment of the click.
+		Metadata: map[string]any{"rank": req.Rank, "layer": req.Layer},
+	})
+	if err != nil {
+		span.RecordError(err)
+		slog.Error("feedback evidence: upsert failed", "error", err, "query_hash", queryHash)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	span.SetAttributes(
+		attribute.Int64("feedback.id", id),
+		attribute.Int("feedback.resolved_thumbs", int(resolved)),
+	)
+
+	writeJSON(w, http.StatusOK, EvidenceFeedbackResponse{Thumbs: resolved})
+}

--- a/internal/api/feedback_evidence_test.go
+++ b/internal/api/feedback_evidence_test.go
@@ -1,0 +1,261 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/store"
+)
+
+// The stub keeps these tests off the database on purpose: what is under test
+// here is the HTTP contract. The SQL contract (idempotence, split, partial
+// index) is pinned against a real PostgreSQL in
+// internal/store/feedback_evidence_test.go.
+type stubEvidenceVoter struct {
+	calls    int
+	got      store.EvidenceVote
+	retThumb int16
+	err      error
+}
+
+func (s *stubEvidenceVoter) UpsertEvidence(_ context.Context, v store.EvidenceVote) (int64, int16, error) {
+	s.calls++
+	s.got = v
+	if s.err != nil {
+		return 0, 0, s.err
+	}
+	return 42, s.retThumb, nil
+}
+
+func newEvidenceTestServer(v EvidenceVoter) *Server {
+	return NewServer(nil, nil, nil, nil, nil, "", "").WithEvidenceFeedback(v)
+}
+
+// A syntactically valid but meaningless document UUID. No real document.
+const dummyEvidenceDocID = "11111111-2222-3333-4444-555555555555"
+
+func evidenceBody(t *testing.T, fields map[string]any) *strings.Reader {
+	t.Helper()
+	b, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return strings.NewReader(string(b))
+}
+
+func postEvidence(t *testing.T, srv *Server, body *strings.Reader) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/feedback/evidence", body)
+	req.Header.Set("Content-Type", "application/json")
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func validEvidenceFields() map[string]any {
+	return map[string]any{
+		"conversation_id": "dummy-conversation",
+		"query":           "dummy question text",
+		"document_id":     dummyEvidenceDocID,
+		"thumbs":          1,
+		"rank":            2,
+		"layer":           "observed",
+	}
+}
+
+// TestEvidenceHandler_DisabledReturns404 pins the rollout contract: with the
+// flag unset the endpoint behaves exactly as if it had never been written.
+// 404 rather than 501 — a disabled feature should not announce itself.
+func TestEvidenceHandler_DisabledReturns404(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "")
+	voter := &stubEvidenceVoter{}
+	rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, validEvidenceFields()))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if voter.calls != 0 {
+		t.Errorf("store called %d times while the feature is off", voter.calls)
+	}
+}
+
+// TestEvidenceHandler_DefaultsToOff is the deployment guard: an environment
+// that says nothing about this feature must not get it.
+func TestEvidenceHandler_DefaultsToOff(t *testing.T) {
+	for _, v := range []string{"", "0", "false", "no"} {
+		t.Setenv("FEEDBACK_EVIDENCE_ENABLED", v)
+		rec := postEvidence(t, newEvidenceTestServer(&stubEvidenceVoter{}), evidenceBody(t, validEvidenceFields()))
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("FEEDBACK_EVIDENCE_ENABLED=%q gave status %d, want 404", v, rec.Code)
+		}
+	}
+}
+
+func TestEvidenceHandler_NotRegisteredWithoutVoter(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	srv := NewServer(nil, nil, nil, nil, nil, "", "")
+	rec := postEvidence(t, srv, evidenceBody(t, validEvidenceFields()))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d, want 404 when no store is wired", rec.Code)
+	}
+}
+
+func TestEvidenceHandler_RejectsBadThumbs(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	for _, thumbs := range []int{2, -2, 7} {
+		voter := &stubEvidenceVoter{}
+		f := validEvidenceFields()
+		f["thumbs"] = thumbs
+		rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, f))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("thumbs=%d gave status %d, want 400", thumbs, rec.Code)
+		}
+		if voter.calls != 0 {
+			t.Errorf("thumbs=%d reached the store", thumbs)
+		}
+	}
+}
+
+// TestEvidenceHandler_RejectsNonUUIDDocument keeps a malformed identifier from
+// becoming a foreign-key error surfaced as a 500.
+func TestEvidenceHandler_RejectsNonUUIDDocument(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	for _, id := range []string{"not-a-uuid", "", "1234"} {
+		voter := &stubEvidenceVoter{}
+		f := validEvidenceFields()
+		f["document_id"] = id
+		rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, f))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("document_id=%q gave status %d, want 400", id, rec.Code)
+		}
+		if voter.calls != 0 {
+			t.Errorf("document_id=%q reached the store", id)
+		}
+	}
+}
+
+func TestEvidenceHandler_RejectsEmptyQuery(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	for _, q := range []string{"", "   "} {
+		voter := &stubEvidenceVoter{}
+		f := validEvidenceFields()
+		f["query"] = q
+		rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, f))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("query=%q gave status %d, want 400", q, rec.Code)
+		}
+		if voter.calls != 0 {
+			t.Errorf("query=%q reached the store", q)
+		}
+	}
+}
+
+func TestEvidenceHandler_RejectsEmptyConversationID(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	voter := &stubEvidenceVoter{}
+	f := validEvidenceFields()
+	f["conversation_id"] = ""
+	rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, f))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+	if voter.calls != 0 {
+		t.Error("empty conversation_id reached the store")
+	}
+}
+
+// TestEvidenceHandler_PassesRankAndLayerToMetadata pins the position signal.
+// Rank is what makes a later position-bias correction possible; if it is not
+// captured at collection time it cannot be recovered.
+func TestEvidenceHandler_PassesRankAndLayerToMetadata(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	voter := &stubEvidenceVoter{retThumb: 1}
+	rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, validEvidenceFields()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if voter.got.Metadata["rank"] != 2 {
+		t.Errorf("metadata rank = %v, want 2", voter.got.Metadata["rank"])
+	}
+	if voter.got.Metadata["layer"] != "observed" {
+		t.Errorf("metadata layer = %v, want %q", voter.got.Metadata["layer"], "observed")
+	}
+	if _, ok := voter.got.Metadata["query"]; ok {
+		t.Error("metadata duplicated the query text; it already has its own column")
+	}
+	if voter.got.UserID != nil {
+		t.Error("handler attached a user id; labels are stored without an identity")
+	}
+	if voter.got.SessionID != "dummy-conversation" {
+		t.Errorf("session id = %q, want the conversation id", voter.got.SessionID)
+	}
+}
+
+// TestEvidenceHandler_ReturnsServerResolvedThumbs pins that the toggle decision
+// belongs to the server. The client must not have to predict it.
+func TestEvidenceHandler_ReturnsServerResolvedThumbs(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	for _, want := range []int16{0, 1, -1} {
+		voter := &stubEvidenceVoter{retThumb: want}
+		rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, validEvidenceFields()))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		var body struct {
+			Thumbs int16 `json:"thumbs"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.Thumbs != want {
+			t.Errorf("response thumbs = %d, want %d (the store's answer)", body.Thumbs, want)
+		}
+	}
+}
+
+func TestEvidenceHandler_StoreFailureIs500(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	voter := &stubEvidenceVoter{err: errors.New("db down")}
+	rec := postEvidence(t, newEvidenceTestServer(voter), evidenceBody(t, validEvidenceFields()))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d, want 500", rec.Code)
+	}
+}
+
+// TestEvidenceHandler_NeverEchoesQueryText is a privacy guard. Queries are the
+// user's own speech and routinely contain names and numbers; an error body is
+// one of the easiest places for that text to escape into a log or a screenshot.
+func TestEvidenceHandler_NeverEchoesQueryText(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	const secret = "zzsentinelqueryzz"
+	cases := []func(map[string]any){
+		func(f map[string]any) { f["thumbs"] = 9 },
+		func(f map[string]any) { f["document_id"] = "not-a-uuid" },
+		func(f map[string]any) { f["conversation_id"] = "" },
+	}
+	for i, mutate := range cases {
+		f := validEvidenceFields()
+		f["query"] = secret
+		mutate(f)
+		rec := postEvidence(t, newEvidenceTestServer(&stubEvidenceVoter{}), evidenceBody(t, f))
+		if strings.Contains(rec.Body.String(), secret) {
+			t.Errorf("case %d: response body echoed the query text", i)
+		}
+	}
+}
+
+func TestEvidenceHandler_RejectsMalformedJSON(t *testing.T) {
+	t.Setenv("FEEDBACK_EVIDENCE_ENABLED", "1")
+	voter := &stubEvidenceVoter{}
+	rec := postEvidence(t, newEvidenceTestServer(voter), strings.NewReader("{not json"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+	if voter.calls != 0 {
+		t.Error("malformed body reached the store")
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -159,6 +159,13 @@ type Server struct {
 	actionLister ActionLister
 	actionSetter ActionStateSetter
 
+	// evidenceVoter is optional. When non-nil the
+	// POST /api/v1/feedback/evidence route is registered; the handler still
+	// gates itself on FEEDBACK_EVIDENCE_ENABLED, so wiring the store is
+	// necessary but not sufficient to expose the endpoint.
+	// Set via WithEvidenceFeedback before calling Handler().
+	evidenceVoter EvidenceVoter
+
 	// briefingCache, briefingMaxActions, and briefingModel are optional. When
 	// briefingCache is non-nil AND both actionLister and llmClient are present,
 	// the GET /api/v1/briefing route is registered. Set via WithBriefing before
@@ -343,6 +350,9 @@ func (s *Server) buildHandler() http.Handler {
 			r.Get("/api/v1/graph/expand", s.graphExpandHandler)
 			r.Get("/api/v1/graph/evidence", s.graphEvidenceHandler)
 			r.Get("/api/v1/graph/entities", s.graphEntitiesHandler)
+		}
+		if s.evidenceVoter != nil {
+			r.Post("/api/v1/feedback/evidence", s.evidenceFeedbackHandler)
 		}
 		if s.actionLister != nil {
 			r.Get("/api/v1/actions", s.listActionsHandler)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,6 +494,50 @@ type Config struct {
 	// BRIEFING_MAX_ACTIONS: caps how many open actions feed a single
 	// briefing request. Default 40. Invalid values use the default.
 	BriefingMaxActions int
+
+	// BriefingTimeout bounds one GET /api/v1/briefing request (the open-action
+	// query plus the LLM call). BRIEFING_TIMEOUT_SECONDS env var, default 120s.
+	//
+	// It replaces a hardcoded 30s ceiling in internal/api/briefing.go. In
+	// production that ceiling was below the actual model latency, so every
+	// request hit it and briefing.Generate degraded to the deterministic
+	// aggregate: HTTP 200, degraded=true, a single sentence, dropped_count=0.
+	// The failure was invisible from the status code alone, which is exactly
+	// why the bound must be operator-tunable instead of compiled in.
+	//
+	// The default deliberately matches LLMTimeoutSeconds' own default (120s):
+	// the LLM client's HTTP timeout should be what fails a slow model, not
+	// this outer context, so that a timeout is attributed to the model call.
+	// Invalid, zero, and negative values use the default.
+	BriefingTimeout time.Duration
+
+	// HTTPWriteTimeout is http.Server.WriteTimeout for the API server.
+	// HTTP_WRITE_TIMEOUT_SECONDS env var, default 90s.
+	//
+	// This is a slow-client guard: it bounds how long one connection may hold
+	// a response open, so it must stay finite. The default is sized to cover
+	// the slowest NON-briefing paths — /ask (AskTimeoutSeconds, default 60s,
+	// streamed as SSE) and a cold-start /search whose first query after a
+	// container restart has been measured past 30s (issue #195) — with margin.
+	// The briefing, which may legitimately run far longer, extends its own
+	// write deadline per request instead of forcing this global value up (see
+	// internal/api/briefing.go).
+	//
+	// Invalid, zero, and negative values use the default; there is no
+	// "unlimited" setting on purpose.
+	HTTPWriteTimeout time.Duration
+
+	// FeedbackEvidenceEnabled gates POST /api/v1/feedback/evidence (Part D).
+	// FEEDBACK_EVIDENCE_ENABLED env var, default false.
+	//
+	// As with ActionsAPIEnabled, "off" means the route is never registered in
+	// the router — a 404, not a branch inside the handler — which is the
+	// rollback mechanism. The handler in internal/api/feedback_evidence.go
+	// re-reads the same variable per request, so both layers must agree on
+	// what counts as "on"; envFlag mirrors that handler's truthy set
+	// (1/true/yes/on, case-insensitive, surrounding space ignored) rather
+	// than the plain == "true" used by older flags.
+	FeedbackEvidenceEnabled bool
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -757,7 +801,77 @@ func Load() (*Config, error) {
 		ActionsAPIEnabled:  os.Getenv("ACTIONS_API_ENABLED") == "true",
 		BriefingEnabled:    os.Getenv("BRIEFING_ENABLED") == "true",
 		BriefingMaxActions: briefingMaxActions(),
+		BriefingTimeout:    BriefingTimeout(),
+		HTTPWriteTimeout:   httpWriteTimeout(),
+
+		// Part D feedback collection — default false (see doc comment above).
+		FeedbackEvidenceEnabled: envFlag("FEEDBACK_EVIDENCE_ENABLED"),
 	}, nil
+}
+
+// DefaultBriefingTimeout is the fallback for BRIEFING_TIMEOUT_SECONDS.
+const DefaultBriefingTimeout = 120 * time.Second
+
+// BriefingTimeout resolves BRIEFING_TIMEOUT_SECONDS from the environment.
+//
+// Exported, and readable without a *Config, because internal/api's briefing
+// handler needs the value but has nowhere to store it: the api.Server fields
+// it would live in are owned by another change in flight, and the value is
+// read once per briefing request — a low-frequency, cache-protected path — so
+// resolving it from the environment costs nothing measurable. Config.Load
+// calls this too, so `cfg.BriefingTimeout` and this function can never report
+// different numbers.
+//
+// Invalid, zero, and negative values fall back to DefaultBriefingTimeout: a
+// zero timeout would mean "already expired" (context.WithTimeout with a
+// non-positive duration cancels immediately), turning a typo into a briefing
+// that is permanently degraded.
+func BriefingTimeout() time.Duration {
+	return timeoutSeconds("BRIEFING_TIMEOUT_SECONDS", DefaultBriefingTimeout)
+}
+
+// defaultHTTPWriteTimeout is the fallback for HTTP_WRITE_TIMEOUT_SECONDS.
+const defaultHTTPWriteTimeout = 90 * time.Second
+
+// httpWriteTimeout resolves HTTP_WRITE_TIMEOUT_SECONDS from the environment.
+// See Config.HTTPWriteTimeout for why this stays finite.
+func httpWriteTimeout() time.Duration {
+	return timeoutSeconds("HTTP_WRITE_TIMEOUT_SECONDS", defaultHTTPWriteTimeout)
+}
+
+// timeoutSeconds parses an integer-seconds env var into a duration, logging
+// and falling back to def for anything that is not a positive integer.
+func timeoutSeconds(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		slog.Warn("config: timeout is invalid; using default",
+			"key", key,
+			"value", v,
+			"default", def.String(),
+			"error", err,
+		)
+		return def
+	}
+	return time.Duration(n) * time.Second
+}
+
+// envFlag reports whether key holds a truthy value. The accepted set matches
+// the api package's own per-request gate for FEEDBACK_EVIDENCE_ENABLED, so
+// that wiring (this file) and handler (internal/api) cannot disagree about
+// whether a feature is on. Anything else — including the empty string and an
+// unset variable — is false: a deployment that says nothing about a feature
+// does not get it.
+func envFlag(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func calendarLookaheadDays() int {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -622,3 +622,134 @@ func TestLoad_UserEmailAddresses(t *testing.T) {
 		}
 	}
 }
+
+// TestLoad_BriefingTimeoutSeconds verifies BRIEFING_TIMEOUT_SECONDS parsing.
+// The default must be comfortably above the observed LLM latency: production
+// measurement showed the briefing LLM call exceeding the old hardcoded 30s
+// ceiling on every request, which silently degraded the endpoint to the
+// aggregate-only fallback (degraded=true, one sentence, dropped_count=0).
+func TestLoad_BriefingTimeoutSeconds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   time.Duration
+	}{
+		{name: "default_when_unset", unset: true, want: 120 * time.Second},
+		{name: "explicit_45", envVal: "45", want: 45 * time.Second},
+		{name: "explicit_300", envVal: "300", want: 300 * time.Second},
+		{name: "invalid_string_uses_default", envVal: "notanumber", want: 120 * time.Second},
+		{name: "zero_uses_default", envVal: "0", want: 120 * time.Second},
+		{name: "negative_uses_default", envVal: "-1", want: 120 * time.Second},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "BRIEFING_TIMEOUT_SECONDS")
+			} else {
+				setenv(t, "BRIEFING_TIMEOUT_SECONDS", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.BriefingTimeout != tc.want {
+				t.Errorf("BriefingTimeout = %v, want %v", cfg.BriefingTimeout, tc.want)
+			}
+			// The api package resolves the same value per request through the
+			// exported helper; the two must not drift.
+			if got := BriefingTimeout(); got != tc.want {
+				t.Errorf("BriefingTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_HTTPWriteTimeoutSeconds verifies HTTP_WRITE_TIMEOUT_SECONDS parsing.
+// This is the global http.Server.WriteTimeout — a slow-client guard that must
+// stay bounded, so 0/negative fall back to the default rather than meaning
+// "unlimited".
+func TestLoad_HTTPWriteTimeoutSeconds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   time.Duration
+	}{
+		{name: "default_when_unset", unset: true, want: 90 * time.Second},
+		{name: "explicit_30", envVal: "30", want: 30 * time.Second},
+		{name: "invalid_string_uses_default", envVal: "abc", want: 90 * time.Second},
+		{name: "zero_uses_default", envVal: "0", want: 90 * time.Second},
+		{name: "negative_uses_default", envVal: "-10", want: 90 * time.Second},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "HTTP_WRITE_TIMEOUT_SECONDS")
+			} else {
+				setenv(t, "HTTP_WRITE_TIMEOUT_SECONDS", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.HTTPWriteTimeout != tc.want {
+				t.Errorf("HTTPWriteTimeout = %v, want %v", cfg.HTTPWriteTimeout, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoad_FeedbackEvidenceEnabled verifies FEEDBACK_EVIDENCE_ENABLED parsing.
+// The accepted truthy set deliberately mirrors the api handler's own gate
+// (1/true/yes/on, case-insensitive) so that wiring and handler cannot
+// disagree about whether the feature is on.
+func TestLoad_FeedbackEvidenceEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   bool
+	}{
+		{name: "default_off_when_unset", unset: true, want: false},
+		{name: "empty_is_off", envVal: "", want: false},
+		{name: "true_is_on", envVal: "true", want: true},
+		{name: "TRUE_is_on", envVal: "TRUE", want: true},
+		{name: "one_is_on", envVal: "1", want: true},
+		{name: "yes_is_on", envVal: "yes", want: true},
+		{name: "on_is_on", envVal: " on ", want: true},
+		{name: "false_is_off", envVal: "false", want: false},
+		{name: "garbage_is_off", envVal: "maybe", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "FEEDBACK_EVIDENCE_ENABLED")
+			} else {
+				setenv(t, "FEEDBACK_EVIDENCE_ENABLED", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.FeedbackEvidenceEnabled != tc.want {
+				t.Errorf("FeedbackEvidenceEnabled = %v, want %v", cfg.FeedbackEvidenceEnabled, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dataset/api_surface_test.go
+++ b/internal/dataset/api_surface_test.go
@@ -1,0 +1,45 @@
+package dataset
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestHoldoutSet_ExportedSurfaceIsFrozen is the guard that keeps validation-set
+// isolation structural rather than customary. HoldoutSet must never grow an
+// exported way to hand its pairs, queries or document IDs to a caller: an
+// optimiser that can read the holdout set will, sooner or later, be tuned
+// against it, and then the holdout number stops meaning anything.
+//
+// If this test fails, do not update `want`. Remove the accessor.
+func TestHoldoutSet_ExportedSurfaceIsFrozen(t *testing.T) {
+	t.Parallel()
+	got := exportedMethodNames(reflect.TypeOf(&HoldoutSet{}))
+	want := []string{"Evaluate", "Queries"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("HoldoutSet exported methods = %v, want %v — the public surface of "+
+			"HoldoutSet changed, so validation-set isolation may be broken", got, want)
+	}
+}
+
+// TestHoldoutSet_HasNoExportedFields complements the method check: an exported
+// field would leak the pairs just as effectively as an accessor.
+func TestHoldoutSet_HasNoExportedFields(t *testing.T) {
+	t.Parallel()
+	typ := reflect.TypeOf(HoldoutSet{})
+	for i := 0; i < typ.NumField(); i++ {
+		if f := typ.Field(i); f.IsExported() {
+			t.Errorf("HoldoutSet has exported field %q — it leaks holdout data", f.Name)
+		}
+	}
+}
+
+func exportedMethodNames(t reflect.Type) []string {
+	names := make([]string, 0, t.NumMethod())
+	for i := 0; i < t.NumMethod(); i++ {
+		if m := t.Method(i); m.IsExported() {
+			names = append(names, m.Name)
+		}
+	}
+	return names
+}

--- a/internal/dataset/dataset.go
+++ b/internal/dataset/dataset.go
@@ -1,0 +1,107 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/baekenough/second-brain/internal/store"
+)
+
+// DefaultHoldoutBudget is how many times a HoldoutSet may be evaluated: one
+// baseline measurement plus one candidate measurement. Repeatedly probing the
+// holdout set and keeping whichever candidate scores best turns it into a
+// second training set with extra steps, so the budget is a hard stop rather
+// than a warning.
+const DefaultHoldoutBudget = 2
+
+// ErrHoldoutBudgetExhausted is returned by HoldoutSet.Evaluate once the
+// evaluation budget is spent.
+var ErrHoldoutBudgetExhausted = errors.New("dataset: holdout evaluation budget exhausted")
+
+// Source supplies evaluation pairs for exactly one split at a time.
+// *store.EvalStore satisfies it.
+//
+// The interface takes the split as an argument on purpose: there is no
+// "give me everything" method to accidentally call, so no code path exists
+// that could hand the whole labelled set to a tuner.
+type Source interface {
+	EvalPairsBySplit(ctx context.Context, split string) ([]store.EvalPair, error)
+}
+
+// Compile-time proof that the production store satisfies the split-only
+// contract, so a signature change on either side breaks the build rather than
+// the isolation guarantee.
+var _ Source = (*store.EvalStore)(nil)
+
+// TrainSet is the readable half. Coordinate search needs the raw pairs, so
+// they are exposed.
+type TrainSet struct {
+	pairs []store.EvalPair
+}
+
+// Pairs returns a copy of the training pairs. The copy keeps a caller from
+// mutating the set between evaluations, which would make a search run
+// irreproducible.
+func (t *TrainSet) Pairs() []store.EvalPair {
+	out := make([]store.EvalPair, len(t.pairs))
+	copy(out, t.pairs)
+	return out
+}
+
+// Queries returns the number of training pairs (one pair per distinct query).
+func (t *TrainSet) Queries() int { return len(t.pairs) }
+
+// HoldoutSet is the closed half. Every field is unexported and the only
+// exported methods are Evaluate and Queries, neither of which returns a query
+// string, a document ID or an evaluation pair. A caller in another package can
+// therefore measure against the holdout set but cannot look at it — the
+// compiler enforces this, and TestHoldoutSet_ExportedSurfaceIsFrozen keeps the
+// surface from quietly growing.
+type HoldoutSet struct {
+	pairs  []store.EvalPair
+	budget int
+}
+
+// Queries returns how many holdout queries exist. It is a count, not the
+// queries — the promotion gate needs the size of the sample and nothing more.
+func (h *HoldoutSet) Queries() int { return len(h.pairs) }
+
+// Load reads the two splits with two separate queries and returns them as
+// distinct types.
+//
+// Splits are read separately rather than read whole and partitioned in memory:
+// a single "read everything" call would put the holdout rows in a variable that
+// some future caller could pass along, and the point of this package is that
+// such a variable never exists outside it.
+func Load(ctx context.Context, src Source) (*TrainSet, *HoldoutSet, error) {
+	trainPairs, err := src.EvalPairsBySplit(ctx, SplitTrain)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dataset: load train split: %w", err)
+	}
+	holdoutPairs, err := src.EvalPairsBySplit(ctx, SplitHoldout)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dataset: load holdout split: %w", err)
+	}
+
+	// Contamination check. The split is a pure function of the normalised
+	// query, so an overlap means the Go rule and the SQL rule have drifted
+	// apart. That is not a degraded state to log and continue from: every
+	// holdout number computed afterwards would be measured on data the
+	// optimiser trained on. Fail closed.
+	trainQueries := make(map[string]struct{}, len(trainPairs))
+	for _, p := range trainPairs {
+		trainQueries[Normalize(p.Query)] = struct{}{}
+	}
+	for _, p := range holdoutPairs {
+		if _, dup := trainQueries[Normalize(p.Query)]; dup {
+			return nil, nil, fmt.Errorf(
+				"dataset: query hash %s appears in both splits; split rule drift, refusing to load",
+				queryHash(p.Query))
+		}
+	}
+
+	return &TrainSet{pairs: trainPairs},
+		&HoldoutSet{pairs: holdoutPairs, budget: DefaultHoldoutBudget},
+		nil
+}

--- a/internal/dataset/dataset_test.go
+++ b/internal/dataset/dataset_test.go
@@ -1,0 +1,177 @@
+package dataset
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/store"
+)
+
+// stubSource records which splits were asked for and serves canned pairs.
+// It stands in for store.EvalStore so these tests need no database.
+type stubSource struct {
+	asked []string
+	pairs map[string][]store.EvalPair
+	err   error
+}
+
+func (s *stubSource) EvalPairsBySplit(_ context.Context, split string) ([]store.EvalPair, error) {
+	s.asked = append(s.asked, split)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.pairs[split], nil
+}
+
+func newStubSource() *stubSource {
+	return &stubSource{pairs: map[string][]store.EvalPair{
+		SplitTrain: {
+			{ID: 1, Query: "train query one", RelevantDocIDs: []string{"d1"}},
+			{ID: 2, Query: "train query two", RelevantDocIDs: []string{"d2"}, IrrelevantDocIDs: []string{"d9"}},
+		},
+		SplitHoldout: {
+			{ID: 3, Query: "holdout query one", RelevantDocIDs: []string{"d1"}, IrrelevantDocIDs: []string{"d9"}},
+		},
+	}}
+}
+
+func TestLoad_QueriesEachSplitSeparately(t *testing.T) {
+	t.Parallel()
+	src := newStubSource()
+	if _, _, err := Load(context.Background(), src); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{SplitTrain, SplitHoldout}
+	if len(src.asked) != len(want) {
+		t.Fatalf("Source called with %v, want exactly %v", src.asked, want)
+	}
+	for i := range want {
+		if src.asked[i] != want[i] {
+			t.Fatalf("Source call %d asked for %q, want %q", i, src.asked[i], want[i])
+		}
+	}
+}
+
+func TestLoad_NoQueryAppearsInBothSets(t *testing.T) {
+	t.Parallel()
+	src := newStubSource()
+	train, _, err := Load(context.Background(), src)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// The holdout side is deliberately unreadable, so the cross-check is made
+	// against what the stub served for the holdout split.
+	holdoutQueries := map[string]bool{}
+	for _, p := range src.pairs[SplitHoldout] {
+		holdoutQueries[Normalize(p.Query)] = true
+	}
+	for _, p := range train.Pairs() {
+		if holdoutQueries[Normalize(p.Query)] {
+			t.Fatalf("query present in both splits: %q", p.Query)
+		}
+	}
+}
+
+func TestLoad_RejectsOverlappingSplits(t *testing.T) {
+	t.Parallel()
+	src := newStubSource()
+	src.pairs[SplitHoldout] = append(src.pairs[SplitHoldout],
+		store.EvalPair{ID: 4, Query: " Train Query One ", RelevantDocIDs: []string{"d1"}})
+	if _, _, err := Load(context.Background(), src); err == nil {
+		t.Fatal("Load accepted a query present in both splits; contamination must be fatal")
+	}
+}
+
+func TestLoad_PropagatesSourceError(t *testing.T) {
+	t.Parallel()
+	src := &stubSource{err: errors.New("boom")}
+	if _, _, err := Load(context.Background(), src); err == nil {
+		t.Fatal("Load swallowed the source error")
+	}
+}
+
+func constantRun(order []string) RunFunc {
+	return func(_ context.Context, _ string, _ int) ([]string, error) { return order, nil }
+}
+
+func TestHoldout_EvaluateReturnsScalarsOnly(t *testing.T) {
+	t.Parallel()
+	_, holdout, err := Load(context.Background(), newStubSource())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Relevant d1 at rank 1 -> NDCG@10 = 1.0, MRR@10 = 1.0.
+	// Irrelevant d9 inside the top-10 -> FP penalty = 1/10 = 0.1.
+	m, err := holdout.Evaluate(context.Background(), constantRun([]string{"d1", "d9"}))
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if math.Abs(m.NDCG10-1.0) > 1e-9 {
+		t.Errorf("NDCG10 = %v, want 1.0", m.NDCG10)
+	}
+	if math.Abs(m.MRR10-1.0) > 1e-9 {
+		t.Errorf("MRR10 = %v, want 1.0", m.MRR10)
+	}
+	if math.Abs(m.FPPenalty10-0.1) > 1e-9 {
+		t.Errorf("FPPenalty10 = %v, want 0.1", m.FPPenalty10)
+	}
+	if math.Abs(m.Objective-(1.0-0.5*0.1)) > 1e-9 {
+		t.Errorf("Objective = %v, want %v", m.Objective, 1.0-0.5*0.1)
+	}
+	if m.Queries != 1 || m.Pairs != 1 {
+		t.Errorf("Queries/Pairs = %d/%d, want 1/1", m.Queries, m.Pairs)
+	}
+}
+
+func TestHoldout_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+	_, holdout, err := Load(context.Background(), newStubSource())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	run := constantRun([]string{"d1"})
+	for i := 0; i < DefaultHoldoutBudget; i++ {
+		if _, err := holdout.Evaluate(context.Background(), run); err != nil {
+			t.Fatalf("Evaluate %d: %v", i, err)
+		}
+	}
+	if _, err := holdout.Evaluate(context.Background(), run); !errors.Is(err, ErrHoldoutBudgetExhausted) {
+		t.Fatalf("third Evaluate error = %v, want ErrHoldoutBudgetExhausted", err)
+	}
+}
+
+func TestHoldout_EvaluatePropagatesRunError(t *testing.T) {
+	t.Parallel()
+	_, holdout, err := Load(context.Background(), newStubSource())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	boom := errors.New("search down")
+	_, err = holdout.Evaluate(context.Background(), func(context.Context, string, int) ([]string, error) {
+		return nil, boom
+	})
+	if !errors.Is(err, boom) {
+		t.Fatalf("Evaluate error = %v, want %v", err, boom)
+	}
+}
+
+func TestTrainSet_PairsIsACopy(t *testing.T) {
+	t.Parallel()
+	train, _, err := Load(context.Background(), newStubSource())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := train.Pairs()
+	if len(got) == 0 {
+		t.Fatal("TrainSet.Pairs is empty")
+	}
+	got[0].Query = "mutated"
+	if train.Pairs()[0].Query == "mutated" {
+		t.Fatal("TrainSet.Pairs exposes its backing array")
+	}
+	if train.Queries() != 2 {
+		t.Fatalf("TrainSet.Queries = %d, want 2", train.Queries())
+	}
+}

--- a/internal/dataset/runner.go
+++ b/internal/dataset/runner.go
@@ -1,0 +1,138 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/baekenough/second-brain/internal/search"
+	"github.com/baekenough/second-brain/internal/store"
+	"golang.org/x/sync/errgroup"
+)
+
+// evalK is the cutoff every metric in this package uses. It is fixed at 10 to
+// match NDCG@10 / FP@10, the two numbers the promotion gate is written against.
+const evalK = 10
+
+// maxEvalConcurrency bounds how many queries are searched at once. It is well
+// under the Postgres pool size so that an evaluation run cannot starve the
+// service sharing the database.
+const maxEvalConcurrency = 4
+
+// RunFunc executes one search and returns the top-k document IDs in rank order.
+// It is the only thing a caller hands to HoldoutSet.Evaluate — the caller
+// supplies the searcher, the set supplies the questions, and only aggregate
+// numbers come back.
+type RunFunc func(ctx context.Context, query string, k int) ([]string, error)
+
+// Metrics is the entire output of an evaluation: scalars, no per-query detail.
+type Metrics struct {
+	NDCG10      float64 `json:"ndcg10"`
+	MRR10       float64 `json:"mrr10"`
+	FPPenalty10 float64 `json:"fp_penalty10"`
+	Objective   float64 `json:"objective"`
+	Pairs       int     `json:"pairs"`
+	Queries     int     `json:"queries"`
+}
+
+// ObjectiveOf is the single objective function used for both search and
+// promotion: NDCG@10 penalised by half the false-positive rate at 10 (plan
+// §2.4). Defined once here so a tuner and a gate cannot disagree about what
+// "better" means.
+func ObjectiveOf(ndcg10, fpPenalty10 float64) float64 {
+	return ndcg10 - 0.5*fpPenalty10
+}
+
+// Evaluate runs the supplied searcher over every holdout query and returns the
+// aggregate metrics. The pairs themselves never leave this method.
+//
+// The budget is spent on entry, including for a run that later fails: an
+// attempt that reached the search path has already observed the holdout set,
+// and letting failures be free would make an unlimited probing loop trivial to
+// write by accident.
+func (h *HoldoutSet) Evaluate(ctx context.Context, run RunFunc) (Metrics, error) {
+	if h.budget <= 0 {
+		return Metrics{}, ErrHoldoutBudgetExhausted
+	}
+	h.budget--
+	return evaluatePairs(ctx, h.pairs, run)
+}
+
+// EvaluateTrain runs the searcher over the training pairs. Unlike the holdout
+// path this is unbudgeted — the train split is what coordinate search is
+// supposed to be hammering.
+func (t *TrainSet) EvaluateTrain(ctx context.Context, run RunFunc) (Metrics, error) {
+	return evaluatePairs(ctx, t.pairs, run)
+}
+
+// evaluatePairs searches every pair with bounded concurrency and aggregates.
+//
+// Results are written into a pre-sized slice at the pair's index rather than
+// appended, so the aggregate does not depend on goroutine completion order. A
+// single failed search aborts the whole evaluation: scoring a failed query as
+// zero would blur "these weights are worse" into "the database hiccuped", and
+// the entire point of this package is to be able to tell those apart.
+func evaluatePairs(ctx context.Context, pairs []store.EvalPair, run RunFunc) (Metrics, error) {
+	if len(pairs) == 0 {
+		return Metrics{}, nil
+	}
+
+	results := make([][]string, len(pairs))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxEvalConcurrency)
+	for i, p := range pairs {
+		i, p := i, p
+		g.Go(func() error {
+			docIDs, err := run(gctx, p.Query, evalK)
+			if err != nil {
+				// query_hash, never the query: see QueryHash.
+				return fmt.Errorf("dataset: evaluate query %s: %w", queryHash(p.Query), err)
+			}
+			results[i] = docIDs
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return Metrics{}, err
+	}
+
+	relevant := make([]map[string]bool, len(pairs))
+	irrelevant := make([]map[string]bool, len(pairs))
+	for i, p := range pairs {
+		relevant[i] = toSet(p.RelevantDocIDs)
+		irrelevant[i] = toSet(p.IrrelevantDocIDs)
+	}
+
+	agg := search.Aggregate(results, relevant)
+	fp := search.AggregateFPPenalty(results, irrelevant, evalK)
+
+	return Metrics{
+		NDCG10:      agg.NDCG10,
+		MRR10:       agg.MRR10,
+		FPPenalty10: fp,
+		Objective:   ObjectiveOf(agg.NDCG10, fp),
+		Pairs:       len(pairs),
+		Queries:     distinctQueries(pairs),
+	}, nil
+}
+
+func toSet(ids []string) map[string]bool {
+	if len(ids) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
+}
+
+// distinctQueries counts normalised queries. EvalPair is already one row per
+// query today, but the promotion gate's "30 distinct queries" threshold must
+// not silently inflate if that ever stops being true.
+func distinctQueries(pairs []store.EvalPair) int {
+	seen := make(map[string]struct{}, len(pairs))
+	for _, p := range pairs {
+		seen[Normalize(p.Query)] = struct{}{}
+	}
+	return len(seen)
+}

--- a/internal/dataset/split.go
+++ b/internal/dataset/split.go
@@ -1,0 +1,79 @@
+// Package dataset owns the train/holdout split of the search feedback labels
+// and the boundary that keeps the holdout half out of the optimiser's reach.
+//
+// The package exists because "we agreed not to tune on the validation set" is
+// not a mechanism. Here the separation is carried by types: Load hands back a
+// TrainSet whose pairs are readable and a HoldoutSet whose pairs are not, and
+// the Go compiler — not a convention — refuses code in any other package that
+// tries to read them.
+package dataset
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"strings"
+)
+
+// Split values stored in feedback.split.
+const (
+	SplitTrain   = "train"
+	SplitHoldout = "holdout"
+)
+
+// splitSeed is FROZEN. It is part of the hash input, so changing it reassigns
+// every query to a different split and retroactively contaminates the holdout
+// set with queries the optimiser has already been tuned against. A new rule
+// needs a new prefix ("sbfeedback:v2:") AND a new column, never an edit here.
+const splitSeed = "sbfeedback:v1:"
+
+// trainCutoff puts ~70% of distinct queries in the train split.
+const trainCutoff = 70
+
+// Normalize collapses a query to the form the split rule hashes.
+//
+// It mirrors PostgreSQL's `lower(btrim(query))` used by the backfill and the
+// uniqueness index in migrations/025_feedback_evidence.sql. btrim's default
+// trim set is the space character only, so this deliberately uses
+// strings.Trim(q, " ") rather than strings.TrimSpace: TrimSpace also strips
+// tabs and newlines, which would make Go and SQL disagree on any query that
+// carries one, and a disagreement here puts the same query in both splits.
+func Normalize(query string) string {
+	return strings.ToLower(strings.Trim(query, " "))
+}
+
+// SplitOf returns SplitTrain or SplitHoldout for a query, or "" when the query
+// is empty after normalisation (such rows are not splittable and are ignored by
+// the loader).
+//
+// The rule is: uint32(first 4 bytes of md5(splitSeed || normalized)) % 100.
+// PostgreSQL's ('x'||substr(md5(...),1,8))::bit(32)::bigint yields the same
+// unsigned value, which is why the SQL backfill and this function agree.
+// TestSplitOf_KnownVectors pins that agreement to concrete values.
+func SplitOf(query string) string {
+	norm := Normalize(query)
+	if norm == "" {
+		return ""
+	}
+	sum := md5.Sum([]byte(splitSeed + norm))
+	if binary.BigEndian.Uint32(sum[:4])%100 < trainCutoff {
+		return SplitTrain
+	}
+	return SplitHoldout
+}
+
+// QueryHash returns the first 8 hex characters of md5(normalized query). It is
+// the only identifier for a query that may appear in logs, spans or error
+// messages: the raw text is user speech and routinely contains names, phone
+// numbers and other personal detail.
+func QueryHash(query string) string { return queryHash(query) }
+
+func queryHash(query string) string {
+	sum := md5.Sum([]byte(Normalize(query)))
+	const hexDigits = "0123456789abcdef"
+	out := make([]byte, 8)
+	for i := 0; i < 4; i++ {
+		out[i*2] = hexDigits[sum[i]>>4]
+		out[i*2+1] = hexDigits[sum[i]&0x0f]
+	}
+	return string(out)
+}

--- a/internal/dataset/split_test.go
+++ b/internal/dataset/split_test.go
@@ -1,0 +1,86 @@
+package dataset
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The split rule is a frozen contract: it decides, permanently, which labels a
+// weight optimiser is allowed to see. These tests exist to make any change to
+// it loud.
+
+func TestSplitOf_Deterministic(t *testing.T) {
+	t.Parallel()
+	const q = "dummy query about scheduling"
+	want := SplitOf(q)
+	if want == "" {
+		t.Fatalf("SplitOf returned empty for a non-empty query")
+	}
+	for i := 0; i < 1000; i++ {
+		if got := SplitOf(q); got != want {
+			t.Fatalf("iteration %d: SplitOf = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestSplitOf_NormalizationInsensitive(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ a, b string }{
+		{" Foo ", "foo"},
+		{"BAR", "bar"},
+		{"  mixed Case Query  ", "mixed case query"},
+	}
+	for _, c := range cases {
+		if got, want := SplitOf(c.a), SplitOf(c.b); got != want {
+			t.Errorf("SplitOf(%q)=%q != SplitOf(%q)=%q", c.a, got, c.b, want)
+		}
+	}
+}
+
+func TestSplitOf_EmptyQueryIsUnsplittable(t *testing.T) {
+	t.Parallel()
+	for _, q := range []string{"", "   "} {
+		if got := SplitOf(q); got != "" {
+			t.Errorf("SplitOf(%q) = %q, want %q", q, got, "")
+		}
+	}
+}
+
+func TestSplitOf_RoughlySeventyThirty(t *testing.T) {
+	t.Parallel()
+	const n = 10000
+	train := 0
+	for i := 0; i < n; i++ {
+		// Deterministic synthetic queries — no personal data.
+		if SplitOf(fmt.Sprintf("synthetic probe %d", i)) == SplitTrain {
+			train++
+		}
+	}
+	ratio := float64(train) / float64(n)
+	if ratio < 0.65 || ratio > 0.75 {
+		t.Fatalf("train ratio = %.4f, want within [0.65, 0.75]", ratio)
+	}
+}
+
+// TestSplitOf_KnownVectors pins the hash rule to values produced by PostgreSQL
+// for the identical expression in migrations/025_feedback_evidence.sql. If this
+// fails, Go and SQL no longer agree and the holdout set is contaminated the
+// moment a row is inserted by one side and backfilled by the other.
+func TestSplitOf_KnownVectors(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		query string
+		want  string
+	}{
+		{"a", SplitHoldout},           // md5 prefix c01cfb8b -> 3223124875 % 100 = 75
+		{"b", SplitTrain},             // 0b49b11f -> 189378847 % 100 = 47
+		{"c", SplitTrain},             // aed43c56 -> 2933144662 % 100 = 62
+		{"hello world", SplitHoldout}, // 2f00aa1b -> 788572699 % 100 = 99
+		{"zzz", SplitTrain},           // 85d8a445 -> 2245567557 % 100 = 57
+	}
+	for _, c := range cases {
+		if got := SplitOf(c.query); got != c.want {
+			t.Errorf("SplitOf(%q) = %q, want %q", c.query, got, c.want)
+		}
+	}
+}

--- a/internal/model/action.go
+++ b/internal/model/action.go
@@ -52,6 +52,18 @@ var validActionKinds = map[ActionKind]bool{
 func IsValidActionKind(k ActionKind) bool { return validActionKinds[k] }
 
 // Action is a row in the actions table (migration 022).
+//
+// CounterpartName/CounterpartType are WRITE-ONLY inputs — they have no column
+// of their own and are never populated when reading. They exist because
+// counterpart_entity_id was NULL for every awaiting_my_reply action ever
+// written: the structural worker has a name for the other party but no way to
+// turn it into an entities.id (it holds no entity store), and the extraction
+// worker's awaiting_my_reply branch never resolved one either. Rather than
+// wiring an entity resolver into each worker, the writers state the label and
+// the store canonicalises it — see ActionStore.UpsertAction.
+//
+// A caller that already knows the entity id sets CounterpartEntityID and
+// leaves these empty; the id always wins.
 type Action struct {
 	ID                  int64
 	IdentityKey         string
@@ -60,6 +72,8 @@ type Action struct {
 	Kind                ActionKind
 	Summary             string
 	CounterpartEntityID *int64
+	CounterpartName     string
+	CounterpartType     EntityType
 	DueAt               *time.Time
 	DetectedBy          DetectedBy
 	Confidence          float64

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -2,7 +2,10 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 
 	"github.com/baekenough/second-brain/internal/model"
 )
@@ -29,7 +32,20 @@ func NewActionStore(pg *Postgres) *ActionStore {
 //
 // Caller MUST call this before EnsureOpenStatus for the same identity_key —
 // action_status.identity_key has an FK to actions.identity_key.
+//
+// counterpart_entity_id is resolved here rather than by the caller: the
+// structural signal worker holds no entity store, so before this it wrote
+// every awaiting_my_reply action with a NULL counterpart and the /actions
+// screen had no name to render. A caller states the label
+// (model.Action.CounterpartName) and the store canonicalises it through the
+// same (normalized_name, type) dedup every other entity goes through. On
+// conflict the column is COALESCEd, never overwritten: a re-assertion that
+// carries no label must not blank a resolved counterpart, and — the reason the
+// existing NULL rows repair themselves — a row written before this change
+// picks the id up on the worker's next tick.
 func (s *ActionStore) UpsertAction(ctx context.Context, a model.Action) error {
+	counterpartID := s.resolveCounterpart(ctx, a)
+
 	const q = `
 		INSERT INTO actions (identity_key, document_id, thread_key, kind, summary, counterpart_entity_id, due_at, detected_by, confidence, observed_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
@@ -39,18 +55,54 @@ func (s *ActionStore) UpsertAction(ctx context.Context, a model.Action) error {
 			due_at      = EXCLUDED.due_at,
 			confidence  = EXCLUDED.confidence,
 			observed_at = EXCLUDED.observed_at,
+			counterpart_entity_id = COALESCE(EXCLUDED.counterpart_entity_id, actions.counterpart_entity_id),
 			detected_by = CASE
 				WHEN actions.detected_by = EXCLUDED.detected_by THEN actions.detected_by
 				ELSE 'both'
 			END`
 	_, err := s.pg.pool.Exec(ctx, q,
 		a.IdentityKey, a.DocumentID, a.ThreadKey, string(a.Kind), a.Summary,
-		a.CounterpartEntityID, a.DueAt, string(a.DetectedBy), a.Confidence, a.ObservedAt,
+		counterpartID, a.DueAt, string(a.DetectedBy), a.Confidence, a.ObservedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert action %s: %w", a.IdentityKey, err)
 	}
 	return nil
+}
+
+// resolveCounterpart turns a.CounterpartName into an entities.id, or returns
+// a.CounterpartEntityID unchanged when the caller already resolved one.
+//
+// A failed resolution is logged and swallowed on purpose: the action itself is
+// what the user needs to see, and losing the whole row because one label could
+// not be filed would be a strictly worse outcome than a card with no name.
+func (s *ActionStore) resolveCounterpart(ctx context.Context, a model.Action) *int64 {
+	if a.CounterpartEntityID != nil {
+		return a.CounterpartEntityID
+	}
+	if strings.TrimSpace(a.CounterpartName) == "" {
+		return nil
+	}
+	entityType := a.CounterpartType
+	if entityType == "" {
+		entityType = model.EntityTypePerson
+	}
+	id, err := NewEntityStore(s.pg).UpsertEntity(ctx, a.CounterpartName, entityType)
+	if err != nil {
+		// Only the CAUSE is logged, never err itself: UpsertEntity formats the
+		// entity name into its message, and a counterpart name is personal
+		// data that must not reach the log. Unwrap yields the database error
+		// (or nil for the "empty after normalization" sentinel, which carries
+		// no name).
+		cause := errors.Unwrap(err)
+		if cause == nil {
+			cause = err
+		}
+		slog.Warn("resolve action counterpart entity failed; action keeps a NULL counterpart",
+			"identity_key", a.IdentityKey, "entity_type", entityType, "error", cause)
+		return nil
+	}
+	return &id
 }
 
 // EnsureOpenStatus inserts an 'open' action_status row for identityKey if

--- a/internal/store/actions_upsert_test.go
+++ b/internal/store/actions_upsert_test.go
@@ -1,0 +1,292 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// ActionStore.UpsertAction — counterpart resolution, real-database tests.
+//
+// These cover the second half of the "50 identical, nameless cards" defect:
+// counterpart_entity_id was NULL for 51% of rows because nothing ever resolved
+// one for awaiting_my_reply. The resolution now happens here, in the write
+// path, and only a real database can prove the CTE-free two-step actually
+// writes the id and that ON CONFLICT does not erase it again.
+//
+// Skipped unless TEST_DATABASE_URL is set. It must NEVER point at production:
+// every row written below is prefixed with a sentinel and deleted in cleanup.
+// ---------------------------------------------------------------------------
+
+const (
+	upsertTestKeyPrefix  = "action:test-cp-"
+	upsertTestSourceID   = "zz-dummy-upsert-test"
+	upsertTestEntityName = "ZZ-Dummy-Counterpart-Label"
+	// normalizeEntityName's output for the label above — what the UI reads
+	// back as counterpart_name.
+	upsertTestEntityNormalized = "zz-dummy-counterpart-label"
+)
+
+// seedUpsertDocument inserts one throwaway document for actions.document_id's
+// FK and registers cleanup for every row this file creates.
+func seedUpsertDocument(t *testing.T, pg *Postgres) uuid.UUID {
+	t.Helper()
+	docID := uuid.New()
+	_, err := pg.pool.Exec(context.Background(), `
+		INSERT INTO documents (id, source_type, source_id, title, content, collected_at)
+		VALUES ($1, 'filesystem', $2, 'dummy title', 'dummy content', now())`,
+		docID, upsertTestSourceID+"-"+docID.String(),
+	)
+	if err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		if _, err := pg.pool.Exec(ctx, `DELETE FROM actions WHERE identity_key LIKE $1`, upsertTestKeyPrefix+"%"); err != nil {
+			t.Errorf("cleanup actions: %v", err)
+		}
+		if _, err := pg.pool.Exec(ctx, `DELETE FROM documents WHERE source_id LIKE $1`, upsertTestSourceID+"%"); err != nil {
+			t.Errorf("cleanup documents: %v", err)
+		}
+		if _, err := pg.pool.Exec(ctx, `DELETE FROM entities WHERE normalized_name = $1`, upsertTestEntityNormalized); err != nil {
+			t.Errorf("cleanup entities: %v", err)
+		}
+	})
+	return docID
+}
+
+// readCounterpart returns the stored counterpart_entity_id and the joined
+// entity's normalized_name (empty when the id is NULL) — i.e. exactly what the
+// /actions query renders.
+func readCounterpart(t *testing.T, pg *Postgres, identityKey string) (*int64, string) {
+	t.Helper()
+	var (
+		id   *int64
+		name string
+	)
+	err := pg.pool.QueryRow(context.Background(), `
+		SELECT a.counterpart_entity_id, COALESCE(e.normalized_name, '')
+		FROM actions a LEFT JOIN entities e ON e.id = a.counterpart_entity_id
+		WHERE a.identity_key = $1`, identityKey,
+	).Scan(&id, &name)
+	if err != nil {
+		t.Fatalf("read counterpart for %s: %v", identityKey, err)
+	}
+	return id, name
+}
+
+func dummyAction(docID uuid.UUID, identityKey string) model.Action {
+	return model.Action{
+		IdentityKey: identityKey,
+		DocumentID:  docID,
+		ThreadKey:   "zz-dummy-thread",
+		Kind:        model.KindAwaitingMyReply,
+		Summary:     "dummy summary",
+		DetectedBy:  model.DetectedStructural,
+		Confidence:  1.0,
+		ObservedAt:  time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestUpsertActionResolvesCounterpartName is the core of the fix: a writer
+// that knows only a label gets a counterpart_entity_id, so the card can show
+// who is waiting.
+func TestUpsertActionResolvesCounterpartName(t *testing.T) {
+	pg := actionTestDB(t)
+	docID := seedUpsertDocument(t, pg)
+	store := NewActionStore(pg)
+	key := upsertTestKeyPrefix + "resolve"
+
+	a := dummyAction(docID, key)
+	a.CounterpartName = upsertTestEntityName
+	a.CounterpartType = model.EntityTypePerson
+	if err := store.UpsertAction(context.Background(), a); err != nil {
+		t.Fatalf("UpsertAction: %v", err)
+	}
+
+	id, name := readCounterpart(t, pg, key)
+	if id == nil {
+		t.Fatal("counterpart_entity_id is NULL; the label was not resolved")
+	}
+	if name != upsertTestEntityNormalized {
+		t.Errorf("counterpart_name = %q, want %q", name, upsertTestEntityNormalized)
+	}
+}
+
+// TestUpsertActionDedupsCounterpartAcrossActions pins that two threads with
+// the same counterpart converge on ONE entity row — otherwise the /actions
+// counterpart filter would need to match several ids for one person.
+func TestUpsertActionDedupsCounterpartAcrossActions(t *testing.T) {
+	pg := actionTestDB(t)
+	docID := seedUpsertDocument(t, pg)
+	store := NewActionStore(pg)
+	ctx := context.Background()
+
+	first := dummyAction(docID, upsertTestKeyPrefix+"dedup-1")
+	first.CounterpartName = upsertTestEntityName
+	first.CounterpartType = model.EntityTypePerson
+	second := dummyAction(docID, upsertTestKeyPrefix+"dedup-2")
+	// Same person, differently cased — normalization must fold them together.
+	second.CounterpartName = "  zz-dummy-COUNTERPART-label  "
+	second.CounterpartType = model.EntityTypePerson
+
+	for _, a := range []model.Action{first, second} {
+		if err := store.UpsertAction(ctx, a); err != nil {
+			t.Fatalf("UpsertAction %s: %v", a.IdentityKey, err)
+		}
+	}
+
+	id1, _ := readCounterpart(t, pg, first.IdentityKey)
+	id2, _ := readCounterpart(t, pg, second.IdentityKey)
+	if id1 == nil || id2 == nil {
+		t.Fatalf("counterpart ids = (%v, %v), want both resolved", id1, id2)
+	}
+	if *id1 != *id2 {
+		t.Errorf("counterpart ids %d and %d differ for the same normalized name", *id1, *id2)
+	}
+}
+
+// TestUpsertActionBackfillsNullCounterpart is what makes the 450 existing NULL
+// rows repair themselves: the structural worker re-asserts every open thread
+// on its next tick, and the ON CONFLICT branch must accept the newly resolved
+// id instead of leaving the old NULL in place.
+func TestUpsertActionBackfillsNullCounterpart(t *testing.T) {
+	pg := actionTestDB(t)
+	docID := seedUpsertDocument(t, pg)
+	store := NewActionStore(pg)
+	ctx := context.Background()
+	key := upsertTestKeyPrefix + "backfill"
+
+	// Pre-fix state: an action written with no counterpart at all.
+	if err := store.UpsertAction(ctx, dummyAction(docID, key)); err != nil {
+		t.Fatalf("UpsertAction (first): %v", err)
+	}
+	if id, _ := readCounterpart(t, pg, key); id != nil {
+		t.Fatalf("counterpart_entity_id = %d before the fix-up write, want NULL", *id)
+	}
+
+	next := dummyAction(docID, key)
+	next.CounterpartName = upsertTestEntityName
+	next.CounterpartType = model.EntityTypePerson
+	if err := store.UpsertAction(ctx, next); err != nil {
+		t.Fatalf("UpsertAction (second): %v", err)
+	}
+
+	id, name := readCounterpart(t, pg, key)
+	if id == nil {
+		t.Fatal("counterpart_entity_id is still NULL after a re-upsert that carried a label")
+	}
+	if name != upsertTestEntityNormalized {
+		t.Errorf("counterpart_name = %q, want %q", name, upsertTestEntityNormalized)
+	}
+}
+
+// TestUpsertActionKeepsResolvedCounterpartOnNamelessReupsert is the mirror
+// guard. The LLM extraction worker can re-assert the same identity_key without
+// a label; that must not blank a counterpart the structural worker resolved.
+func TestUpsertActionKeepsResolvedCounterpartOnNamelessReupsert(t *testing.T) {
+	pg := actionTestDB(t)
+	docID := seedUpsertDocument(t, pg)
+	store := NewActionStore(pg)
+	ctx := context.Background()
+	key := upsertTestKeyPrefix + "keep"
+
+	labelled := dummyAction(docID, key)
+	labelled.CounterpartName = upsertTestEntityName
+	labelled.CounterpartType = model.EntityTypePerson
+	if err := store.UpsertAction(ctx, labelled); err != nil {
+		t.Fatalf("UpsertAction (labelled): %v", err)
+	}
+	before, _ := readCounterpart(t, pg, key)
+	if before == nil {
+		t.Fatal("setup failed: counterpart was not resolved")
+	}
+
+	nameless := dummyAction(docID, key)
+	nameless.DetectedBy = model.DetectedLLM
+	if err := store.UpsertAction(ctx, nameless); err != nil {
+		t.Fatalf("UpsertAction (nameless): %v", err)
+	}
+
+	after, name := readCounterpart(t, pg, key)
+	if after == nil {
+		t.Fatal("a nameless re-upsert erased the resolved counterpart")
+	}
+	if *after != *before {
+		t.Errorf("counterpart id changed %d -> %d", *before, *after)
+	}
+	if name != upsertTestEntityNormalized {
+		t.Errorf("counterpart_name = %q, want %q", name, upsertTestEntityNormalized)
+	}
+}
+
+// TestUpsertActionPrefersExplicitEntityID keeps the extraction worker's
+// existing behaviour authoritative: when it has already resolved an entity for
+// a my_commitment/their_commitment/scheduled action, that id wins over any
+// label.
+func TestUpsertActionPrefersExplicitEntityID(t *testing.T) {
+	pg := actionTestDB(t)
+	docID := seedUpsertDocument(t, pg)
+	entityStore := NewEntityStore(pg)
+	ctx := context.Background()
+
+	explicitID, err := entityStore.UpsertEntity(ctx, upsertTestEntityName, model.EntityTypePerson)
+	if err != nil {
+		t.Fatalf("seed entity: %v", err)
+	}
+
+	key := upsertTestKeyPrefix + "explicit"
+	a := dummyAction(docID, key)
+	a.CounterpartEntityID = &explicitID
+	// A label that would resolve to a DIFFERENT row if it were consulted.
+	a.CounterpartName = "zz-dummy-should-be-ignored"
+	a.CounterpartType = model.EntityTypeOther
+	if err := NewActionStore(pg).UpsertAction(ctx, a); err != nil {
+		t.Fatalf("UpsertAction: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := pg.pool.Exec(context.Background(),
+			`DELETE FROM entities WHERE normalized_name = $1`, "zz-dummy-should-be-ignored"); err != nil {
+			t.Errorf("cleanup stray entity: %v", err)
+		}
+	})
+
+	id, _ := readCounterpart(t, pg, key)
+	if id == nil || *id != explicitID {
+		t.Errorf("counterpart_entity_id = %v, want %d (explicit id must win)", id, explicitID)
+	}
+	var strays int
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT count(*) FROM entities WHERE normalized_name = $1`, "zz-dummy-should-be-ignored").Scan(&strays); err != nil {
+		t.Fatalf("count stray entities: %v", err)
+	}
+	if strays != 0 {
+		t.Errorf("%d entity rows created from an ignored label; resolution must be skipped entirely", strays)
+	}
+}
+
+// TestUpsertActionUnresolvableLabelStillWritesAction guards the failure mode
+// that matters operationally: an entity upsert that fails (blank label after
+// normalization) must not cost the user the action row itself.
+func TestUpsertActionUnresolvableLabelStillWritesAction(t *testing.T) {
+	pg := actionTestDB(t)
+	docID := seedUpsertDocument(t, pg)
+	ctx := context.Background()
+	key := upsertTestKeyPrefix + "blank-label"
+
+	a := dummyAction(docID, key)
+	a.CounterpartName = "   " // normalizes to "", which UpsertEntity rejects
+	a.CounterpartType = model.EntityTypePerson
+	if err := NewActionStore(pg).UpsertAction(ctx, a); err != nil {
+		t.Fatalf("UpsertAction returned %v; an unusable label must not fail the action write", err)
+	}
+
+	id, _ := readCounterpart(t, pg, key)
+	if id != nil {
+		t.Errorf("counterpart_entity_id = %d, want NULL", *id)
+	}
+}

--- a/internal/store/eval.go
+++ b/internal/store/eval.go
@@ -48,6 +48,33 @@ func NewEvalStore(pg *Postgres) *EvalStore {
 // Results are ordered by the earliest positive feedback creation time (DESC)
 // and capped at 5 000 pairs to bound memory usage.
 func (s *EvalStore) BuildFromFeedback(ctx context.Context) ([]EvalPair, error) {
+	return s.buildFromFeedback(ctx, "")
+}
+
+// EvalPairsBySplit returns the eval pairs belonging to one train/holdout split
+// (see migrations/025_feedback_evidence.sql and internal/dataset).
+//
+// It exists so that internal/dataset can read the two halves with two separate
+// queries. There is deliberately no "read everything and partition afterwards"
+// path: a variable holding both halves is exactly what must not exist outside
+// the dataset package, or the weight optimiser can be handed its own validation
+// set by accident.
+//
+// split must be "train" or "holdout"; anything else is rejected rather than
+// silently widened to "all", because a typo that returns the whole labelled set
+// would be indistinguishable from success right up until the holdout metric
+// stops meaning anything.
+func (s *EvalStore) EvalPairsBySplit(ctx context.Context, split string) ([]EvalPair, error) {
+	if split != "train" && split != "holdout" {
+		return nil, fmt.Errorf("eval: invalid split %q (want \"train\" or \"holdout\")", split)
+	}
+	return s.buildFromFeedback(ctx, split)
+}
+
+// buildFromFeedback is the shared implementation. An empty split means "no
+// split filter" and is reachable only from BuildFromFeedback, whose behaviour
+// is unchanged.
+func (s *EvalStore) buildFromFeedback(ctx context.Context, split string) ([]EvalPair, error) {
 	// --- Step 1: Positive pairs from feedback (thumbs >= 1) ---
 	rows, err := s.pg.Pool().Query(ctx, `
 		SELECT query,
@@ -57,11 +84,12 @@ func (s *EvalStore) BuildFromFeedback(ctx context.Context) ([]EvalPair, error) {
 		WHERE thumbs >= 1
 		  AND query IS NOT NULL
 		  AND query != ''
+		  AND ($1 = '' OR split = $1)
 		GROUP BY query
 		HAVING COUNT(DISTINCT document_id) FILTER (WHERE document_id IS NOT NULL) > 0
 		ORDER BY created_at DESC
 		LIMIT 5000
-	`)
+	`, split)
 	if err != nil {
 		return nil, fmt.Errorf("eval: build from feedback: %w", err)
 	}
@@ -98,9 +126,10 @@ func (s *EvalStore) BuildFromFeedback(ctx context.Context) ([]EvalPair, error) {
 		WHERE thumbs = -1
 		  AND query IS NOT NULL
 		  AND query != ''
+		  AND ($1 = '' OR split = $1)
 		GROUP BY query
 		HAVING COUNT(DISTINCT document_id) FILTER (WHERE document_id IS NOT NULL) > 0
-	`)
+	`, split)
 	if err != nil {
 		return nil, fmt.Errorf("eval: build negative feedback: %w", err)
 	}
@@ -147,11 +176,12 @@ func (s *EvalStore) BuildFromFeedback(ctx context.Context) ([]EvalPair, error) {
 		WHERE source = 'manual'
 		  AND query IS NOT NULL
 		  AND query != ''
+		  AND ($1 = '' OR split = $1)
 		GROUP BY query
 		HAVING COUNT(DISTINCT document_id) FILTER (WHERE document_id IS NOT NULL) > 0
 		ORDER BY created_at DESC
 		LIMIT 1000
-	`)
+	`, split)
 	if err != nil {
 		return nil, fmt.Errorf("eval: build manual pairs: %w", err)
 	}

--- a/internal/store/feedback_evidence.go
+++ b/internal/store/feedback_evidence.go
@@ -1,0 +1,131 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// SourceAskEvidence is the feedback.source value reserved for per-evidence
+// votes cast on /ask answer cards.
+//
+// It is a constant rather than a caller-supplied string because the uniqueness
+// index that makes UpsertEvidence idempotent is PARTIAL on this exact value
+// (migrations/025_feedback_evidence.sql). A caller passing anything else would
+// silently fall outside the index and start inserting duplicate labels.
+const SourceAskEvidence = "ask_evidence"
+
+// evidenceSplitExpr computes feedback.split for a newly inserted evidence row.
+//
+// The split is computed in SQL, not in Go, and this is deliberate. The same
+// expression appears in the backfill in migrations/025_feedback_evidence.sql;
+// keeping insert-time and backfill-time assignment in the same language and the
+// same expression removes the one failure mode that would quietly destroy the
+// value of the whole exercise — a query landing in train on one path and in
+// holdout on the other, which puts it in both and makes the holdout number
+// meaningless. internal/dataset.SplitOf mirrors the rule for Go callers and
+// TestUpsertEvidence_SplitMatchesSQLBackfill pins the two together against a
+// real database.
+//
+// (internal/store cannot import internal/dataset in any case: dataset depends
+// on store.EvalPair, so the import would be a cycle.)
+const evidenceSplitExpr = `CASE WHEN abs(('x' || substr(md5('sbfeedback:v1:' || lower(btrim($1))),1,8))::bit(32)::bigint) % 100 < 70
+	     THEN 'train' ELSE 'holdout' END`
+
+// EvidenceVote is one thumbs judgement on one evidence card of one /ask answer.
+type EvidenceVote struct {
+	// SessionID is the conversation the card was shown in. It is part of the
+	// idempotency key: the same question asked in a different conversation is
+	// an independent signal, not a re-vote.
+	SessionID string
+	// Query is the question that produced the card — the turn's question, not
+	// whatever is currently typed.
+	Query string
+	// DocumentID is the evidence document (UUID).
+	DocumentID string
+	// Thumbs is +1, -1 or 0.
+	Thumbs int16
+	// UserID is optional and normally nil: this is a single-user system and a
+	// label does not need an identity attached to it.
+	UserID *string
+	// Metadata carries presentation context such as {"rank": 0, "layer": "observed"}.
+	// The query text is NOT duplicated here — it already has its own column.
+	Metadata map[string]any
+}
+
+// UpsertEvidence records or updates one per-evidence vote and returns the row
+// ID together with the thumbs value the database settled on.
+//
+// It is idempotent per (session, normalised query, document): a repeat call
+// updates the existing row instead of adding one.
+//
+// Re-sending the same value toggles the vote off (to 0) rather than leaving it
+// set, so a user can un-vote by clicking the same button again. The decision is
+// made inside the UPDATE so it is atomic and needs no read-modify-write round
+// trip. The resolved value is returned because the server, not the client, is
+// the authority on what the vote now is.
+//
+// Rows with thumbs = 0 are kept. "Looked at it and had no opinion" and "never
+// saw it" are different facts, and EvalStore.BuildFromFeedback only reads
+// thumbs >= 1 and thumbs = -1, so a zero row is inert for evaluation anyway.
+//
+// This deliberately does NOT reuse FeedbackStore.Upsert: that function deletes
+// every row for a (user, session, source) tuple before inserting, which is
+// right for a Discord reaction toggle and catastrophic here — it would wipe
+// every other label already collected in the same conversation.
+func (s *FeedbackStore) UpsertEvidence(ctx context.Context, v EvidenceVote) (int64, int16, error) {
+	if v.SessionID == "" {
+		return 0, 0, fmt.Errorf("feedback upsert evidence: session id is required")
+	}
+	if v.Query == "" {
+		return 0, 0, fmt.Errorf("feedback upsert evidence: query is required")
+	}
+	if v.DocumentID == "" {
+		return 0, 0, fmt.Errorf("feedback upsert evidence: document id is required")
+	}
+	if v.Thumbs < -1 || v.Thumbs > 1 {
+		return 0, 0, fmt.Errorf("feedback upsert evidence: thumbs must be -1, 0 or 1")
+	}
+
+	meta := v.Metadata
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return 0, 0, fmt.Errorf("feedback upsert evidence marshal metadata: %w", err)
+	}
+
+	// The ON CONFLICT target must be written exactly as the partial unique
+	// index in migration 025, expression for expression, or PostgreSQL will not
+	// match it and will raise "no unique or exclusion constraint matching".
+	//
+	// RETURNING lists only columns of the target row. Referencing EXCLUDED in
+	// RETURNING is invalid — this project has already shipped that bug once and
+	// found it in production.
+	const q = `
+		INSERT INTO feedback
+			(query, document_id, source, session_id, user_id, thumbs, metadata, split)
+		VALUES ($1, $2::uuid, '` + SourceAskEvidence + `', $3, $4, $5, $6::jsonb, ` + evidenceSplitExpr + `)
+		ON CONFLICT (session_id, md5(lower(btrim(query))), document_id)
+		WHERE source = '` + SourceAskEvidence + `'
+		DO UPDATE SET
+			thumbs = CASE WHEN feedback.thumbs = EXCLUDED.thumbs THEN 0 ELSE EXCLUDED.thumbs END,
+			metadata = EXCLUDED.metadata
+		RETURNING id, thumbs`
+
+	var (
+		id     int64
+		thumbs int16
+	)
+	// split is intentionally absent from the DO UPDATE SET list. The query is
+	// part of the conflict key, so a conflicting row has the same query and
+	// therefore the same split; recomputing it would only create a way for a
+	// future rule change to move historical rows between splits.
+	if err := s.pg.pool.QueryRow(ctx, q,
+		v.Query, v.DocumentID, v.SessionID, v.UserID, v.Thumbs, string(metaJSON),
+	).Scan(&id, &thumbs); err != nil {
+		return 0, 0, fmt.Errorf("feedback upsert evidence: %w", err)
+	}
+	return id, thumbs, nil
+}

--- a/internal/store/feedback_evidence_test.go
+++ b/internal/store/feedback_evidence_test.go
@@ -1,0 +1,341 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/dataset"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// UpsertEvidence — real-database tests.
+//
+// This package has no SQL stub harness and a stub could not prove any of the
+// properties that matter here: the ON CONFLICT target has to match a PARTIAL
+// unique index expression exactly, and the split value is computed by the
+// database. Everything below therefore runs against a real PostgreSQL instance
+// addressed by TEST_DATABASE_URL and is skipped when that variable is unset.
+//
+// TEST_DATABASE_URL must NEVER point at production. Every row written here uses
+// the sentinel session prefix below and is removed in t.Cleanup. No test data
+// resembles a real query, name or document.
+//
+// The file lives in package store_test rather than store because it imports
+// internal/dataset, which imports internal/store; an in-package test file would
+// be an import cycle.
+// ---------------------------------------------------------------------------
+
+const evidenceTestSessionPrefix = "zz-dummy-evidence-"
+
+func evidenceTestDB(t *testing.T) *store.Postgres {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping real-database evidence feedback test")
+	}
+	pg, err := store.NewPostgres(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect to TEST_DATABASE_URL: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	return pg
+}
+
+// seedEvidenceDoc inserts one throwaway document (feedback.document_id is an FK)
+// and registers cleanup for every row this test writes.
+func seedEvidenceDoc(t *testing.T, pg *store.Postgres) string {
+	t.Helper()
+	ctx := context.Background()
+	docID := uuid.New()
+	_, err := pg.Pool().Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, collected_at)
+		VALUES ($1, 'filesystem', $2, 'dummy title', 'dummy content', now())`,
+		docID, "zz-dummy-evidence-"+docID.String())
+	if err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		if _, err := pg.Pool().Exec(ctx,
+			`DELETE FROM feedback WHERE session_id LIKE $1`, evidenceTestSessionPrefix+"%"); err != nil {
+			t.Errorf("cleanup feedback: %v", err)
+		}
+		if _, err := pg.Pool().Exec(ctx, `DELETE FROM feedback WHERE document_id = $1`, docID); err != nil {
+			t.Errorf("cleanup feedback by doc: %v", err)
+		}
+		if _, err := pg.Pool().Exec(ctx, `DELETE FROM documents WHERE id = $1`, docID); err != nil {
+			t.Errorf("cleanup document: %v", err)
+		}
+	})
+	return docID.String()
+}
+
+func evidenceSession(t *testing.T) string {
+	t.Helper()
+	return evidenceTestSessionPrefix + uuid.NewString()
+}
+
+func countEvidenceRows(t *testing.T, pg *store.Postgres, session string) int {
+	t.Helper()
+	var n int
+	if err := pg.Pool().QueryRow(context.Background(),
+		`SELECT count(*)::int FROM feedback WHERE session_id = $1`, session).Scan(&n); err != nil {
+		t.Fatalf("count evidence rows: %v", err)
+	}
+	return n
+}
+
+// TestUpsertEvidence_SecondDocInSameSessionIsNotDeleted is the regression guard
+// for the reason this function exists at all. FeedbackStore.Upsert deletes every
+// row for a (user, session, source) tuple before inserting; reusing it for
+// per-evidence votes would erase the labels already collected in the same
+// conversation. Both documents must survive.
+func TestUpsertEvidence_SecondDocInSameSessionIsNotDeleted(t *testing.T) {
+	pg := evidenceTestDB(t)
+	docA := seedEvidenceDoc(t, pg)
+	docB := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	session := evidenceSession(t)
+	ctx := context.Background()
+
+	if _, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID: session, Query: "dummy evidence query alpha", DocumentID: docA, Thumbs: 1,
+	}); err != nil {
+		t.Fatalf("upsert docA: %v", err)
+	}
+	if _, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID: session, Query: "dummy evidence query alpha", DocumentID: docB, Thumbs: -1,
+	}); err != nil {
+		t.Fatalf("upsert docB: %v", err)
+	}
+
+	if got := countEvidenceRows(t, pg, session); got != 2 {
+		t.Fatalf("rows for session = %d, want 2 (a prior label was destroyed)", got)
+	}
+}
+
+func TestUpsertEvidence_RepeatSameVoteTogglesToZero(t *testing.T) {
+	pg := evidenceTestDB(t)
+	doc := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	session := evidenceSession(t)
+	ctx := context.Background()
+	vote := store.EvidenceVote{SessionID: session, Query: "dummy evidence query beta", DocumentID: doc, Thumbs: 1}
+
+	id1, thumbs1, err := fs.UpsertEvidence(ctx, vote)
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if thumbs1 != 1 {
+		t.Fatalf("first upsert thumbs = %d, want 1", thumbs1)
+	}
+	id2, thumbs2, err := fs.UpsertEvidence(ctx, vote)
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("second upsert created a new row (%d != %d); the call is not idempotent", id1, id2)
+	}
+	if thumbs2 != 0 {
+		t.Errorf("second identical vote thumbs = %d, want 0 (toggle off)", thumbs2)
+	}
+	if got := countEvidenceRows(t, pg, session); got != 1 {
+		t.Errorf("rows for session = %d, want 1", got)
+	}
+}
+
+func TestUpsertEvidence_OppositeVoteOverwrites(t *testing.T) {
+	pg := evidenceTestDB(t)
+	doc := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	session := evidenceSession(t)
+	ctx := context.Background()
+
+	if _, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID: session, Query: "dummy evidence query gamma", DocumentID: doc, Thumbs: 1,
+	}); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	_, thumbs, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID: session, Query: "dummy evidence query gamma", DocumentID: doc, Thumbs: -1,
+	})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if thumbs != -1 {
+		t.Errorf("opposite vote thumbs = %d, want -1", thumbs)
+	}
+	if got := countEvidenceRows(t, pg, session); got != 1 {
+		t.Errorf("rows for session = %d, want 1", got)
+	}
+}
+
+// TestUpsertEvidence_DoesNotTouchLegacyRows proves the partial index and the
+// upsert stay inside source='ask_evidence'. Rows collected by the existing
+// generic endpoint must be untouched.
+func TestUpsertEvidence_DoesNotTouchLegacyRows(t *testing.T) {
+	pg := evidenceTestDB(t)
+	doc := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	session := evidenceSession(t)
+	ctx := context.Background()
+	query := "dummy evidence query delta"
+
+	// Two legacy rows that would collide under a global unique index.
+	for i := 0; i < 2; i++ {
+		if _, err := fs.Record(ctx, store.Feedback{
+			Query: &query, DocumentID: &doc, Source: "search",
+			SessionID: &session, Thumbs: 1,
+		}); err != nil {
+			t.Fatalf("seed legacy row %d: %v", i, err)
+		}
+	}
+
+	if _, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID: session, Query: query, DocumentID: doc, Thumbs: 1,
+	}); err != nil {
+		t.Fatalf("upsert evidence: %v", err)
+	}
+
+	var legacy int
+	if err := pg.Pool().QueryRow(ctx,
+		`SELECT count(*)::int FROM feedback WHERE session_id = $1 AND source = 'search'`,
+		session).Scan(&legacy); err != nil {
+		t.Fatalf("count legacy: %v", err)
+	}
+	if legacy != 2 {
+		t.Fatalf("legacy rows = %d, want 2 (evidence upsert modified unrelated rows)", legacy)
+	}
+}
+
+// TestUpsertEvidence_SplitMatchesSQLBackfill is the only defence against the Go
+// and SQL hash rules drifting apart. If they drift, a query can be assigned to
+// train at insert time and to holdout by the backfill (or the reverse), and the
+// holdout set stops being independent of what the optimiser saw.
+func TestUpsertEvidence_SplitMatchesSQLBackfill(t *testing.T) {
+	pg := evidenceTestDB(t)
+	doc := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	ctx := context.Background()
+
+	sawTrain, sawHoldout := false, false
+	for i := 0; i < 20; i++ {
+		session := evidenceSession(t)
+		query := fmt.Sprintf("dummy split probe %d", i)
+		id, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+			SessionID: session, Query: query, DocumentID: doc, Thumbs: 1,
+		})
+		if err != nil {
+			t.Fatalf("upsert %d: %v", i, err)
+		}
+
+		var stored, backfill string
+		if err := pg.Pool().QueryRow(ctx, `
+			SELECT split,
+			       CASE WHEN abs(('x' || substr(md5('sbfeedback:v1:' || lower(btrim(query))),1,8))::bit(32)::bigint) % 100 < 70
+			            THEN 'train' ELSE 'holdout' END
+			FROM feedback WHERE id = $1`, id).Scan(&stored, &backfill); err != nil {
+			t.Fatalf("read split %d: %v", i, err)
+		}
+
+		goSplit := dataset.SplitOf(query)
+		if stored != backfill {
+			t.Errorf("query %d: stored split %q != backfill expression %q", i, stored, backfill)
+		}
+		if stored != goSplit {
+			t.Errorf("query %d: stored split %q != dataset.SplitOf %q", i, stored, goSplit)
+		}
+		switch goSplit {
+		case dataset.SplitTrain:
+			sawTrain = true
+		case dataset.SplitHoldout:
+			sawHoldout = true
+		}
+	}
+	if !sawTrain || !sawHoldout {
+		t.Fatalf("probe set did not exercise both splits (train=%v holdout=%v)", sawTrain, sawHoldout)
+	}
+}
+
+// --- EvalPairsBySplit -------------------------------------------------------
+
+func TestEvalPairsBySplit_RejectsUnknownSplit(t *testing.T) {
+	pg := evidenceTestDB(t)
+	es := store.NewEvalStore(pg)
+	for _, split := range []string{"", "all", "TRAIN"} {
+		if _, err := es.EvalPairsBySplit(context.Background(), split); err == nil {
+			t.Errorf("EvalPairsBySplit(%q) returned no error; an unrecognised split must not "+
+				"silently widen to the full labelled set", split)
+		}
+	}
+}
+
+// TestEvalPairsBySplit_ReturnsOnlyRequestedSplit exercises the real SQL: the
+// split filter is a bound parameter on three separate queries, and a typing or
+// placeholder mistake there is invisible to a stub.
+func TestEvalPairsBySplit_ReturnsOnlyRequestedSplit(t *testing.T) {
+	pg := evidenceTestDB(t)
+	doc := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	es := store.NewEvalStore(pg)
+	ctx := context.Background()
+
+	// Seed one query on each side of the split so both branches are covered.
+	seeded := map[string]string{} // query -> split
+	for i := 0; i < 12; i++ {
+		query := fmt.Sprintf("dummy split lane probe %d", i)
+		if _, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+			SessionID: evidenceSession(t), Query: query, DocumentID: doc, Thumbs: 1,
+		}); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+		seeded[query] = dataset.SplitOf(query)
+	}
+
+	for _, split := range []string{dataset.SplitTrain, dataset.SplitHoldout} {
+		pairs, err := es.EvalPairsBySplit(ctx, split)
+		if err != nil {
+			t.Fatalf("EvalPairsBySplit(%q): %v", split, err)
+		}
+		for _, p := range pairs {
+			if want, ok := seeded[p.Query]; ok && want != split {
+				t.Errorf("query hash %s expected in %q but returned for %q",
+					dataset.QueryHash(p.Query), want, split)
+			}
+		}
+	}
+}
+
+// TestBuildFromFeedback_UnfilteredStillWorks guards the refactor that gave
+// BuildFromFeedback a shared implementation with EvalPairsBySplit: the three
+// queries now carry a bound parameter they did not have before, and a mistake
+// there would break the existing /api/v1/eval/export path.
+func TestBuildFromFeedback_UnfilteredStillWorks(t *testing.T) {
+	pg := evidenceTestDB(t)
+	doc := seedEvidenceDoc(t, pg)
+	fs := store.NewFeedbackStore(pg)
+	es := store.NewEvalStore(pg)
+	ctx := context.Background()
+
+	query := "dummy unfiltered probe"
+	if _, _, err := fs.UpsertEvidence(ctx, store.EvidenceVote{
+		SessionID: evidenceSession(t), Query: query, DocumentID: doc, Thumbs: 1,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	pairs, err := es.BuildFromFeedback(ctx)
+	if err != nil {
+		t.Fatalf("BuildFromFeedback: %v", err)
+	}
+	for _, p := range pairs {
+		if p.Query == query {
+			return
+		}
+	}
+	t.Fatalf("BuildFromFeedback did not return the seeded query (got %d pairs)", len(pairs))
+}

--- a/internal/store/weights_history.go
+++ b/internal/store/weights_history.go
@@ -1,0 +1,276 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/jackc/pgx/v5"
+)
+
+// Lifecycle of a candidate in search_weights_history.
+//
+//	proposed ──promote──> active ──promote(other)──> superseded ──rollback──> active
+//	                         └────────rollback────────> rolled_back
+const (
+	// WeightsStatusProposed is a candidate that was measured but not promoted.
+	// Refused candidates are recorded too — otherwise there is no way to ask
+	// later why the weights did not change.
+	WeightsStatusProposed = "proposed"
+	// WeightsStatusActive is the live configuration. At most one row may hold
+	// this status; a partial unique index enforces it.
+	WeightsStatusActive = "active"
+	// WeightsStatusRolledBack is a configuration that was live and was undone.
+	WeightsStatusRolledBack = "rolled_back"
+	// WeightsStatusSuperseded is a configuration that was live and was replaced
+	// by a newer promotion. Rollback restores the most recent of these.
+	WeightsStatusSuperseded = "superseded"
+)
+
+// ErrWeightsRecordNotFound is returned when a promotion targets a row that does
+// not exist.
+var ErrWeightsRecordNotFound = errors.New("weights history: record not found")
+
+// WeightsRecord is one row of search_weights_history.
+//
+// The metric fields are pointers because "not measured" and "measured as zero"
+// are different facts: a proposed candidate that never reached the holdout
+// evaluation has no holdout score, and recording 0.0 would make it look like a
+// catastrophically bad configuration in any later review.
+//
+// No query text and no document IDs appear here by design — see migration 026.
+type WeightsRecord struct {
+	ID             int64
+	Weights        model.SearchWeights
+	Status         string
+	TrainObjective *float64
+	HoldoutNDCG10  *float64
+	HoldoutFP10    *float64
+	BaselineNDCG10 *float64
+	BaselineFP10   *float64
+	HoldoutQueries int
+	// GateReason is written for a human: "holdout distinct queries 12 < 30".
+	GateReason *string
+	// Metadata carries run context such as
+	// {"rerank": false, "train_holdout_gap": 0.04, "sweeps": 2}.
+	// train_holdout_gap is the overfitting tell-tale.
+	Metadata   map[string]any
+	CreatedAt  time.Time
+	PromotedAt *time.Time
+}
+
+// WeightsHistoryStore persists search weight candidates and their promotion
+// state.
+type WeightsHistoryStore struct {
+	pg *Postgres
+}
+
+// NewWeightsHistoryStore returns a WeightsHistoryStore backed by Postgres.
+func NewWeightsHistoryStore(pg *Postgres) *WeightsHistoryStore {
+	return &WeightsHistoryStore{pg: pg}
+}
+
+func validWeightsStatus(s string) bool {
+	switch s {
+	case WeightsStatusProposed, WeightsStatusActive, WeightsStatusRolledBack, WeightsStatusSuperseded:
+		return true
+	default:
+		return false
+	}
+}
+
+// Insert records a candidate and returns its ID.
+//
+// Insert never writes status 'active' on its own: becoming live is what
+// Promote does, in a transaction that first stands the previous holder down.
+// Allowing a direct active insert here would give a caller a way to create the
+// second active row that the whole design exists to prevent.
+func (s *WeightsHistoryStore) Insert(ctx context.Context, rec WeightsRecord) (int64, error) {
+	if !validWeightsStatus(rec.Status) {
+		return 0, fmt.Errorf("weights history insert: invalid status %q", rec.Status)
+	}
+	if rec.Status == WeightsStatusActive {
+		return 0, fmt.Errorf("weights history insert: use Promote to make a record active")
+	}
+
+	weightsJSON, err := json.Marshal(rec.Weights)
+	if err != nil {
+		return 0, fmt.Errorf("weights history insert marshal weights: %w", err)
+	}
+	meta := rec.Metadata
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	metaJSON, err := json.Marshal(meta)
+	if err != nil {
+		return 0, fmt.Errorf("weights history insert marshal metadata: %w", err)
+	}
+
+	var id int64
+	err = s.pg.pool.QueryRow(ctx, `
+		INSERT INTO search_weights_history
+			(weights, status, train_objective, holdout_ndcg10, holdout_fp10,
+			 baseline_ndcg10, baseline_fp10, holdout_queries, gate_reason, metadata)
+		VALUES ($1::jsonb, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+		RETURNING id`,
+		string(weightsJSON), rec.Status, rec.TrainObjective, rec.HoldoutNDCG10, rec.HoldoutFP10,
+		rec.BaselineNDCG10, rec.BaselineFP10, rec.HoldoutQueries, rec.GateReason, string(metaJSON),
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("weights history insert: %w", err)
+	}
+	return id, nil
+}
+
+const weightsSelectColumns = `
+	id, weights, status, train_objective, holdout_ndcg10, holdout_fp10,
+	baseline_ndcg10, baseline_fp10, holdout_queries, gate_reason, metadata,
+	created_at, promoted_at`
+
+// Active returns the live configuration, or (nil, nil) when nothing has been
+// promoted. A nil result is not an error: it is the normal state before the
+// first promotion and after a rollback with nothing to restore, and it means
+// "use the compiled-in defaults".
+func (s *WeightsHistoryStore) Active(ctx context.Context) (*WeightsRecord, error) {
+	row := s.pg.pool.QueryRow(ctx,
+		`SELECT`+weightsSelectColumns+`
+		 FROM search_weights_history WHERE status = '`+WeightsStatusActive+`'`)
+	rec, err := scanWeightsRecord(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("weights history active: %w", err)
+	}
+	return &rec, nil
+}
+
+// Promote makes one record live in a single transaction.
+//
+// The order matters and is not interchangeable: the incumbent is stood down to
+// 'superseded' first, then the target is raised to 'active'. Doing it the other
+// way round puts two active rows in the table for the duration of a statement,
+// and the partial unique index rejects that — the transaction would fail even
+// though the end state is legal.
+func (s *WeightsHistoryStore) Promote(ctx context.Context, id int64) error {
+	tx, err := s.pg.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("weights history promote begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE search_weights_history
+		SET status = '`+WeightsStatusSuperseded+`'
+		WHERE status = '`+WeightsStatusActive+`' AND id <> $1`, id); err != nil {
+		return fmt.Errorf("weights history promote supersede: %w", err)
+	}
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE search_weights_history
+		SET status = '`+WeightsStatusActive+`', promoted_at = now()
+		WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("weights history promote activate: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("weights history promote %d: %w", id, ErrWeightsRecordNotFound)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("weights history promote commit: %w", err)
+	}
+	return nil
+}
+
+// Rollback stands the current configuration down and restores the one it
+// replaced. It returns the restored record, or (nil, nil) when there was
+// nothing to restore — in which case the system falls back to the compiled-in
+// defaults, which is itself a safe state.
+//
+// Runs in one transaction for the same reason as Promote: between the two
+// statements the table would otherwise be readable with zero or two active
+// rows.
+func (s *WeightsHistoryStore) Rollback(ctx context.Context) (*WeightsRecord, error) {
+	tx, err := s.pg.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("weights history rollback begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var currentID int64
+	err = tx.QueryRow(ctx,
+		`SELECT id FROM search_weights_history WHERE status = '`+WeightsStatusActive+`' FOR UPDATE`).Scan(&currentID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Nothing is live; there is nothing to undo.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("weights history rollback read active: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE search_weights_history SET status = '`+WeightsStatusRolledBack+`'
+		WHERE id = $1`, currentID); err != nil {
+		return nil, fmt.Errorf("weights history rollback stand down: %w", err)
+	}
+
+	// The most recently promoted superseded row is the one this configuration
+	// replaced. promoted_at orders them; id breaks ties deterministically.
+	var previousID int64
+	err = tx.QueryRow(ctx, `
+		SELECT id FROM search_weights_history
+		WHERE status = '`+WeightsStatusSuperseded+`'
+		ORDER BY promoted_at DESC NULLS LAST, id DESC
+		LIMIT 1`).Scan(&previousID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("weights history rollback commit: %w", err)
+		}
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("weights history rollback read previous: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE search_weights_history SET status = '`+WeightsStatusActive+`', promoted_at = now()
+		WHERE id = $1`, previousID); err != nil {
+		return nil, fmt.Errorf("weights history rollback restore: %w", err)
+	}
+
+	row := tx.QueryRow(ctx, `SELECT`+weightsSelectColumns+` FROM search_weights_history WHERE id = $1`, previousID)
+	rec, err := scanWeightsRecord(row)
+	if err != nil {
+		return nil, fmt.Errorf("weights history rollback read restored: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("weights history rollback commit: %w", err)
+	}
+	return &rec, nil
+}
+
+func scanWeightsRecord(row pgx.Row) (WeightsRecord, error) {
+	var (
+		rec         WeightsRecord
+		weightsJSON []byte
+		metaJSON    []byte
+	)
+	if err := row.Scan(
+		&rec.ID, &weightsJSON, &rec.Status, &rec.TrainObjective,
+		&rec.HoldoutNDCG10, &rec.HoldoutFP10, &rec.BaselineNDCG10, &rec.BaselineFP10,
+		&rec.HoldoutQueries, &rec.GateReason, &metaJSON, &rec.CreatedAt, &rec.PromotedAt,
+	); err != nil {
+		return WeightsRecord{}, err
+	}
+	if err := json.Unmarshal(weightsJSON, &rec.Weights); err != nil {
+		return WeightsRecord{}, fmt.Errorf("unmarshal weights: %w", err)
+	}
+	if err := json.Unmarshal(metaJSON, &rec.Metadata); err != nil {
+		rec.Metadata = map[string]any{}
+	}
+	return rec, nil
+}

--- a/internal/store/weights_history_test.go
+++ b/internal/store/weights_history_test.go
@@ -1,0 +1,233 @@
+package store
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// search_weights_history — real-database tests.
+//
+// The single-active invariant is enforced by a PARTIAL UNIQUE INDEX and the
+// promotion sequence has to survive it mid-transaction; neither property can be
+// observed without PostgreSQL. Skipped when TEST_DATABASE_URL is unset.
+//
+// TEST_DATABASE_URL must NEVER point at production. These tests clear
+// search_weights_history before and after each case: the single-active
+// invariant is global to the table, so a leftover row from another case would
+// decide the outcome of the next one. That is safe here because the table is
+// written only by the offline weight tuner and never by the serving path — and
+// because a throwaway database is the only legitimate value for that variable.
+// ---------------------------------------------------------------------------
+
+func weightsTestStore(t *testing.T) *WeightsHistoryStore {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping real-database weights history test")
+	}
+	pg, err := NewPostgres(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect to TEST_DATABASE_URL: %v", err)
+	}
+	t.Cleanup(pg.Close)
+
+	clear := func() {
+		if _, err := pg.pool.Exec(context.Background(), `DELETE FROM search_weights_history`); err != nil {
+			t.Fatalf("clear search_weights_history: %v", err)
+		}
+	}
+	clear()
+	t.Cleanup(clear)
+	return NewWeightsHistoryStore(pg)
+}
+
+func dummyWeights(fts float64) model.SearchWeights {
+	return model.SearchWeights{
+		FTSWeight: fts, VecWeight: 1, BigmWeight: 1,
+		SummaryVec: 0.8, EntityWeight: 0.5, RRFK: 60,
+	}
+}
+
+func insertProposed(t *testing.T, s *WeightsHistoryStore, fts float64) int64 {
+	t.Helper()
+	id, err := s.Insert(context.Background(), WeightsRecord{
+		Weights:        dummyWeights(fts),
+		Status:         WeightsStatusProposed,
+		HoldoutQueries: 42,
+		Metadata:       map[string]any{"rerank": false},
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	return id
+}
+
+func countActive(t *testing.T, s *WeightsHistoryStore) int {
+	t.Helper()
+	var n int
+	if err := s.pg.pool.QueryRow(context.Background(),
+		`SELECT count(*)::int FROM search_weights_history WHERE status = 'active'`).Scan(&n); err != nil {
+		t.Fatalf("count active: %v", err)
+	}
+	return n
+}
+
+func TestActive_ReturnsNilWhenEmpty(t *testing.T) {
+	s := weightsTestStore(t)
+	got, err := s.Active(context.Background())
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Active = %+v, want nil when nothing has been promoted", got)
+	}
+}
+
+// TestPromote_LeavesExactlyOneActive is the core invariant: whatever the
+// sequence of promotions, the serving path must find one answer to "which
+// weights are live?", never two.
+func TestPromote_LeavesExactlyOneActive(t *testing.T) {
+	s := weightsTestStore(t)
+	ctx := context.Background()
+
+	var last int64
+	for i := 0; i < 3; i++ {
+		id := insertProposed(t, s, 0.25*float64(i+1))
+		if err := s.Promote(ctx, id); err != nil {
+			t.Fatalf("promote %d: %v", i, err)
+		}
+		last = id
+		if got := countActive(t, s); got != 1 {
+			t.Fatalf("after promotion %d there are %d active rows, want 1", i, got)
+		}
+	}
+
+	active, err := s.Active(ctx)
+	if err != nil {
+		t.Fatalf("Active: %v", err)
+	}
+	if active == nil || active.ID != last {
+		t.Fatalf("Active = %+v, want the row promoted last (id %d)", active, last)
+	}
+	if active.PromotedAt == nil {
+		t.Error("promoted row has no promoted_at timestamp")
+	}
+	if active.Weights != dummyWeights(0.75) {
+		t.Errorf("Active weights = %+v, want %+v (JSON round-trip lost data)", active.Weights, dummyWeights(0.75))
+	}
+}
+
+// TestPromote_IsAtomicUnderDuplicateActive proves the invariant lives in the
+// database. An application-level check would pass here and still corrupt the
+// table under two concurrent tuner runs.
+func TestPromote_IsAtomicUnderDuplicateActive(t *testing.T) {
+	s := weightsTestStore(t)
+	ctx := context.Background()
+
+	a := insertProposed(t, s, 0.5)
+	b := insertProposed(t, s, 1.0)
+	if err := s.Promote(ctx, a); err != nil {
+		t.Fatalf("promote a: %v", err)
+	}
+	// Bypass the store deliberately: the point is that raw SQL cannot create a
+	// second active row either.
+	if _, err := s.pg.pool.Exec(ctx,
+		`UPDATE search_weights_history SET status = 'active' WHERE id = $1`, b); err == nil {
+		t.Fatal("database accepted a second active row; the single-active invariant is not enforced")
+	}
+	if got := countActive(t, s); got != 1 {
+		t.Fatalf("active rows = %d, want 1", got)
+	}
+}
+
+func TestPromote_UnknownIDFails(t *testing.T) {
+	s := weightsTestStore(t)
+	if err := s.Promote(context.Background(), 987654321); err == nil {
+		t.Fatal("Promote accepted an unknown id")
+	}
+}
+
+// TestRollback_RestoresPreviousActive pins the escape hatch: a promotion that
+// turns out to be wrong must be undoable without a deploy.
+func TestRollback_RestoresPreviousActive(t *testing.T) {
+	s := weightsTestStore(t)
+	ctx := context.Background()
+
+	a := insertProposed(t, s, 0.5)
+	b := insertProposed(t, s, 1.75)
+	if err := s.Promote(ctx, a); err != nil {
+		t.Fatalf("promote a: %v", err)
+	}
+	if err := s.Promote(ctx, b); err != nil {
+		t.Fatalf("promote b: %v", err)
+	}
+
+	restored, err := s.Rollback(ctx)
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if restored == nil || restored.ID != a {
+		t.Fatalf("Rollback restored %+v, want the row promoted before (id %d)", restored, a)
+	}
+	if got := countActive(t, s); got != 1 {
+		t.Fatalf("active rows = %d, want 1", got)
+	}
+
+	var statusB string
+	if err := s.pg.pool.QueryRow(ctx,
+		`SELECT status FROM search_weights_history WHERE id = $1`, b).Scan(&statusB); err != nil {
+		t.Fatalf("read b: %v", err)
+	}
+	if statusB != WeightsStatusRolledBack {
+		t.Errorf("rolled-back row status = %q, want %q", statusB, WeightsStatusRolledBack)
+	}
+}
+
+// TestRollback_NoPreviousReturnsNilNoError covers the first-ever promotion:
+// undoing it returns the system to "no active row", which is the code default.
+func TestRollback_NoPreviousReturnsNilNoError(t *testing.T) {
+	s := weightsTestStore(t)
+	ctx := context.Background()
+
+	a := insertProposed(t, s, 0.5)
+	if err := s.Promote(ctx, a); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	restored, err := s.Rollback(ctx)
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if restored != nil {
+		t.Fatalf("Rollback = %+v, want nil (nothing to restore)", restored)
+	}
+	if got := countActive(t, s); got != 0 {
+		t.Fatalf("active rows = %d, want 0 (fall back to the code defaults)", got)
+	}
+}
+
+func TestRollback_WithNoActiveIsANoOp(t *testing.T) {
+	s := weightsTestStore(t)
+	restored, err := s.Rollback(context.Background())
+	if err != nil {
+		t.Fatalf("Rollback with nothing active: %v", err)
+	}
+	if restored != nil {
+		t.Fatalf("Rollback = %+v, want nil", restored)
+	}
+}
+
+// TestInsert_RejectsUnknownStatus keeps a typo from creating a status the
+// promotion logic does not understand.
+func TestInsert_RejectsUnknownStatus(t *testing.T) {
+	s := weightsTestStore(t)
+	_, err := s.Insert(context.Background(), WeightsRecord{
+		Weights: dummyWeights(1), Status: "activated",
+	})
+	if err == nil {
+		t.Fatal("Insert accepted an unknown status")
+	}
+}

--- a/internal/tune/harness.go
+++ b/internal/tune/harness.go
@@ -1,0 +1,84 @@
+// Package tune measures search-weight candidates against labelled feedback.
+//
+// It is deliberately the only place that knows how to turn a set of weights
+// into a number. The holdout half of the labels is never visible here: this
+// package receives a *dataset.HoldoutSet at most as something to call
+// Evaluate on, and the Go compiler prevents it from reading anything inside.
+package tune
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/baekenough/second-brain/internal/dataset"
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/search"
+)
+
+// Searcher is the one capability the harness needs. *search.Service satisfies
+// it.
+type Searcher interface {
+	Search(ctx context.Context, q model.SearchQuery) ([]*model.SearchResult, error)
+}
+
+// Compile-time proof that the production search service still fits.
+var _ Searcher = (*search.Service)(nil)
+
+// RunnerFor returns a dataset.RunFunc that searches with exactly the given
+// weights.
+//
+// Weights travel on the query rather than through search.Service.WithWeights.
+// WithWeights mutates the service and returns it, so evaluating a second
+// candidate through the same instance would leave the first candidate's
+// weights in place for any lane that did not overwrite them — a silent
+// contamination that produces plausible-looking numbers for the wrong
+// configuration. model.SearchQuery.Weights is per-request and takes precedence
+// over the service-level value, which makes each evaluation independent by
+// construction and lets a single service instance be reused safely.
+//
+// Defaults() is applied so that a candidate can never collapse to the zero
+// value, which search.Service reads as "fall back to whatever this service was
+// configured with".
+//
+// UseRerank and UseHyDE are forced off, not merely left unset:
+//   - HyDE calls a remote LLM, so the same query would retrieve different
+//     candidates on each sweep. A search whose result depends on the weather is
+//     not something to tune against, and hundreds of sweeps would bill for it.
+//   - The reranker is a separate HTTP service that the batch host is not
+//     guaranteed to reach (macmini and ubuntu1 cannot address each other's
+//     service ports). Baseline and candidate are compared under identical
+//     conditions, so the relative comparison stays valid; the absolute numbers
+//     are simply pre-rerank numbers, and the weights being tuned act on RRF
+//     fusion, which happens before reranking anyway. Record rerank=false
+//     alongside any promoted result so this is not mistaken for a live measure.
+func RunnerFor(svc Searcher, w model.SearchWeights) dataset.RunFunc {
+	weights := w.Defaults()
+	return func(ctx context.Context, query string, k int) ([]string, error) {
+		results, err := svc.Search(ctx, model.SearchQuery{
+			Query:     query,
+			Limit:     k,
+			Weights:   weights,
+			UseRerank: false,
+			UseHyDE:   false,
+		})
+		if err != nil {
+			// The query text is not included: it is the user's own words.
+			return nil, fmt.Errorf("tune: search for %s: %w", dataset.QueryHash(query), err)
+		}
+		if k > 0 && len(results) > k {
+			results = results[:k]
+		}
+		ids := make([]string, len(results))
+		for i, r := range results {
+			ids[i] = r.ID.String()
+		}
+		return ids, nil
+	}
+}
+
+// Objective scores a measurement. It delegates to dataset.ObjectiveOf so that
+// the optimiser and the promotion gate cannot end up with different ideas of
+// what an improvement is.
+func Objective(m dataset.Metrics) float64 {
+	return dataset.ObjectiveOf(m.NDCG10, m.FPPenalty10)
+}

--- a/internal/tune/harness_test.go
+++ b/internal/tune/harness_test.go
@@ -1,0 +1,156 @@
+package tune
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/dataset"
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+)
+
+type stubSearcher struct {
+	calls   []model.SearchQuery
+	results []*model.SearchResult
+	err     error
+}
+
+func (s *stubSearcher) Search(_ context.Context, q model.SearchQuery) ([]*model.SearchResult, error) {
+	s.calls = append(s.calls, q)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.results, nil
+}
+
+func resultWithID(id uuid.UUID) *model.SearchResult {
+	r := &model.SearchResult{}
+	r.ID = id
+	return r
+}
+
+// TestRunnerFor_AppliesWeightsPerCandidate is the contamination guard. Two
+// candidates evaluated in sequence must reach the searcher with their own
+// weights; if the second run inherited the first candidate's weights the whole
+// comparison would be measuring the wrong thing while looking perfectly healthy.
+func TestRunnerFor_AppliesWeightsPerCandidate(t *testing.T) {
+	t.Parallel()
+	stub := &stubSearcher{}
+	a := model.SearchWeights{FTSWeight: 0.25, VecWeight: 2.0, BigmWeight: 1.0, SummaryVec: 0.05, EntityWeight: 0.05, RRFK: 20}
+	b := model.SearchWeights{FTSWeight: 2.0, VecWeight: 0.25, BigmWeight: 1.0, SummaryVec: 1.5, EntityWeight: 1.5, RRFK: 120}
+
+	for _, w := range []model.SearchWeights{a, b, a} {
+		if _, err := RunnerFor(stub, w)(context.Background(), "dummy query", 10); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	}
+
+	if len(stub.calls) != 3 {
+		t.Fatalf("searcher called %d times, want 3", len(stub.calls))
+	}
+	want := []model.SearchWeights{a.Defaults(), b.Defaults(), a.Defaults()}
+	for i, w := range want {
+		if stub.calls[i].Weights != w {
+			t.Errorf("call %d weights = %+v, want %+v", i, stub.calls[i].Weights, w)
+		}
+	}
+}
+
+// TestRunnerFor_ForcesRerankAndHyDEOff pins reproducibility. HyDE calls a remote
+// LLM, so the same query would return different candidates on every sweep and
+// each evaluation would cost money; the reranker is an HTTP service the batch
+// host is not guaranteed to reach at all.
+func TestRunnerFor_ForcesRerankAndHyDEOff(t *testing.T) {
+	t.Parallel()
+	stub := &stubSearcher{}
+	w := model.SearchWeights{FTSWeight: 1, VecWeight: 1, BigmWeight: 1, SummaryVec: 0.8, EntityWeight: 0.5, RRFK: 60}
+	if _, err := RunnerFor(stub, w)(context.Background(), "dummy query", 10); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got := stub.calls[0]
+	if got.UseRerank {
+		t.Error("UseRerank is true; the batch host cannot be assumed to reach the reranker")
+	}
+	if got.UseHyDE {
+		t.Error("UseHyDE is true; evaluation would stop being reproducible")
+	}
+	if got.Limit != 10 {
+		t.Errorf("Limit = %d, want the requested k (10)", got.Limit)
+	}
+	if got.Query != "dummy query" {
+		t.Errorf("Query = %q, want it passed through unchanged", got.Query)
+	}
+}
+
+func TestRunnerFor_ReturnsDocumentIDsInRankOrder(t *testing.T) {
+	t.Parallel()
+	ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+	stub := &stubSearcher{results: []*model.SearchResult{
+		resultWithID(ids[0]), resultWithID(ids[1]), resultWithID(ids[2]),
+	}}
+	got, err := RunnerFor(stub, model.SearchWeights{})(context.Background(), "dummy query", 10)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d ids, want 3", len(got))
+	}
+	for i, id := range ids {
+		if got[i] != id.String() {
+			t.Errorf("position %d = %s, want %s", i, got[i], id)
+		}
+	}
+}
+
+func TestRunnerFor_TruncatesToK(t *testing.T) {
+	t.Parallel()
+	stub := &stubSearcher{}
+	for i := 0; i < 5; i++ {
+		stub.results = append(stub.results, resultWithID(uuid.New()))
+	}
+	got, err := RunnerFor(stub, model.SearchWeights{})(context.Background(), "dummy query", 3)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d ids, want 3", len(got))
+	}
+}
+
+// TestRunnerFor_PropagatesSearchError keeps a broken database from being scored
+// as a bad set of weights.
+func TestRunnerFor_PropagatesSearchError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("db down")
+	_, err := RunnerFor(&stubSearcher{err: boom}, model.SearchWeights{})(context.Background(), "dummy query", 10)
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want %v", err, boom)
+	}
+}
+
+func TestObjective_PenalisesFalsePositives(t *testing.T) {
+	t.Parallel()
+	prev := Objective(dataset.Metrics{NDCG10: 0.8, FPPenalty10: 0})
+	for _, fp := range []float64{0.1, 0.2, 0.4, 0.8} {
+		got := Objective(dataset.Metrics{NDCG10: 0.8, FPPenalty10: fp})
+		if got >= prev {
+			t.Fatalf("objective did not decrease as FP grew: fp=%v gave %v, previous %v", fp, got, prev)
+		}
+		prev = got
+	}
+	if got, want := Objective(dataset.Metrics{NDCG10: 0.8, FPPenalty10: 0.2}), 0.8-0.5*0.2; math.Abs(got-want) > 1e-12 {
+		t.Errorf("Objective = %v, want %v", got, want)
+	}
+}
+
+// TestObjective_MatchesDatasetDefinition keeps the tuner and the dataset
+// package from drifting into two different notions of "better".
+func TestObjective_MatchesDatasetDefinition(t *testing.T) {
+	t.Parallel()
+	m := dataset.Metrics{NDCG10: 0.61, FPPenalty10: 0.13}
+	if got, want := Objective(m), dataset.ObjectiveOf(m.NDCG10, m.FPPenalty10); got != want {
+		t.Fatalf("Objective = %v, dataset.ObjectiveOf = %v", got, want)
+	}
+}

--- a/internal/worker/extraction_worker.go
+++ b/internal/worker/extraction_worker.go
@@ -345,12 +345,22 @@ func (w *ExtractionWorker) persistAction(ctx context.Context, doc *model.Documen
 
 	var counterpartID *int64
 	var counterpartIdentity string
+	var counterpartName string
+	var counterpartType model.EntityType
 	if a.Kind == string(model.KindAwaitingMyReply) {
 		identity, ok := action.CounterpartIdentity(doc, func(addr string) bool { return action.IsUserAddress(w.userAddrs, addr) })
 		if !ok {
 			return nil // e.g. gmail "from" is the user's own address — not awaiting a reply
 		}
 		counterpartIdentity = identity
+		// The counterpart of an awaiting_my_reply action is fixed by the
+		// document's metadata, not named by the LLM (that is what makes the
+		// structural and LLM candidates converge on one identity_key). It
+		// still deserves an entities row, so the card can name who is
+		// waiting; the store resolves the label.
+		if name, entityType, ok := action.CounterpartDisplay(doc); ok {
+			counterpartName, counterpartType = name, entityType
+		}
 	} else {
 		counterpartIdentity = strings.ToLower(strings.TrimSpace(a.Counterpart))
 		if a.Counterpart != "" {
@@ -371,6 +381,8 @@ func (w *ExtractionWorker) persistAction(ctx context.Context, doc *model.Documen
 		Kind:                model.ActionKind(a.Kind),
 		Summary:             a.Summary,
 		CounterpartEntityID: counterpartID,
+		CounterpartName:     counterpartName,
+		CounterpartType:     counterpartType,
 		DetectedBy:          model.DetectedLLM,
 		Confidence:          a.Confidence,
 		ObservedAt:          time.Now().UTC(),

--- a/internal/worker/extraction_worker_test.go
+++ b/internal/worker/extraction_worker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/baekenough/second-brain/internal/action"
 	"github.com/baekenough/second-brain/internal/llm"
 	"github.com/baekenough/second-brain/internal/model"
 	"github.com/google/uuid"
@@ -568,5 +569,46 @@ func TestNewExtractionWorker_Defaults(t *testing.T) {
 	}
 	if w.extractFn == nil {
 		t.Error("extractFn must default to ExtractRelationsAndActions")
+	}
+}
+
+// TestExtractionWorker_AwaitingMyReply_CarriesCounterpartLabel closes the
+// second half of the "nameless action card" defect on the LLM path. The
+// counterpart of an awaiting_my_reply action is fixed by document metadata
+// (never named by the LLM, so the structural and LLM candidates converge on
+// one identity_key) — which used to mean it was never resolved to an entity
+// either, leaving counterpart_entity_id NULL. The worker now states the
+// display label and the store resolves it, WITHOUT that label entering the
+// identity_key.
+func TestExtractionWorker_AwaitingMyReply_CarriesCounterpartLabel(t *testing.T) {
+	t.Parallel()
+
+	docID := uuid.New()
+	doc := newExtractionDoc(docID, 0)
+	doc.Metadata["from"] = `"테스트발신자" <counterpart@example.com>`
+	lister := &fakeExtractionLister{docs: []*model.Document{doc}}
+	actions := &fakeActionWriter{}
+
+	w := newTestExtractionWorker(lister, &fakeRelationEntityResolver{}, &fakeRelationWriter{}, actions,
+		func(_ context.Context, _ llm.Completer, _ *model.Document, _ []string) (*ExtractionResult, error) {
+			return &ExtractionResult{
+				Actions: []rawAction{
+					{Kind: string(model.KindAwaitingMyReply), Summary: "dummy llm summary", Confidence: 0.6},
+				},
+			}, nil
+		},
+	)
+	w.tick(context.Background())
+
+	if len(actions.upsertedActions) != 1 {
+		t.Fatalf("UpsertAction called %d times, want 1", len(actions.upsertedActions))
+	}
+	got := actions.upsertedActions[0]
+	if got.CounterpartName != "테스트발신자" || got.CounterpartType != model.EntityTypePerson {
+		t.Errorf("counterpart label = (%q, %q), want (%q, %q)", got.CounterpartName, got.CounterpartType, "테스트발신자", model.EntityTypePerson)
+	}
+	wantKey := action.BuildIdentityKey("gmail:thread-1", string(model.KindAwaitingMyReply), `"테스트발신자" <counterpart@example.com>`, "")
+	if got.IdentityKey != wantKey {
+		t.Errorf("IdentityKey = %q, want %q (the raw From header, not the display label, is hashed)", got.IdentityKey, wantKey)
 	}
 }

--- a/internal/worker/structural_signals.go
+++ b/internal/worker/structural_signals.go
@@ -16,11 +16,21 @@ import (
 // ThreadLatestMessage is one row of StructuralSignalLister.ListLatestPerThread's
 // result: the most recent document in a conversation thread, plus what's
 // needed to determine whether it is an "awaiting my reply" candidate (spec
-// §7.1).
+// §7.1) and to describe it on an action card.
+//
+// Title and EventAt exist only for the card: the summary this worker writes
+// used to be a fixed constant, which made every awaiting_my_reply row read
+// identically. They are the two document columns that carry conversation
+// context without carrying the message body.
 type ThreadLatestMessage struct {
 	DocumentID uuid.UUID
 	SourceType string
 	Metadata   map[string]any
+	Title      string
+	// EventAt is COALESCE(occurred_at, collected_at) — occurred_at is
+	// nullable, and ingest order is a serviceable stand-in for event time
+	// when the collector could not determine one.
+	EventAt time.Time
 }
 
 // StructuralSignalLister provides the thread-grouped SQL query consumed by
@@ -59,7 +69,8 @@ func NewPgStructuralSignalLister(pool *pgxpool.Pool) *PgStructuralSignalLister {
 // No LLM call — pure SQL, safe to run far more often than ExtractionWorker.
 const listLatestPerThreadQuery = `
 	WITH ranked AS (
-		SELECT id, source_type, metadata,
+		SELECT id, source_type, metadata, title,
+		       COALESCE(occurred_at, collected_at) AS event_at,
 		       row_number() OVER (
 		           PARTITION BY
 		               CASE
@@ -75,7 +86,7 @@ const listLatestPerThreadQuery = `
 		  AND occurred_at >= now() - interval '30 days'
 		  AND (source_type <> 'sms' OR COALESCE((metadata->>'is_auth_like')::boolean, false) = false)
 	)
-	SELECT id, source_type, metadata FROM ranked WHERE rn = 1
+	SELECT id, source_type, metadata, title, event_at FROM ranked WHERE rn = 1
 	LIMIT $1`
 
 // ListLatestPerThread implements StructuralSignalLister.
@@ -90,7 +101,7 @@ func (l *PgStructuralSignalLister) ListLatestPerThread(ctx context.Context, limi
 	for rows.Next() {
 		var m ThreadLatestMessage
 		var metaJSON []byte
-		if err := rows.Scan(&m.DocumentID, &m.SourceType, &metaJSON); err != nil {
+		if err := rows.Scan(&m.DocumentID, &m.SourceType, &metaJSON, &m.Title, &m.EventAt); err != nil {
 			return nil, fmt.Errorf("scan thread latest message: %w", err)
 		}
 		if len(metaJSON) > 0 {
@@ -118,6 +129,10 @@ type StructuralSignalWorkerConfig struct {
 	// BatchSize is the number of threads inspected per tick. Defaults to 500
 	// (this is cheap SQL-only work, so the default batch is generous).
 	BatchSize int
+	// Now supplies the current instant used to age each thread ("3일째
+	// 미응답"). Defaults to time.Now. Injectable so a test can assert the
+	// rendered card without racing the wall clock.
+	Now func() time.Time
 }
 
 // StructuralSignalWorker computes the "awaiting my reply" candidate action
@@ -131,6 +146,7 @@ type StructuralSignalWorker struct {
 	userAddresses []string
 	interval      time.Duration
 	batchSize     int
+	now           func() time.Time
 }
 
 // NewStructuralSignalWorker constructs a StructuralSignalWorker from cfg.
@@ -150,12 +166,17 @@ func NewStructuralSignalWorker(cfg StructuralSignalWorkerConfig) *StructuralSign
 	if batchSize <= 0 {
 		batchSize = 500
 	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
 	return &StructuralSignalWorker{
 		store:         cfg.Store,
 		actions:       cfg.Actions,
 		userAddresses: cfg.UserAddresses,
 		interval:      interval,
 		batchSize:     batchSize,
+		now:           now,
 	}
 }
 
@@ -191,7 +212,16 @@ func (w *StructuralSignalWorker) Tick(ctx context.Context) {
 }
 
 func (w *StructuralSignalWorker) processMessage(ctx context.Context, m ThreadLatestMessage) {
-	doc := &model.Document{ID: m.DocumentID, SourceType: model.SourceType(m.SourceType), Metadata: m.Metadata}
+	doc := &model.Document{
+		ID:         m.DocumentID,
+		SourceType: model.SourceType(m.SourceType),
+		Metadata:   m.Metadata,
+		Title:      m.Title,
+	}
+	if !m.EventAt.IsZero() {
+		eventAt := m.EventAt
+		doc.OccurredAt = &eventAt
+	}
 
 	// Defense in depth: ListLatestPerThread's SQL already excludes
 	// is_auth_like sms documents at the source (spec §7.4), but this Go-level
@@ -217,19 +247,31 @@ func (w *StructuralSignalWorker) processMessage(ctx context.Context, m ThreadLat
 
 	identityKey := action.BuildIdentityKey(threadKey, string(model.KindAwaitingMyReply), counterpart, "")
 
+	// displayName is the label a human reads; counterpart (above) is the
+	// hash input. They are intentionally different strings — see
+	// action.CounterpartDisplay. An unresolvable display name leaves both the
+	// card label and counterpart_entity_id empty rather than inventing one.
+	displayName, entityType, hasDisplay := action.CounterpartDisplay(doc)
+	if !hasDisplay {
+		displayName, entityType = "", ""
+	}
+
 	if err := w.actions.UpsertAction(ctx, model.Action{
 		IdentityKey: identityKey,
 		DocumentID:  doc.ID,
 		ThreadKey:   threadKey,
 		Kind:        model.KindAwaitingMyReply,
-		// Fixed template summary, not free text — matches NormalizeSummary's
-		// treatment of this kind (the text itself is never hashed, but a
-		// stored summary still needs SOME value for Part C's briefing to
-		// display).
-		Summary:    "마지막 메시지 이후 응답 없음",
-		DetectedBy: model.DetectedStructural,
-		Confidence: 1.0, // deterministic rule, not a probabilistic guess
-		ObservedAt: time.Now().UTC(),
+		// Generated per thread, NOT a fixed template: a constant made all 434
+		// of these rows render as the same card. The text is still never
+		// hashed — NormalizeSummary discards it for this kind — so it may
+		// change on every tick (it reports the thread's age) without moving
+		// identity_key.
+		Summary:         action.AwaitingReplySummary(doc, displayName, w.now()),
+		CounterpartName: displayName,
+		CounterpartType: entityType,
+		DetectedBy:      model.DetectedStructural,
+		Confidence:      1.0, // deterministic rule, not a probabilistic guess
+		ObservedAt:      w.now().UTC(),
 	}); err != nil {
 		slog.Warn("structural signal worker: upsert action failed", "doc_id", doc.ID, "error", err)
 		return

--- a/internal/worker/structural_signals_sql_test.go
+++ b/internal/worker/structural_signals_sql_test.go
@@ -1,0 +1,123 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ---------------------------------------------------------------------------
+// PgStructuralSignalLister — real-database test.
+//
+// listLatestPerThreadQuery gained two columns (title and
+// COALESCE(occurred_at, collected_at)) so the action card can say WHICH
+// conversation is waiting. A stub cannot prove a query compiles or that the
+// scan targets line up — this project already shipped SQL that passed stub
+// tests and failed in production (EXCLUDED inside RETURNING). So this runs
+// against a real PostgreSQL addressed by TEST_DATABASE_URL and skips when it
+// is unset.
+//
+// TEST_DATABASE_URL must NEVER point at production. Every row written here is
+// prefixed with a sentinel and deleted in cleanup; all content is dummy.
+// ---------------------------------------------------------------------------
+
+const structuralSQLTestSourceID = "zz-dummy-structural-sql"
+
+func structuralTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping real-database structural signal query test")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect to TEST_DATABASE_URL: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(),
+			`DELETE FROM documents WHERE source_id LIKE $1`, structuralSQLTestSourceID+"%"); err != nil {
+			t.Errorf("cleanup documents: %v", err)
+		}
+	})
+	return pool
+}
+
+func insertThreadDocument(t *testing.T, pool *pgxpool.Pool, sourceType, title, metadata string, occurredAt *time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO documents (id, source_type, source_id, title, content, metadata, collected_at, occurred_at, status)
+		VALUES ($1, $2, $3, $4, 'dummy content', $5::jsonb, now(), $6, 'active')`,
+		id, sourceType, structuralSQLTestSourceID+"-"+id.String(), title, metadata, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("insert %s document: %v", sourceType, err)
+	}
+	return id
+}
+
+// TestListLatestPerThreadReturnsTitleAndEventTime pins the query's contract:
+// one row per thread (the newest), carrying the two new card columns.
+func TestListLatestPerThreadReturnsTitleAndEventTime(t *testing.T) {
+	pool := structuralTestPool(t)
+
+	newest := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	older := newest.Add(-48 * time.Hour)
+
+	insertThreadDocument(t, pool, "sms", "SMS received zz-dummy", `{"contact_name":"zz-dummy-contact","direction":"received"}`, &older)
+	newestID := insertThreadDocument(t, pool, "sms", "SMS received zz-dummy (newest)", `{"contact_name":"zz-dummy-contact","direction":"received"}`, &newest)
+
+	got, err := NewPgStructuralSignalLister(pool).ListLatestPerThread(context.Background(), 500)
+	if err != nil {
+		t.Fatalf("ListLatestPerThread: %v", err)
+	}
+
+	var found *ThreadLatestMessage
+	var sameThread int
+	for i := range got {
+		if name, _ := got[i].Metadata["contact_name"].(string); name == "zz-dummy-contact" {
+			sameThread++
+			found = &got[i]
+		}
+	}
+	if sameThread != 1 {
+		t.Fatalf("got %d rows for one thread, want 1 (the newest message only)", sameThread)
+	}
+	if found.DocumentID != newestID {
+		t.Errorf("DocumentID = %s, want the newest message %s", found.DocumentID, newestID)
+	}
+	if found.Title != "SMS received zz-dummy (newest)" {
+		t.Errorf("Title = %q, want the newest message's title", found.Title)
+	}
+	if !found.EventAt.Equal(newest) {
+		t.Errorf("EventAt = %s, want %s (occurred_at)", found.EventAt, newest)
+	}
+}
+
+// TestListLatestPerThreadSkipsDocumentsWithoutEventTime documents an existing
+// limitation this change did NOT alter: the 30-day window is evaluated on
+// occurred_at, so a thread whose newest message has none never produces an
+// awaiting_my_reply candidate at all. EventAt's COALESCE to collected_at is
+// therefore defence for any future caller that relaxes the window, not a
+// behaviour change here — widening the window would create actions for threads
+// that have never had them, which is a separate decision.
+func TestListLatestPerThreadSkipsDocumentsWithoutEventTime(t *testing.T) {
+	pool := structuralTestPool(t)
+
+	insertThreadDocument(t, pool, "sms", "SMS received zz-dummy-noevent", `{"contact_name":"zz-dummy-contact-noevent","direction":"received"}`, nil)
+
+	got, err := NewPgStructuralSignalLister(pool).ListLatestPerThread(context.Background(), 500)
+	if err != nil {
+		t.Fatalf("ListLatestPerThread: %v", err)
+	}
+	for _, m := range got {
+		if name, _ := m.Metadata["contact_name"].(string); name == "zz-dummy-contact-noevent" {
+			t.Fatalf("a document with NULL occurred_at was returned (EventAt=%s); the 30-day window filters on occurred_at", m.EventAt)
+		}
+	}
+}

--- a/internal/worker/structural_signals_test.go
+++ b/internal/worker/structural_signals_test.go
@@ -2,7 +2,10 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
+	"unicode/utf8"
 
 	"github.com/baekenough/second-brain/internal/action"
 	"github.com/baekenough/second-brain/internal/model"
@@ -17,15 +20,34 @@ func (f *fakeStructuralLister) ListLatestPerThread(_ context.Context, _ int) ([]
 	return f.messages, nil
 }
 
+// fakeStructuralActionWriter records what the worker asked the store to write.
+// upsertErr/statusErr exist so the failure paths are exercisable: a double
+// that can only succeed proves nothing about a worker whose whole job is to
+// keep writing on the next tick after a failed one. ctxErr captures whether
+// the write was attempted with an already-cancelled context.
 type fakeStructuralActionWriter struct {
-	upserted []model.Action
+	upserted    []model.Action
+	upsertErr   error
+	statusErr   error
+	statusCalls int
+	ctxErr      error
 }
 
-func (f *fakeStructuralActionWriter) UpsertAction(_ context.Context, a model.Action) error {
+func (f *fakeStructuralActionWriter) UpsertAction(ctx context.Context, a model.Action) error {
+	if err := ctx.Err(); err != nil && f.ctxErr == nil {
+		f.ctxErr = err
+	}
 	f.upserted = append(f.upserted, a)
-	return nil
+	return f.upsertErr
 }
-func (f *fakeStructuralActionWriter) EnsureOpenStatus(_ context.Context, _ string) error { return nil }
+
+func (f *fakeStructuralActionWriter) EnsureOpenStatus(ctx context.Context, _ string) error {
+	if err := ctx.Err(); err != nil && f.ctxErr == nil {
+		f.ctxErr = err
+	}
+	f.statusCalls++
+	return f.statusErr
+}
 
 // TestStructuralSignalWorker_InboundSMS_CreatesAwaitingMyReply verifies the
 // simplest positive case: an sms document with direction=received is the
@@ -169,5 +191,204 @@ func TestStructuralSignalWorker_SMSNoContactName_FallsBackToNumberHash(t *testin
 	}
 	if actions.upserted[0].ThreadKey == "sms:"+number {
 		t.Error("ThreadKey used the raw phone number instead of its hash")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Card content: the summary and the counterpart label.
+//
+// Before this change every awaiting_my_reply action carried the fixed string
+// below, so the /actions screen rendered 50 identical cards and the
+// counterpart column was empty for every one of them (the worker never set
+// CounterpartName, so counterpart_entity_id was NULL by construction).
+// ---------------------------------------------------------------------------
+
+// legacyStructuralSummary is the constant the worker used to write.
+const legacyStructuralSummary = "마지막 메시지 이후 응답 없음"
+
+// fixedNow pins the worker's clock so summaries are deterministic. 12:00 KST.
+var fixedNow = time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+
+// TestStructuralSignalWorker_SummariesAreThreadSpecific is the headline
+// regression test: three different conversations must yield three different
+// cards, none of them the old constant.
+func TestStructuralSignalWorker_SummariesAreThreadSpecific(t *testing.T) {
+	t.Parallel()
+	lister := &fakeStructuralLister{messages: []ThreadLatestMessage{
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceSMS),
+			Metadata: map[string]any{"contact_name": "테스트연락처A", "direction": "received"},
+			Title:    "SMS received A", EventAt: fixedNow.AddDate(0, 0, -2),
+		},
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceGmail),
+			Metadata: map[string]any{"thread_id": "t1", "from": `"테스트발신자B" <b@example.test>`},
+			Title:    "8월 정산 자료 요청", EventAt: fixedNow.AddDate(0, 0, -5),
+		},
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceCallLog),
+			Metadata: map[string]any{"contact_name": "테스트연락처C", "direction": "missed"},
+			Title:    "missed 통화 C", EventAt: fixedNow,
+		},
+	}}
+	actions := &fakeStructuralActionWriter{}
+	w := NewStructuralSignalWorker(StructuralSignalWorkerConfig{
+		Store: lister, Actions: actions, Now: func() time.Time { return fixedNow },
+	})
+	w.Tick(context.Background())
+
+	if len(actions.upserted) != 3 {
+		t.Fatalf("got %d actions, want 3", len(actions.upserted))
+	}
+	seen := make(map[string]int, 3)
+	for _, a := range actions.upserted {
+		if a.Summary == legacyStructuralSummary {
+			t.Errorf("action %s still carries the fixed constant summary", a.ThreadKey)
+		}
+		if n := utf8.RuneCountInString(a.Summary); n > 80 || n == 0 {
+			t.Errorf("summary %q is %d runes, want 1..80", a.Summary, n)
+		}
+		seen[a.Summary]++
+	}
+	for text, n := range seen {
+		if n > 1 {
+			t.Errorf("summary %q was written for %d different threads", text, n)
+		}
+	}
+}
+
+// TestStructuralSignalWorker_PopulatesCounterpartNameForResolution pins the
+// counterpart_entity_id fix at its origin. The worker itself does not touch
+// the entities table — it hands the store a human-readable label plus the
+// entity type to file it under, and ActionStore.UpsertAction resolves it.
+// Before this change the field did not exist and every structural action was
+// written with a NULL counterpart.
+func TestStructuralSignalWorker_PopulatesCounterpartNameForResolution(t *testing.T) {
+	t.Parallel()
+	lister := &fakeStructuralLister{messages: []ThreadLatestMessage{
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceSMS),
+			Metadata: map[string]any{"contact_name": "테스트연락처A", "direction": "received"},
+			EventAt:  fixedNow,
+		},
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceGmail),
+			Metadata: map[string]any{"thread_id": "t1", "from": `"테스트발신자B" <b@example.test>`},
+			EventAt:  fixedNow,
+		},
+	}}
+	actions := &fakeStructuralActionWriter{}
+	w := NewStructuralSignalWorker(StructuralSignalWorkerConfig{
+		Store: lister, Actions: actions, Now: func() time.Time { return fixedNow },
+	})
+	w.Tick(context.Background())
+
+	if len(actions.upserted) != 2 {
+		t.Fatalf("got %d actions, want 2", len(actions.upserted))
+	}
+	if got := actions.upserted[0]; got.CounterpartName != "테스트연락처A" || got.CounterpartType != model.EntityTypePerson {
+		t.Errorf("sms action counterpart = (%q, %q), want (%q, %q)", got.CounterpartName, got.CounterpartType, "테스트연락처A", model.EntityTypePerson)
+	}
+	if got := actions.upserted[1]; got.CounterpartName != "테스트발신자B" || got.CounterpartType != model.EntityTypePerson {
+		t.Errorf("gmail action counterpart = (%q, %q), want (%q, %q)", got.CounterpartName, got.CounterpartType, "테스트발신자B", model.EntityTypePerson)
+	}
+	// The identity string (what identity_key hashes) is unchanged: still the
+	// raw From header, not the display name.
+	wantKey := action.BuildIdentityKey("gmail:t1", string(model.KindAwaitingMyReply), `"테스트발신자B" <b@example.test>`, "")
+	if actions.upserted[1].IdentityKey != wantKey {
+		t.Errorf("gmail IdentityKey = %q, want %q (counterpart display name must not enter the key)", actions.upserted[1].IdentityKey, wantKey)
+	}
+}
+
+// TestStructuralSignalWorker_UnnamedCounterpart_LeavesNameEmpty keeps junk out
+// of the entities table: a thread whose only handle is a hashed number has no
+// label worth registering, and filing every such thread under one shared row
+// would merge unrelated callers.
+func TestStructuralSignalWorker_UnnamedCounterpart_LeavesNameEmpty(t *testing.T) {
+	t.Parallel()
+	lister := &fakeStructuralLister{messages: []ThreadLatestMessage{
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceSMS),
+			Metadata: map[string]any{"direction": "received"}, EventAt: fixedNow,
+		},
+	}}
+	actions := &fakeStructuralActionWriter{}
+	w := NewStructuralSignalWorker(StructuralSignalWorkerConfig{
+		Store: lister, Actions: actions, Now: func() time.Time { return fixedNow },
+	})
+	w.Tick(context.Background())
+
+	if len(actions.upserted) != 1 {
+		t.Fatalf("got %d actions, want 1", len(actions.upserted))
+	}
+	if name := actions.upserted[0].CounterpartName; name != "" {
+		t.Errorf("CounterpartName = %q, want empty (no label exists for this thread)", name)
+	}
+	if actions.upserted[0].Summary == "" {
+		t.Error("summary is empty; an unnamed thread still needs a readable card")
+	}
+}
+
+// TestStructuralSignalWorker_IdentityKeyStableAsThreadAges runs two ticks a
+// day apart. The summary must change (it reports the age) while identity_key
+// must not — that is what lets a user's done/ignored decision survive.
+func TestStructuralSignalWorker_IdentityKeyStableAsThreadAges(t *testing.T) {
+	t.Parallel()
+	docID := uuid.New()
+	msg := ThreadLatestMessage{
+		DocumentID: docID, SourceType: string(model.SourceSMS),
+		Metadata: map[string]any{"contact_name": "테스트연락처A", "direction": "received"},
+		EventAt:  fixedNow.AddDate(0, 0, -1),
+	}
+	lister := &fakeStructuralLister{messages: []ThreadLatestMessage{msg}}
+	actions := &fakeStructuralActionWriter{}
+
+	day1 := NewStructuralSignalWorker(StructuralSignalWorkerConfig{
+		Store: lister, Actions: actions, Now: func() time.Time { return fixedNow },
+	})
+	day1.Tick(context.Background())
+
+	day2 := NewStructuralSignalWorker(StructuralSignalWorkerConfig{
+		Store: lister, Actions: actions, Now: func() time.Time { return fixedNow.AddDate(0, 0, 1) },
+	})
+	day2.Tick(context.Background())
+
+	if len(actions.upserted) != 2 {
+		t.Fatalf("got %d actions, want 2", len(actions.upserted))
+	}
+	first, second := actions.upserted[0], actions.upserted[1]
+	if first.Summary == second.Summary {
+		t.Errorf("summary %q did not change as the thread aged", first.Summary)
+	}
+	if first.IdentityKey != second.IdentityKey {
+		t.Errorf("identity_key changed with the summary: %q -> %q", first.IdentityKey, second.IdentityKey)
+	}
+	if want := action.BuildIdentityKey("sms:테스트연락처A", string(model.KindAwaitingMyReply), "테스트연락처A", ""); first.IdentityKey != want {
+		t.Errorf("identity_key = %q, want %q (empty-summary form)", first.IdentityKey, want)
+	}
+}
+
+// TestStructuralSignalWorker_UpsertFailure_SkipsStatusWrite exercises the
+// failure path the happy-path fake hides: action_status has an FK to
+// actions.identity_key, so writing a status after a failed action insert can
+// only raise 23503. The fake records ctx.Err() as well, so a cancelled tick
+// cannot silently look like a successful one.
+func TestStructuralSignalWorker_UpsertFailure_SkipsStatusWrite(t *testing.T) {
+	t.Parallel()
+	lister := &fakeStructuralLister{messages: []ThreadLatestMessage{
+		{
+			DocumentID: uuid.New(), SourceType: string(model.SourceSMS),
+			Metadata: map[string]any{"contact_name": "테스트연락처A", "direction": "received"},
+			EventAt:  fixedNow,
+		},
+	}}
+	actions := &fakeStructuralActionWriter{upsertErr: errors.New("injected write failure")}
+	w := NewStructuralSignalWorker(StructuralSignalWorkerConfig{
+		Store: lister, Actions: actions, Now: func() time.Time { return fixedNow },
+	})
+	w.Tick(context.Background())
+
+	if actions.statusCalls != 0 {
+		t.Errorf("EnsureOpenStatus called %d times after a failed UpsertAction, want 0", actions.statusCalls)
 	}
 }

--- a/migrations/025_feedback_evidence.sql
+++ b/migrations/025_feedback_evidence.sql
@@ -1,0 +1,63 @@
+-- Feedback: per-evidence labelling support (Part D — feedback loop, Task 1).
+--
+-- ADDITIVE ONLY. This migration adds one nullable column, backfills it, and
+-- creates two PARTIAL indexes. There is deliberately no DROP, no ALTER ... TYPE
+-- and no SET NOT NULL anywhere in this file: the table already holds real user
+-- feedback rows collected since issue #17, and losing them would destroy
+-- labels that cannot be regenerated.
+--
+-- Two design points that make this migration unable to fail on existing data
+-- (plan §2.1):
+--
+--  1. `split` is nullable with a NOT VALID CHECK. NOT VALID skips the re-scan of
+--     existing rows, so the constraint cannot reject data that predates it. New
+--     and updated rows are still checked.
+--  2. The uniqueness index is PARTIAL on `source = 'ask_evidence'`. Existing
+--     rows use 'search' / 'discord_bot' / 'api', so the index covers zero rows
+--     at creation time and therefore cannot fail on a pre-existing duplicate.
+--     A global UNIQUE index on (session_id, query, document_id) could fail here.
+--
+-- The split rule is fixed by plan §2.2 and MUST match internal/dataset.SplitOf:
+--   uint32(first 4 bytes of md5('sbfeedback:v1:' || lower(btrim(query)))) % 100
+--   < 70  -> 'train', otherwise 'holdout'
+-- In PostgreSQL, ('x'||<8 hex>)::bit(32)::bigint yields the UNSIGNED 32-bit
+-- value (verified: 'c01cfb8b' -> 3223124875), which is exactly Go's
+-- binary.BigEndian.Uint32. abs() is therefore a no-op and is kept only so the
+-- expression stays total if that cast ever changes sign semantics.
+--
+-- The seed string 'sbfeedback:v1:' is frozen. Changing it reshuffles every past
+-- split and silently contaminates the holdout set; a future rule needs a new
+-- prefix AND a new column.
+
+ALTER TABLE feedback ADD COLUMN IF NOT EXISTS split TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'feedback_split_chk'
+    ) THEN
+        ALTER TABLE feedback
+            ADD CONSTRAINT feedback_split_chk
+            CHECK (split IS NULL OR split IN ('train','holdout')) NOT VALID;
+    END IF;
+END
+$$;
+
+-- Backfill. Rows without a usable query are not splittable and keep split NULL;
+-- the dataset loader ignores NULL splits. Re-running this statement is a no-op
+-- because of the `split IS NULL` guard, so an already-assigned row can never be
+-- moved between train and holdout by a repeated migration run.
+UPDATE feedback SET split = CASE
+        WHEN abs(('x' || substr(md5('sbfeedback:v1:' || lower(btrim(query))),1,8))::bit(32)::bigint) % 100 < 70
+        THEN 'train' ELSE 'holdout' END
+WHERE split IS NULL AND query IS NOT NULL AND btrim(query) <> '';
+
+-- Idempotency key for per-evidence votes: one label per (conversation, query,
+-- document). Different sessions asking the same question are independent
+-- signals and deliberately produce separate rows.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_feedback_ask_evidence
+  ON feedback (session_id, md5(lower(btrim(query))), document_id)
+  WHERE source = 'ask_evidence';
+
+CREATE INDEX IF NOT EXISTS idx_feedback_split
+  ON feedback (split, thumbs) WHERE source = 'ask_evidence';

--- a/migrations/026_search_weights_history.sql
+++ b/migrations/026_search_weights_history.sql
@@ -1,0 +1,34 @@
+-- Search weight change history and promotion state (Part D — feedback loop, Task 7).
+--
+-- Every candidate the tuner produces is recorded here, including the ones that
+-- are refused: without a row for the refusals, "why did the weights not change
+-- last week?" has no answer other than re-running the search.
+--
+-- No query text and no document IDs are stored — only aggregate scalars. The
+-- labels this table summarises are personal; the summary must not be.
+CREATE TABLE IF NOT EXISTS search_weights_history (
+    id              BIGSERIAL PRIMARY KEY,
+    weights         JSONB       NOT NULL,          -- model.SearchWeights serialised
+    status          TEXT        NOT NULL,          -- proposed|active|rolled_back|superseded
+    train_objective DOUBLE PRECISION,
+    holdout_ndcg10  DOUBLE PRECISION,
+    holdout_fp10    DOUBLE PRECISION,
+    baseline_ndcg10 DOUBLE PRECISION,
+    baseline_fp10   DOUBLE PRECISION,
+    holdout_queries INTEGER     NOT NULL DEFAULT 0,
+    gate_reason     TEXT,                          -- human-readable refusal reason
+    metadata        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    promoted_at     TIMESTAMPTZ,
+    CHECK (status IN ('proposed','active','rolled_back','superseded'))
+);
+
+-- At most one active row, enforced by the database rather than by an
+-- application-level check. Two concurrent tuner runs would both pass an
+-- "is there already an active row?" test and both write one; a partial unique
+-- index makes the second one fail instead.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_search_weights_active
+  ON search_weights_history ((status)) WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_search_weights_created
+  ON search_weights_history (created_at DESC);

--- a/web/src/app/actions/BriefingPanel.tsx
+++ b/web/src/app/actions/BriefingPanel.tsx
@@ -35,11 +35,28 @@ function numberEvidence(data: BriefingResponse): {
   return { sentences };
 }
 
+/** Max footnote markers shown inline before the rest collapse behind an
+ * "외 N건" toggle. A degraded aggregate-only fallback can cite every open
+ * action in one sentence (dozens of ids) — the cap keeps the sentence
+ * readable without ever hiding evidence (plan Task 8's evidence contract). */
+const FOOTNOTE_VISIBLE_CAP = 5;
+
 export function BriefingPanel({ refreshKey }: BriefingPanelProps) {
   const [data, setData] = useState<BriefingResponse | null>(null);
   // React 19 transition rather than a setState in the effect body (project
   // lint rule react-hooks/set-state-in-effect).
   const [loading, startLoad] = useTransition();
+  // Which sentence indices have their full footnote list expanded.
+  const [expanded, setExpanded] = useState<ReadonlySet<number>>(() => new Set());
+
+  const toggleExpanded = (i: number) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -97,22 +114,40 @@ export function BriefingPanel({ refreshKey }: BriefingPanelProps) {
         </div>
 
         <p className="text-sm leading-relaxed text-foreground">
-          {numbered.sentences.map((s, i) => (
-            <span key={i}>
-              {s.text}
-              {s.refs.map((ref) => (
-                <sup key={ref.id} className="ml-0.5">
-                  <Link
-                    href={`/documents/${ref.id}`}
-                    aria-label={`근거 문서 ${ref.n}`}
-                    className="text-text-accent underline-offset-2 hover:underline"
-                  >
-                    [{ref.n}]
-                  </Link>
-                </sup>
-              ))}{" "}
-            </span>
-          ))}
+          {numbered.sentences.map((s, i) => {
+            const isExpanded = expanded.has(i);
+            const overflow = s.refs.length - FOOTNOTE_VISIBLE_CAP;
+            const visibleRefs =
+              overflow > 0 && !isExpanded ? s.refs.slice(0, FOOTNOTE_VISIBLE_CAP) : s.refs;
+            return (
+              <span key={i}>
+                {s.text}
+                {visibleRefs.map((ref) => (
+                  <sup key={ref.id} className="ml-0.5">
+                    <Link
+                      href={`/documents/${ref.id}`}
+                      aria-label={`근거 문서 ${ref.n}`}
+                      className="text-text-accent underline-offset-2 hover:underline"
+                    >
+                      [{ref.n}]
+                    </Link>
+                  </sup>
+                ))}
+                {overflow > 0 && (
+                  <sup className="ml-0.5">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(i)}
+                      aria-expanded={isExpanded}
+                      className="text-text-accent underline-offset-2 hover:underline"
+                    >
+                      {isExpanded ? "접기" : `외 ${overflow}건`}
+                    </button>
+                  </sup>
+                )}{" "}
+              </span>
+            );
+          })}
         </p>
 
         {data.dropped_count > 0 && (

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -67,6 +67,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 검색
               </Link>
               <Link
+                href="/actions"
+                className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"
+              >
+                할 일
+              </Link>
+              <Link
                 href="/dashboard"
                 className="rounded-md px-3 py-1.5 text-foreground-muted transition-colors hover:bg-surface-subtle hover:text-foreground"
               >


### PR DESCRIPTION
## 증상
`/actions` 화면의 카드 50개가 전부 동일한 문구("응답 대기 / 구조 신호 / 신뢰도 100% / 마지막 메시지 이후 응답 없음")로 렌더돼 어떤 액션이 무엇인지 구분할 수 없었다.

## 원인 3건

1. **요약이 하드코딩 상수였다**: `structural_signals.go`가 `awaiting_my_reply` 434건에 동일 문자열을 채워 넣고 있었다.
2. **`counterpart_entity_id`가 구조적으로 100% NULL이었다**: `StructuralSignalWorker`에 엔티티 스토어가 배선돼 있지 않아 이름을 `entities.id`로 해소할 방법이 없었고, `UpsertAction`의 `ON CONFLICT`에 이 컬럼이 없어 한 번 NULL로 들어간 행은 영원히 NULL이었다.
3. **브리핑이 매번 degraded로 떨어졌다**: `briefingTimeout`(30s)과 `WriteTimeout`(30s) 둘 다 LLM 호출 시간보다 짧았다. `/ask`도 같은 `WriteTimeout` 제약으로 긴 SSE 응답이 이미 잘리고 있었다.

## 변경 내용

- 요약을 상대방·채널·경과일수 기반 동적 텍스트로 교체 (`{상대방} · 메일 "{제목}" · 3일째 미응답`), 화면용 80 rune 상한 적용
- `structural_signals` 워커에 엔티티 스토어를 배선하고, `UpsertAction`의 `ON CONFLICT`에 `counterpart_entity_id`를 COALESCE 병합 추가 — 기존 NULL 행은 다음 워커 틱에 자가 복구된다. 전화번호는 PERSON이 아닌 OTHER 타입으로 저장
- `BRIEFING_TIMEOUT_SECONDS`, `HTTP_WRITE_TIMEOUT_SECONDS` 환경변수를 신설하고, 브리핑 핸들러 단위로 write deadline을 연장 (전역 타임아웃은 느린 클라이언트 방어용으로 유한하게 유지)
- 웹: `/actions` 네비 링크 추가, 브리핑 각주 5개 초과 시 "외 N건"으로 접기(클릭 시 전부 펼침)
- Part D(피드백 루프) 백엔드도 함께 포함: 근거 단위 피드백 수집 API, 학습/검증 고정 분할(검증셋 격리를 패키지 경계로 강제), 가중치 평가 하네스 + 이력 테이블. `FEEDBACK_EVIDENCE_ENABLED`는 기본 off

## 검증
- Go 유닛 테스트 작성 완료 (`internal/action`, `internal/worker`, `internal/store`, `internal/dataset`, `internal/tune`, `internal/api` 신규/수정 테스트 포함)
- 스토어 SQL 관련 테스트는 `TEST_DATABASE_URL` 없으면 SKIP됨(로컬/CI 환경 확인 필요)

## 미검증 항목
- 브라우저 렌더 전무: `/actions` 화면, "할 일" 네비 링크, 각주 접기/펼치기 토글, `sup > button` 클릭 타겟 크기, 네비 7개 항목의 좁은 화면 줄바꿈 — 전부 미확인
- 실 DB end-to-end 미검증 (스토어 테스트는 `TEST_DATABASE_URL` 없으면 SKIP)

## 배포 후 확인사항
- 새 환경변수를 `.env.local`에 넣어야 효과가 난다: `BRIEFING_TIMEOUT_SECONDS`(기본 120), `HTTP_WRITE_TIMEOUT_SECONDS`(기본 90). `FEEDBACK_EVIDENCE_ENABLED`는 기본 off로 두고 켜지 마라
- 마이그레이션 025·026이 기동 시 자동 적용된다. 025는 기존 `feedback` ~50행에 `split`을 채운다(추가 전용)
- 배포 후 **카드가 서로 구분되는지** `select count(distinct summary) from actions where kind='awaiting_my_reply'`로 확인할 것. 1이면 실패다
- 구조 신호 워커는 10분 주기이므로 기존 행 복구에 한 틱이 필요하다
- 즉시 청소를 원하면 `DELETE FROM actions WHERE kind = 'awaiting_my_reply'` (action_status는 CASCADE). 사용자가 "기존 판단은 버려도 된다"고 확인했다

## 알려진 위험
- `entities`에 전화번호가 OTHER 타입으로 들어갈 수 있다(`contact_name` 없고 `metadata.number`만 있을 때). #164 해싱을 켜면 자동 차단된다
- 요약이 매 틱 UPDATE 된다(경과일수 변동). 880행 규모에선 무시 가능
- UI가 보여주는 `counterpart_name`은 `entities.normalized_name`(소문자)이라 영문 이름이 소문자로 렌더된다
- `occurred_at`이 NULL인 문서가 최신인 스레드는 여전히 액션이 생성되지 않는다(30일 창이 `occurred_at` 기준)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>