### PR TITLE
fix(search): 청크 결과 시각 정보 + 승격 가중치 서빙 배선

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -118,10 +118,26 @@ func run() error {
 	// --- Search service ---
 	// ChunkStore is attached to enable chunk-based FTS fallback (issue #9).
 	// EntityStore is attached to surface entities in search results (issue #77).
+	//
+	// WeightsHistoryStore closes the tuning loop (#214): cmd/tune -promote
+	// writes the winning configuration to search_weights_history, and this is
+	// the only process that reads it back. The reader is attached
+	// unconditionally and the flag decides whether it is consulted, so that
+	// turning SEARCH_ACTIVE_WEIGHTS_ENABLED on is a restart and not a redeploy.
+	// It is attached HERE and nowhere else on purpose: cmd/tune must keep
+	// measuring against the compiled defaults, or its baseline would drift to
+	// whatever it last promoted and every subsequent run would compare a
+	// configuration against itself.
+	weightsHistoryStore := store.NewWeightsHistoryStore(pg)
 	searchSvc := search.NewService(docStore, embedClient).
 		WithChunkStore(chunkStore).
 		WithReranker(reranker).
-		WithEntityFetcher(entityStore)
+		WithEntityFetcher(entityStore).
+		WithActiveWeights(weightsHistoryStore, cfg.SearchActiveWeightsEnabled)
+	if cfg.SearchActiveWeightsEnabled {
+		slog.Info("search: serving the promoted weights from search_weights_history",
+			"flag", "SEARCH_ACTIVE_WEIGHTS_ENABLED")
+	}
 
 	// --- LLM client (curation) ---
 	llmClient := llm.New(llm.Config{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -538,6 +538,25 @@ type Config struct {
 	// (1/true/yes/on, case-insensitive, surrounding space ignored) rather
 	// than the plain == "true" used by older flags.
 	FeedbackEvidenceEnabled bool
+
+	// SearchActiveWeightsEnabled makes the promoted row in
+	// search_weights_history the default RRF weighting for every search
+	// request that does not carry its own (#214).
+	// SEARCH_ACTIVE_WEIGHTS_ENABLED env var, default false.
+	//
+	// Off by default for the same reason ActionsAPIEnabled is: the row is
+	// written by a separate process (cmd/tune -promote) after measuring
+	// candidates against a holdout set, and a deployment that has not opted in
+	// should not start serving a ranking configuration merely because a row
+	// appeared in a table. Production currently has no active row at all, so
+	// turning this on today is a no-op — which is exactly the state in which a
+	// flag should be introduced.
+	//
+	// It is also the outermost rollback: unset the variable and restart, and
+	// the compiled defaults are back whatever the table says. The inner
+	// rollback (cmd/tune -rollback) needs no restart, because the row is read
+	// once per request — see search.Service.defaultWeights.
+	SearchActiveWeightsEnabled bool
 }
 
 // Load reads configuration from environment variables and returns a Config.
@@ -806,6 +825,9 @@ func Load() (*Config, error) {
 
 		// Part D feedback collection — default false (see doc comment above).
 		FeedbackEvidenceEnabled: envFlag("FEEDBACK_EVIDENCE_ENABLED"),
+
+		// Part D weight serving — default false (see doc comment above).
+		SearchActiveWeightsEnabled: envFlag("SEARCH_ACTIVE_WEIGHTS_ENABLED"),
 	}, nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -753,3 +753,50 @@ func TestLoad_FeedbackEvidenceEnabled(t *testing.T) {
 		})
 	}
 }
+
+// TestLoad_SearchActiveWeightsEnabled pins the #214 flag: default OFF, same
+// truthy set as every other envFlag-backed switch.
+//
+// The default is the assertion that matters. An active row in
+// search_weights_history was promoted against a holdout set on whichever
+// deployment ran the tuner; a deployment that has said nothing about the
+// feature must keep the compiled defaults rather than inherit that row.
+func TestLoad_SearchActiveWeightsEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		envVal string
+		unset  bool
+		want   bool
+	}{
+		{name: "default_off_when_unset", unset: true, want: false},
+		{name: "empty_is_off", envVal: "", want: false},
+		{name: "true_is_on", envVal: "true", want: true},
+		{name: "TRUE_is_on", envVal: "TRUE", want: true},
+		{name: "one_is_on", envVal: "1", want: true},
+		{name: "yes_is_on", envVal: "yes", want: true},
+		{name: "on_is_on", envVal: " on ", want: true},
+		{name: "false_is_off", envVal: "false", want: false},
+		{name: "garbage_is_off", envVal: "maybe", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unset {
+				unsetenv(t, "SEARCH_ACTIVE_WEIGHTS_ENABLED")
+			} else {
+				setenv(t, "SEARCH_ACTIVE_WEIGHTS_ENABLED", tc.envVal)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.SearchActiveWeightsEnabled != tc.want {
+				t.Errorf("SearchActiveWeightsEnabled = %v, want %v", cfg.SearchActiveWeightsEnabled, tc.want)
+			}
+		})
+	}
+}

--- a/internal/search/active_weights.go
+++ b/internal/search/active_weights.go
@@ -1,0 +1,150 @@
+package search
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+)
+
+// ActiveWeightsReader returns the promoted search-weight configuration, or
+// (nil, nil) when nothing has been promoted. It is satisfied by
+// *store.WeightsHistoryStore.
+//
+// This is the last link of the tuning loop (#214). cmd/tune measures
+// candidates, gates them on a holdout set and writes the winner to
+// search_weights_history as the single 'active' row — and until this interface
+// existed, nothing read that row. Promotion changed a table and not one search.
+type ActiveWeightsReader interface {
+	Active(ctx context.Context) (*store.WeightsRecord, error)
+}
+
+// WithActiveWeights makes the promoted row in search_weights_history the
+// default RRF weighting for every request that does not carry its own.
+//
+// enabled is passed in rather than inferred so that "off" means the table is
+// never queried at all — not queried and ignored. Off is the default for the
+// deployment (SEARCH_ACTIVE_WEIGHTS_ENABLED, see internal/config): an active
+// row is a configuration that was validated against a holdout set SOMEWHERE,
+// and a deployment that has not opted in should not start serving it because a
+// row appeared. It is also the rollback of last resort — unset the variable,
+// restart, and the compiled defaults are back regardless of the table's state.
+//
+// Safe to call with a nil reader; the lookup is skipped exactly as if the flag
+// were off.
+func (s *Service) WithActiveWeights(r ActiveWeightsReader, enabled bool) *Service {
+	s.activeWeights = r
+	s.activeWeightsEnabled = enabled
+	if s.activeWeightsLog == nil {
+		s.activeWeightsLog = &activeWeightsFailureLog{}
+	}
+	return s
+}
+
+// defaultWeights resolves the weighting a request gets when it did not specify
+// one. The precedence, highest first:
+//
+//  1. model.SearchQuery.Weights — the caller's explicit per-request choice.
+//     Resolved by Search before it calls this, so a request that sets Weights
+//     never reaches here and never pays for the lookup. This ordering is not
+//     cosmetic: internal/tune/harness.go evaluates candidates by setting that
+//     field, and an active row that outranked it would make every candidate
+//     measure as the incumbent — the tuner would compare a configuration
+//     against itself and then promote on noise.
+//  2. The active row in search_weights_history, when the flag is on.
+//  3. Service.weights (WithWeights), then the compiled defaults, which are what
+//     a zero SearchWeights means to the store.
+//
+// (2) outranks (3) because the flag is itself an explicit, per-deployment
+// statement that the promoted row is this process's default, and unlike
+// WithWeights it has an undo — cmd/tune -rollback. No production caller sets
+// WithWeights today, so the ordering is currently unobservable; it is written
+// down here so that it is a decision rather than an accident later.
+//
+// READ TIMING: once per request, uncached.
+//
+// A cache would need invalidating, and the writer is cmd/tune — a DIFFERENT
+// PROCESS. No hook in this process can observe its promote or its rollback, so
+// the strongest guarantee a cache could offer is "within the TTL", while the
+// rollback procedure is specified as "back on the next request without a
+// restart". A TTL that satisfies that reading has to be short enough to be
+// nearly per-request anyway.
+//
+// The cost is one single-row lookup on a partial unique index over a table that
+// gains one row per tuning run, against a request that already pays for an
+// embedding round-trip and a five-lane CTE over the whole corpus. If that ever
+// stops being true, the fix is a cache plus a NOTIFY/LISTEN invalidation, not a
+// bare TTL — a bare TTL silently reintroduces the window this comment exists to
+// rule out.
+func (s *Service) defaultWeights(ctx context.Context) model.SearchWeights {
+	if !s.activeWeightsEnabled || s.activeWeights == nil {
+		return s.weights
+	}
+
+	rec, err := s.activeWeights.Active(ctx)
+	if err != nil {
+		// FAIL OPEN. The weights table tunes ranking; it does not decide
+		// whether search works. Returning the error here would let a tuning
+		// experiment take retrieval down with it.
+		s.activeWeightsLog.record(err)
+		return s.weights
+	}
+	if rec == nil {
+		// Nothing promoted — the normal state before the first promotion and
+		// after a rollback with nothing to restore. Not an error.
+		return s.weights
+	}
+	if rec.Weights == (model.SearchWeights{}) {
+		// A promoted row whose weights are all zero says nothing; the store
+		// reads a zero SearchWeights as "use the defaults" anyway, so this is
+		// the same answer arrived at explicitly.
+		return s.weights
+	}
+	return rec.Weights
+}
+
+// activeWeightsFailureLog rate-limits the warning for a failing weights
+// lookup.
+//
+// The lookup runs once per search request, so an unreachable database would
+// otherwise emit one line per request — burying, among other things, whatever
+// log records the actual outage. The first failure is always reported (that is
+// the one that dates the incident) and afterwards at most one line per minute,
+// carrying the running total so the gap is visible rather than implied.
+//
+// The statement behind this error takes no parameters and selects no query
+// text or document ids (see migration 026), so its message cannot carry
+// personal data. Only the error, its type and a count are recorded.
+type activeWeightsFailureLog struct {
+	mu       sync.Mutex
+	failures uint64
+	lastLog  time.Time
+}
+
+const activeWeightsLogInterval = time.Minute
+
+func (l *activeWeightsFailureLog) record(err error) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	l.failures++
+	total := l.failures
+	now := time.Now()
+	report := total == 1 || now.Sub(l.lastLog) >= activeWeightsLogInterval
+	if report {
+		l.lastLog = now
+	}
+	l.mu.Unlock()
+
+	if !report {
+		return
+	}
+	slog.Warn("search: active weights lookup failed, using compiled defaults",
+		"error", err,
+		"failures_total", total,
+	)
+}

--- a/internal/search/active_weights_test.go
+++ b/internal/search/active_weights_test.go
@@ -1,0 +1,212 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// #214 — the promoted weights never reached the serving path.
+//
+// cmd/tune -promote writes an 'active' row into search_weights_history, and
+// nothing read it. Every search kept using the compiled-in defaults, so the
+// whole tuning loop — measure, gate, promote — ended in a table nobody
+// consulted. Promotion looked like it worked and changed nothing.
+//
+// The tests below fix the four decisions this wiring has to make: when the row
+// is read, what it loses to, what happens when the read fails, and that the
+// feature is genuinely off by default.
+// ---------------------------------------------------------------------------
+
+// stubActiveWeights is an ActiveWeightsReader whose answer can be changed
+// between requests, which is how the promote/rollback cases are expressed.
+type stubActiveWeights struct {
+	mu    sync.Mutex
+	rec   *store.WeightsRecord
+	err   error
+	calls int
+}
+
+func (s *stubActiveWeights) Active(context.Context) (*store.WeightsRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	return s.rec, s.err
+}
+
+func (s *stubActiveWeights) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *stubActiveWeights) set(rec *store.WeightsRecord, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rec, s.err = rec, err
+}
+
+func activeRecord(w model.SearchWeights) *store.WeightsRecord {
+	return &store.WeightsRecord{ID: 7, Status: store.WeightsStatusActive, Weights: w}
+}
+
+// promotedWeights is deliberately unlike the compiled defaults on every field
+// so that "the active row was used" cannot be confused with "the defaults were
+// used".
+var promotedWeights = model.SearchWeights{
+	FTSWeight:  0.30,
+	VecWeight:  1.70,
+	BigmWeight: 0.40,
+	SummaryVec: 0.60,
+	RRFK:       25,
+}
+
+func runSearchOnce(t *testing.T, svc *Service, docs *recordingDocSearcher, q model.SearchQuery) model.SearchWeights {
+	t.Helper()
+	if _, err := svc.Search(context.Background(), q); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	return docs.gotQuery.Weights
+}
+
+// (a) An active row replaces the default weights the store is asked to use.
+func TestSearch_ActiveWeights_PromotedRowBecomesTheDefault(t *testing.T) {
+	t.Parallel()
+
+	docs := &recordingDocSearcher{}
+	reader := &stubActiveWeights{rec: activeRecord(promotedWeights)}
+	svc := NewService(docs, disabledEmbedder{}).WithActiveWeights(reader, true)
+
+	got := runSearchOnce(t, svc, docs, model.SearchQuery{Query: "예산"})
+	if got != promotedWeights {
+		t.Fatalf("store saw weights %+v, want the promoted row %+v — promotion must reach the serving path",
+			got, promotedWeights)
+	}
+	if reader.callCount() == 0 {
+		t.Fatal("the active row was never read")
+	}
+}
+
+// (b) A per-request Weights beats the active row. internal/tune evaluates
+// candidates by setting this field, so an active row that overrode it would
+// make every candidate measure as the incumbent — the tuner would then compare
+// a configuration against itself and promote on noise.
+func TestSearch_ActiveWeights_PerRequestWeightsWin(t *testing.T) {
+	t.Parallel()
+
+	requested := model.SearchWeights{FTSWeight: 2.5, VecWeight: 0.1, BigmWeight: 3.0, RRFK: 99}
+
+	docs := &recordingDocSearcher{}
+	reader := &stubActiveWeights{rec: activeRecord(promotedWeights)}
+	svc := NewService(docs, disabledEmbedder{}).WithActiveWeights(reader, true)
+
+	got := runSearchOnce(t, svc, docs, model.SearchQuery{Query: "예산", Weights: requested})
+	if got != requested {
+		t.Fatalf("store saw weights %+v, want the caller's %+v — the active row is a DEFAULT, not an override",
+			got, requested)
+	}
+	if reader.callCount() != 0 {
+		t.Errorf("active row was read %d times for a request that specified its own weights; the lookup is pointless work",
+			reader.callCount())
+	}
+}
+
+// (c) No active row, and a failed lookup, both fall back to the compiled
+// defaults — and the search still returns results. A tuning table is not a
+// dependency search may die on.
+func TestSearch_ActiveWeights_FallsBackToCompiledDefaults(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		reader *stubActiveWeights
+	}{
+		{"no active row", &stubActiveWeights{rec: nil, err: nil}},
+		{"lookup fails", &stubActiveWeights{rec: nil, err: errors.New("connection refused")}},
+		{"row present but weights are the zero value", &stubActiveWeights{rec: activeRecord(model.SearchWeights{})}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			hit := makeSearchResult(uuid.New(), "결과", 0.9)
+			docs := &recordingDocSearcher{results: []*model.SearchResult{hit}}
+			svc := NewService(docs, disabledEmbedder{}).WithActiveWeights(tc.reader, true)
+
+			results, err := svc.Search(context.Background(), model.SearchQuery{Query: "예산"})
+			if err != nil {
+				t.Fatalf("Search returned error: %v — a weights lookup problem must never fail the search", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("results = %d, want 1 — the search must still serve", len(results))
+			}
+			if got := docs.gotQuery.Weights; got != (model.SearchWeights{}) {
+				t.Fatalf("store saw weights %+v, want the zero value (= compiled defaults)", got)
+			}
+		})
+	}
+}
+
+// (d) With the flag off the table is not consulted at all. "Off" has to mean no
+// query, not a query whose result is discarded: the row on a given deployment
+// may be a configuration that was never validated there, and the cost of the
+// lookup is the smaller half of the reason.
+func TestSearch_ActiveWeights_FlagOff_NeverReadsTheTable(t *testing.T) {
+	t.Parallel()
+
+	docs := &recordingDocSearcher{}
+	reader := &stubActiveWeights{rec: activeRecord(promotedWeights)}
+	svc := NewService(docs, disabledEmbedder{}).WithActiveWeights(reader, false)
+
+	got := runSearchOnce(t, svc, docs, model.SearchQuery{Query: "예산"})
+	if reader.callCount() != 0 {
+		t.Errorf("active row was read %d times with the flag off; the flag must gate the query itself",
+			reader.callCount())
+	}
+	if got != (model.SearchWeights{}) {
+		t.Errorf("store saw weights %+v with the flag off, want the zero value (= compiled defaults)", got)
+	}
+}
+
+// (e) The row is re-read on every request, so a promotion or a rollback made by
+// the separate cmd/tune process takes effect on the NEXT request with no
+// restart and no invalidation call — which is the property the rollback
+// procedure depends on. A cached value could only offer "within the TTL",
+// because nothing in this process observes the other process's write.
+func TestSearch_ActiveWeights_PromoteAndRollbackTakeEffectOnTheNextRequest(t *testing.T) {
+	t.Parallel()
+
+	docs := &recordingDocSearcher{}
+	reader := &stubActiveWeights{} // nothing promoted yet
+	svc := NewService(docs, disabledEmbedder{}).WithActiveWeights(reader, true)
+
+	q := model.SearchQuery{Query: "예산"}
+
+	if got := runSearchOnce(t, svc, docs, q); got != (model.SearchWeights{}) {
+		t.Fatalf("before promotion the store saw %+v, want the compiled defaults", got)
+	}
+
+	// cmd/tune -promote, in another process.
+	reader.set(activeRecord(promotedWeights), nil)
+	if got := runSearchOnce(t, svc, docs, q); got != promotedWeights {
+		t.Fatalf("after promotion the store saw %+v, want %+v on the very next request", got, promotedWeights)
+	}
+
+	// cmd/tune -rollback with nothing to restore: back to the defaults.
+	reader.set(nil, nil)
+	if got := runSearchOnce(t, svc, docs, q); got != (model.SearchWeights{}) {
+		t.Fatalf("after rollback the store saw %+v, want the compiled defaults on the very next request", got)
+	}
+
+	if reader.callCount() != 3 {
+		t.Fatalf("reader calls = %d, want 3 (one per request) — a cache here cannot honour 'next request'",
+			reader.callCount())
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -37,12 +37,19 @@ type ChunkSearcher interface {
 // inside an event-time window. It is satisfied by *store.DocumentStore.
 //
 // It exists for the chunk lanes. Those lanes cannot carry the window into their
-// own SQL (ChunkSearcher takes only a query/vector and a limit) and the rows
-// they return carry no occurred_at, so the service used to switch them off
-// entirely whenever a window was set. That was safe but expensive: it deleted
-// chunk-level recall from every temporal query, and a query planner sets a
-// window on most temporal questions. Joining the candidates back to `documents`
-// on id restores the recall while keeping the window a real constraint.
+// own SQL (ChunkSearcher takes only a query/vector and a limit), so the service
+// used to switch them off entirely whenever a window was set. That was safe but
+// expensive: it deleted chunk-level recall from every temporal query, and a
+// query planner sets a window on most temporal questions. Joining the
+// candidates back to `documents` on id restores the recall while keeping the
+// window a real constraint.
+//
+// Selecting occurred_at in the chunk join (#215) does NOT make this redundant.
+// The window must be a WHERE predicate: the chunk lanes truncate at their own
+// LIMIT before the service sees a single row, so filtering afterwards on a
+// timestamp the row now carries would shrink the page instead of narrowing the
+// candidate pool. The join gives those rows an ORDER; this interface is what
+// gives them a MEMBERSHIP test.
 type OccurredRangeChecker interface {
 	FilterIDsByOccurredRange(ctx context.Context, ids []uuid.UUID, from, to *time.Time) (map[uuid.UUID]struct{}, error)
 }
@@ -67,6 +74,13 @@ type Service struct {
 	// any wiring. The field exists for callers that inject a different store
 	// (and for tests).
 	occurredChecker OccurredRangeChecker
+
+	// activeWeights supplies the promoted RRF weighting (#214); nil, and
+	// activeWeightsEnabled false, when the deployment has not opted in. See
+	// WithActiveWeights and defaultWeights in active_weights.go.
+	activeWeights        ActiveWeightsReader
+	activeWeightsEnabled bool
+	activeWeightsLog     *activeWeightsFailureLog
 }
 
 // NewService returns a search Service.
@@ -335,11 +349,14 @@ func (s *Service) Search(ctx context.Context, q model.SearchQuery) ([]*model.Sea
 	q = applyInsightExclusionDefault(q)
 	warnOnSourceFilterConflict(q)
 
-	// Apply service-level weights when the caller has not set explicit weights.
+	// Apply the default weighting when the caller has not set explicit weights.
 	// A zero-value Weights field means "use defaults", so we only overwrite
-	// when the service weights are non-zero (i.e. explicitly configured).
+	// when the resolved default is non-zero (i.e. explicitly configured or
+	// promoted). defaultWeights owns the precedence between the promoted row,
+	// the service-level weights and the compiled defaults, and is the only
+	// thing that reads search_weights_history — see active_weights.go.
 	if q.Weights == (model.SearchWeights{}) {
-		q.Weights = s.weights
+		q.Weights = s.defaultWeights(ctx)
 	}
 
 	// HyDE query expansion: replace the effective query with the original
@@ -369,8 +386,10 @@ func (s *Service) Search(ctx context.Context, q model.SearchQuery) ([]*model.Sea
 
 	// An event-time window is a hard constraint on WHICH documents may be
 	// returned. The document store enforces it in SQL inside every lane; the
-	// chunk lanes cannot, because ChunkSearcher takes no date range and the rows
-	// it returns carry no occurred_at.
+	// chunk lanes cannot, because ChunkSearcher takes no date range — the rows
+	// it returns now carry occurred_at (#215), but only after their own LIMIT
+	// has already been applied, so reading it cannot substitute for the
+	// predicate.
 	//
 	// Previously the chunk lanes were skipped outright whenever a window was
 	// set. That was correct — an unfiltered lane fills exactly the slots the
@@ -461,12 +480,14 @@ func (s *Service) Search(ctx context.Context, q model.SearchQuery) ([]*model.Sea
 	// Making the recency sort the last step would silently change the
 	// rerank+recent combination, which is a different question from this one.
 	//
-	// Chunk-only documents carry no timestamps (the chunk join selects none),
-	// so they sort last — see recencyKey. Their membership is unaffected, and
-	// under a window they are still verified against it; only their position is
-	// approximate. Giving them a real position needs occurred_at back from the
-	// verification lane, which is a store-interface change and out of scope
-	// here.
+	// Chunk-only documents used to carry no timestamps at all, so they sorted
+	// last in BOTH directions — the position was approximate even though the
+	// membership was exact. Since #215 the chunk join selects the parent's
+	// occurred_at/collected_at (see chunkTimestamps), so they are placed on the
+	// same key as every store row. Only a document whose parent genuinely has
+	// no event time still falls to the "unplaceable" branch of recencyKey, and
+	// only on the ascending side, where placing it would mean ordering an
+	// ingest instant among event instants.
 	if chunkFused && q.SortsByRecency() {
 		sortByRecency(results, q.RecencyAscending(time.Now()))
 	}
@@ -688,18 +709,50 @@ func (s *Service) searchChunksFTS(ctx context.Context, query string, limit int) 
 
 // chunkVecToSearchResult converts a vector-search ChunkSearchResult to a
 // model.SearchResult using the Score field (cosine similarity).
+//
+// The timestamps come from the chunk join's `documents` row (#215); see
+// chunkTimestamps for why they are not optional.
 func chunkVecToSearchResult(r store.ChunkSearchResult) *model.SearchResult {
+	occurred, collected := chunkTimestamps(r)
 	return &model.SearchResult{
 		Document: model.Document{
-			ID:         r.Chunk.DocumentID,
-			SourceType: model.SourceType(r.DocumentSource),
-			Title:      r.DocumentTitle,
-			Content:    r.Chunk.Content,
-			Status:     r.DocumentStatus,
+			ID:          r.Chunk.DocumentID,
+			SourceType:  model.SourceType(r.DocumentSource),
+			Title:       r.DocumentTitle,
+			Content:     r.Chunk.Content,
+			Status:      r.DocumentStatus,
+			OccurredAt:  occurred,
+			CollectedAt: collected,
 		},
 		Score:     r.Score,
 		MatchType: "chunk-vector",
 	}
+}
+
+// chunkTimestamps copies the parent document's event and ingest times off a
+// chunk-lane row.
+//
+// A chunk-only document — one no other lane returned — is ordered entirely
+// from these two values: it never passes through the document store's ORDER BY,
+// so search.sortByRecency is the only thing that places it, and recencyKey
+// treats a result with neither timestamp as unplaceable and sends it to the
+// back of the list in BOTH directions. Under a forward-looking window that
+// inverts the answer: the most imminent entry is shown as the furthest away
+// (#215).
+//
+// The pointer is copied rather than dereferenced-with-fallback on purpose. A
+// NULL occurred_at must stay nil so that the descending branch's
+// COALESCE(occurred_at, collected_at) still happens in recencyKey and the
+// ascending branch still refuses to place the row: synthesising an event time
+// out of the ingest time here would make "happened then" and "ingested then"
+// indistinguishable one layer too early, which is the same conflation the
+// window filter deliberately avoids (see SearchQuery.OccurredFrom).
+func chunkTimestamps(r store.ChunkSearchResult) (*time.Time, time.Time) {
+	if r.DocumentOccurredAt == nil {
+		return nil, r.DocumentCollectedAt
+	}
+	occurred := *r.DocumentOccurredAt // copy: never alias the store's row
+	return &occurred, r.DocumentCollectedAt
 }
 
 // chunkToSearchResult converts a ChunkSearchResult to a model.SearchResult.
@@ -708,13 +761,16 @@ func chunkVecToSearchResult(r store.ChunkSearchResult) *model.SearchResult {
 // The full document fetch is deliberately omitted to keep search fast; callers
 // can fetch the full document via GET /api/v1/documents/{id} if needed.
 func chunkToSearchResult(r store.ChunkSearchResult) *model.SearchResult {
+	occurred, collected := chunkTimestamps(r)
 	return &model.SearchResult{
 		Document: model.Document{
-			ID:         r.Chunk.DocumentID,
-			SourceType: model.SourceType(r.DocumentSource),
-			Title:      r.DocumentTitle,
-			Content:    r.Chunk.Content, // snippet: the matching chunk text
-			Status:     r.DocumentStatus,
+			ID:          r.Chunk.DocumentID,
+			SourceType:  model.SourceType(r.DocumentSource),
+			Title:       r.DocumentTitle,
+			Content:     r.Chunk.Content, // snippet: the matching chunk text
+			Status:      r.DocumentStatus,
+			OccurredAt:  occurred,
+			CollectedAt: collected,
 		},
 		Score:     r.Rank,
 		MatchType: "chunk-fts",

--- a/internal/search/search_chunk_timestamps_test.go
+++ b/internal/search/search_chunk_timestamps_test.go
@@ -1,0 +1,237 @@
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// #215 — a chunk-only hit used to arrive with no event time.
+//
+// chunkVecToSearchResult / chunkToSearchResult built a model.Document out of
+// the chunk join, and that join selected no timestamps. So every document
+// reachable ONLY through a chunk lane came back with OccurredAt == nil and a
+// zero CollectedAt, which recencyKey reads as "no usable timestamp" and
+// sortByRecency puts LAST in both directions.
+//
+// The set was still correct — verifyWindow joins the same candidates back to
+// `documents` and drops anything outside the window — but the ORDER was not.
+// The visible symptom is a forward-looking /ask ("다음 주 일정") whose most
+// imminent entry happens to be a chunk-only hit: it is shown last, i.e. as the
+// FURTHEST away, which is the exact inversion the ascending branch exists to
+// prevent.
+//
+// The fix is one JOIN column away: the chunk queries already join `documents`,
+// so occurred_at/collected_at cost nothing extra to select.
+// ---------------------------------------------------------------------------
+
+// chunkResultAt builds a chunk-lane row that carries its parent document's
+// timestamps, which is what the chunk join now selects.
+func chunkResultAt(id uuid.UUID, src model.SourceType, score float64, occurred *time.Time, collected time.Time) store.ChunkSearchResult {
+	r := chunkResult(id, src, score)
+	r.DocumentOccurredAt = occurred
+	r.DocumentCollectedAt = collected
+	return r
+}
+
+// TestChunkConversion_CarriesDocumentTimestamps pins the conversion itself:
+// both chunk lanes must copy the parent document's event and ingest times onto
+// the SearchResult. Without this the sort has nothing to work with no matter
+// what the SQL selects.
+func TestChunkConversion_CarriesDocumentTimestamps(t *testing.T) {
+	t.Parallel()
+
+	occurred := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+	collected := time.Date(2026, 8, 19, 1, 0, 0, 0, time.UTC)
+	id := uuid.New()
+	row := chunkResultAt(id, model.SourceCalendar, 0.9, &occurred, collected)
+
+	cases := []struct {
+		name    string
+		convert func(store.ChunkSearchResult) *model.SearchResult
+	}{
+		{"chunk-vector", chunkVecToSearchResult},
+		{"chunk-fts", chunkToSearchResult},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.convert(row)
+			if got.OccurredAt == nil {
+				t.Fatalf("OccurredAt = nil, want %s — a chunk-only hit with no event time cannot be ordered", occurred)
+			}
+			if !got.OccurredAt.Equal(occurred) {
+				t.Errorf("OccurredAt = %s, want %s", got.OccurredAt, occurred)
+			}
+			if !got.CollectedAt.Equal(collected) {
+				t.Errorf("CollectedAt = %s, want %s", got.CollectedAt, collected)
+			}
+		})
+	}
+}
+
+// TestChunkConversion_NilOccurredAtStaysNil guards the other half of the
+// contract: a document with no event-time concept must NOT acquire one. The
+// pointer is copied, not synthesised from collected_at — recencyKey's
+// descending branch does that COALESCE itself, and doing it here as well would
+// make "happened then" and "ingested then" indistinguishable downstream.
+func TestChunkConversion_NilOccurredAtStaysNil(t *testing.T) {
+	t.Parallel()
+
+	collected := time.Date(2026, 8, 19, 1, 0, 0, 0, time.UTC)
+	row := chunkResultAt(uuid.New(), model.SourceSlack, 0.9, nil, collected)
+
+	for _, convert := range []func(store.ChunkSearchResult) *model.SearchResult{
+		chunkVecToSearchResult, chunkToSearchResult,
+	} {
+		got := convert(row)
+		if got.OccurredAt != nil {
+			t.Errorf("OccurredAt = %s, want nil — collected_at must not be promoted to an event time", got.OccurredAt)
+		}
+		if !got.CollectedAt.Equal(collected) {
+			t.Errorf("CollectedAt = %s, want %s", got.CollectedAt, collected)
+		}
+	}
+}
+
+// TestSearch_SortRecent_FutureWindow_ChunkOnlyHit_RanksFirst is the issue's
+// headline symptom.
+//
+// The chunk-only document is the SOONEST of the three. Under `occurred_at ASC`
+// it belongs at position 0. Before the fix it was placed last, so the answer to
+// "다음 주 일정" opened with the furthest-away entry and closed with the most
+// imminent one.
+func TestSearch_SortRecent_FutureWindow_ChunkOnlyHit_RanksFirst(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	from, to := now.Add(1*time.Hour), now.Add(30*24*time.Hour)
+
+	// Store hits: both later than the chunk-only hit below.
+	mid := recentResult(uuid.New(), "모레 회의", now.Add(48*time.Hour), 0.9)
+	late := recentResult(uuid.New(), "다음 주 회의", now.Add(120*time.Hour), 0.5)
+
+	// Chunk-only: the most imminent entry of the three.
+	soonestID := uuid.New()
+	soonestAt := now.Add(6 * time.Hour)
+
+	docs := &recordingDocSearcher{results: []*model.SearchResult{mid, late}}
+	chunks := &mockChunkSearcher{vectorResults: []store.ChunkSearchResult{
+		chunkResultAt(soonestID, model.SourceCalendar, 0.99, &soonestAt, now),
+	}}
+	checker := &fakeOccurredChecker{occurredAt: map[uuid.UUID]time.Time{
+		mid.ID:    now.Add(48 * time.Hour),
+		late.ID:   now.Add(120 * time.Hour),
+		soonestID: soonestAt,
+	}}
+	svc := NewService(docs, stubEnabledEmbedder{}).
+		WithChunkStore(chunks).
+		WithOccurredRangeChecker(checker)
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{
+		Query:        "다음 주 일정",
+		Limit:        20,
+		Sort:         "recent",
+		OccurredFrom: &from,
+		OccurredTo:   &to,
+	})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	if !sameIDs(results, soonestID, mid.ID, late.ID) {
+		t.Fatalf("order = %v, want soonest-first [%s %s %s] — the chunk-only hit is the most imminent entry and must lead",
+			idsOf(results), soonestID, mid.ID, late.ID)
+	}
+}
+
+// TestSearch_SortRecent_PastWindow_ChunkOnlyHit_RanksByTime is the descending
+// counterpart: the chunk-only hit lands in the MIDDLE, which is only
+// observable once it carries a real timestamp. "Last" was previously
+// indistinguishable from "correct" for any chunk-only hit that happened to be
+// the oldest, so the past direction gets a case where last is wrong.
+func TestSearch_SortRecent_PastWindow_ChunkOnlyHit_RanksByTime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	from, to := now.Add(-30*24*time.Hour), now.Add(-time.Hour)
+
+	newest := recentResult(uuid.New(), "어제 통화", now.Add(-2*time.Hour), 0.9)
+	oldest := recentResult(uuid.New(), "지난달 통화", now.Add(-240*time.Hour), 0.5)
+
+	middleID := uuid.New()
+	middleAt := now.Add(-48 * time.Hour)
+
+	docs := &recordingDocSearcher{results: []*model.SearchResult{newest, oldest}}
+	chunks := &mockChunkSearcher{vectorResults: []store.ChunkSearchResult{
+		chunkResultAt(middleID, model.SourceCallTranscript, 0.99, &middleAt, now),
+	}}
+	checker := &fakeOccurredChecker{occurredAt: map[uuid.UUID]time.Time{
+		newest.ID: now.Add(-2 * time.Hour),
+		oldest.ID: now.Add(-240 * time.Hour),
+		middleID:  middleAt,
+	}}
+	svc := NewService(docs, stubEnabledEmbedder{}).
+		WithChunkStore(chunks).
+		WithOccurredRangeChecker(checker)
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{
+		Query:        "통화",
+		Limit:        20,
+		Sort:         "recent",
+		OccurredFrom: &from,
+		OccurredTo:   &to,
+	})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	if !sameIDs(results, newest.ID, middleID, oldest.ID) {
+		t.Fatalf("order = %v, want newest-first [%s %s %s] — the chunk-only hit belongs between the two store hits",
+			idsOf(results), newest.ID, middleID, oldest.ID)
+	}
+}
+
+// TestSearch_SortRecent_NoWindow_ChunkOnlyHit_UsesCollectedAt covers the
+// descending branch's COALESCE: with no window at all the chunk lanes run
+// unverified, and a chunk-only document whose parent has no occurred_at must
+// still be ordered — on collected_at, exactly as the store's
+// COALESCE(occurred_at, collected_at) DESC does for its own rows.
+func TestSearch_SortRecent_NoWindow_ChunkOnlyHit_UsesCollectedAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	newest := recentResult(uuid.New(), "최근 문서", now.Add(-2*time.Hour), 0.9)
+	oldest := recentResult(uuid.New(), "오래된 문서", now.Add(-240*time.Hour), 0.5)
+
+	middleID := uuid.New()
+	middleCollected := now.Add(-48 * time.Hour)
+
+	docs := &recordingDocSearcher{results: []*model.SearchResult{newest, oldest}}
+	chunks := &mockChunkSearcher{vectorResults: []store.ChunkSearchResult{
+		chunkResultAt(middleID, model.SourceLLMMemory, 0.99, nil, middleCollected),
+	}}
+	svc := NewService(docs, stubEnabledEmbedder{}).WithChunkStore(chunks)
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{
+		Query: "문서",
+		Limit: 20,
+		Sort:  "recent",
+	})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	if !sameIDs(results, newest.ID, middleID, oldest.ID) {
+		t.Fatalf("order = %v, want [%s %s %s] — a chunk-only hit with no event time degrades to ingest order, not to last",
+			idsOf(results), newest.ID, middleID, oldest.ID)
+	}
+}

--- a/internal/search/sort_recent.go
+++ b/internal/search/sort_recent.go
@@ -65,11 +65,14 @@ func sortByRecency(results []*model.SearchResult, ascending bool) {
 //   - descending: COALESCE(occurred_at, collected_at), so a document with no
 //     event-time concept degrades to ingest order exactly as it does in SQL.
 //
-// Chunk-lane rows are the interesting case for the "no usable timestamp"
-// result: chunkVecToSearchResult / chunkToSearchResult populate neither field
-// (the chunk join carries no timestamps), so a document reachable ONLY through
-// a chunk lane is ordered last. That is a deliberate limitation, not an
-// oversight — see the note in Service.Search.
+// Chunk-lane rows are ordinary inputs here. They used to be the whole reason
+// the "no usable timestamp" branch fired: the chunk join selected no
+// timestamps, so every chunk-only document went last regardless of when it
+// happened (#215). The join now carries the parent's occurred_at/collected_at
+// and chunkVecToSearchResult / chunkToSearchResult copy them across, so a
+// chunk-only hit is placed on the same key as a store hit. The branch below is
+// therefore reached only by a document that genuinely has no event time, on the
+// ascending side — which is what it was written for.
 func recencyKey(r *model.SearchResult, ascending bool) (time.Time, bool) {
 	if r.OccurredAt != nil && !r.OccurredAt.IsZero() {
 		return *r.OccurredAt, true

--- a/internal/store/chunks.go
+++ b/internal/store/chunks.go
@@ -40,6 +40,23 @@ type ChunkSearchResult struct {
 	DocumentTitle  string
 	DocumentSource string // source_type value (e.g. "slack", "github")
 	DocumentStatus string
+
+	// DocumentOccurredAt / DocumentCollectedAt are the parent document's event
+	// and ingest times. They are selected here — rather than left to a second
+	// fetch — because internal/search orders a merged result set in Go, and a
+	// document reachable ONLY through a chunk lane never passes through the
+	// document store's ORDER BY.
+	//
+	// Without them such a document has no usable timestamp at all, and
+	// search.recencyKey ranks it LAST in both directions. For a forward-looking
+	// window that is the exact inversion of what Sort="recent" means: the most
+	// imminent entry is shown as the furthest away (#215).
+	//
+	// DocumentOccurredAt stays a pointer, and NULL stays nil: "no event-time
+	// concept" and "the epoch" are different facts, and the COALESCE onto
+	// collected_at belongs to the ordering rule, not to this row.
+	DocumentOccurredAt  *time.Time
+	DocumentCollectedAt time.Time
 }
 
 // ChunkStore provides chunk persistence and FTS search operations.
@@ -141,7 +158,9 @@ func (s *ChunkStore) SearchFTS(ctx context.Context, query string, limit int) ([]
 			) AS rank,
 			d.title          AS document_title,
 			d.source_type    AS document_source,
-			d.status         AS document_status
+			d.status         AS document_status,
+			d.occurred_at    AS document_occurred_at,
+			d.collected_at   AS document_collected_at
 		FROM chunks c
 		JOIN documents d ON d.id = c.document_id
 		WHERE (c.content_tsv @@ plainto_tsquery('simple', $1)
@@ -170,6 +189,8 @@ func (s *ChunkStore) SearchFTS(ctx context.Context, query string, limit int) ([]
 			&r.DocumentTitle,
 			&r.DocumentSource,
 			&r.DocumentStatus,
+			&r.DocumentOccurredAt,
+			&r.DocumentCollectedAt,
 		); err != nil {
 			return nil, fmt.Errorf("chunks search FTS scan: %w", err)
 		}
@@ -383,7 +404,9 @@ func (s *ChunkStore) SearchVector(ctx context.Context, queryVec []float32, limit
 			1 - (c.embedding <=> $1::vector)  AS score,
 			d.title          AS document_title,
 			d.source_type    AS document_source,
-			d.status         AS document_status
+			d.status         AS document_status,
+			d.occurred_at    AS document_occurred_at,
+			d.collected_at   AS document_collected_at
 		FROM chunks c
 		JOIN documents d ON d.id = c.document_id
 		WHERE c.embedding IS NOT NULL
@@ -411,6 +434,8 @@ func (s *ChunkStore) SearchVector(ctx context.Context, queryVec []float32, limit
 			&r.DocumentTitle,
 			&r.DocumentSource,
 			&r.DocumentStatus,
+			&r.DocumentOccurredAt,
+			&r.DocumentCollectedAt,
 		); err != nil {
 			return nil, fmt.Errorf("chunks search vector scan: %w", err)
 		}

--- a/internal/store/chunks_timestamps_db_test.go
+++ b/internal/store/chunks_timestamps_db_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+	"github.com/pgvector/pgvector-go"
+)
+
+// ---------------------------------------------------------------------------
+// #215 — the chunk lanes must return the parent document's timestamps.
+//
+// A struct-field test proves the Go type has the fields. It cannot prove that
+// PostgreSQL accepts `d.occurred_at` in this SELECT list, that the column
+// order in the statement matches the order of the Scan targets, or that pgx
+// decodes a NULL timestamptz into a *time.Time rather than failing. Column
+// order in particular is the failure this file exists for: adding a column to
+// the SELECT and forgetting one Scan target compiles, passes every stub test,
+// and then either errors or silently shifts every subsequent field at runtime.
+//
+// Skipped unless TEST_DATABASE_URL is set. It must NEVER point at production —
+// run a throwaway pgvector container. Seeded rows are scoped by the sentinel
+// source_id prefix below and removed in t.Cleanup. All content is filler.
+// ---------------------------------------------------------------------------
+
+const chunkTSPrefix = "zz-dummy-chunkts-"
+
+// chunkTSTestDB reuses the documents schema helper from
+// document_source_types_db_test.go and adds the chunks table the chunk lanes
+// join against.
+func chunkTSTestDB(t *testing.T) *Postgres {
+	t.Helper()
+	pg := srcTestDB(t) // skips without TEST_DATABASE_URL; creates `documents`
+
+	ctx := context.Background()
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS chunks (
+			id bigserial PRIMARY KEY,
+			document_id uuid NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+			chunk_index int NOT NULL,
+			content text NOT NULL,
+			byte_size int NOT NULL DEFAULT 0,
+			embedding vector(3),
+			created_at timestamptz NOT NULL DEFAULT now(),
+			content_tsv tsvector GENERATED ALWAYS AS (
+				to_tsvector('simple', coalesce(content,''))
+			) STORED
+		)`,
+	}
+	for _, s := range stmts {
+		if _, err := pg.pool.Exec(ctx, s); err != nil {
+			t.Fatalf("prepare chunks schema: %v", err)
+		}
+	}
+	// documents rows are removed by srcTestDB's cleanup; ON DELETE CASCADE
+	// takes the chunks with them.
+	return pg
+}
+
+// seedChunkDoc inserts one document plus one chunk and returns the document ID.
+func seedChunkDoc(t *testing.T, pg *Postgres, occurredAt *time.Time, collectedAt time.Time) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+
+	id := uuid.New()
+	if _, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, embedding, occurred_at, collected_at)
+		VALUES ($1, $2, $3, 'zzdummy chunk title', 'zzdummy chunk body', $4, $5, $6)`,
+		id, string(model.SourceCalendar), chunkTSPrefix+id.String(),
+		pgvector.NewVector([]float32{0.1, 0.2, 0.3}), occurredAt, collectedAt,
+	); err != nil {
+		t.Fatalf("seed document: %v", err)
+	}
+	if _, err := pg.pool.Exec(ctx, `
+		INSERT INTO chunks (document_id, chunk_index, content, byte_size, embedding)
+		VALUES ($1, 0, 'zzdummychunkneedle filler text', 30, $2)`,
+		id, pgvector.NewVector([]float32{0.1, 0.2, 0.3}),
+	); err != nil {
+		t.Fatalf("seed chunk: %v", err)
+	}
+	return id
+}
+
+// TestDB_ChunkSearch_ReturnsDocumentTimestamps executes both chunk statements
+// verbatim and asserts the joined timestamps arrive intact — including the NULL
+// occurred_at case, which is the one that must stay nil rather than becoming
+// the zero instant.
+func TestDB_ChunkSearch_ReturnsDocumentTimestamps(t *testing.T) {
+	pg := chunkTSTestDB(t)
+	cs := NewChunkStore(pg)
+
+	occurred := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+	collectedWith := time.Date(2026, 8, 19, 1, 0, 0, 0, time.UTC)
+	collectedWithout := time.Date(2026, 8, 18, 2, 0, 0, 0, time.UTC)
+
+	withEvent := seedChunkDoc(t, pg, &occurred, collectedWith)
+	noEvent := seedChunkDoc(t, pg, nil, collectedWithout)
+
+	check := func(t *testing.T, lane string, rows []ChunkSearchResult) {
+		t.Helper()
+		byDoc := map[uuid.UUID]ChunkSearchResult{}
+		for _, r := range rows {
+			byDoc[r.Chunk.DocumentID] = r
+		}
+
+		got, ok := byDoc[withEvent]
+		if !ok {
+			t.Fatalf("%s: seeded document %s not returned; the lane cannot be asserted", lane, withEvent)
+		}
+		if got.DocumentOccurredAt == nil {
+			t.Errorf("%s: DocumentOccurredAt = nil, want %s", lane, occurred)
+		} else if !got.DocumentOccurredAt.UTC().Equal(occurred) {
+			t.Errorf("%s: DocumentOccurredAt = %s, want %s", lane, got.DocumentOccurredAt.UTC(), occurred)
+		}
+		if !got.DocumentCollectedAt.UTC().Equal(collectedWith) {
+			t.Errorf("%s: DocumentCollectedAt = %s, want %s", lane, got.DocumentCollectedAt.UTC(), collectedWith)
+		}
+		// Column-order guard: a mis-ordered Scan list shows up here first,
+		// because these fields sit next to the new ones in the SELECT.
+		if got.DocumentSource != string(model.SourceCalendar) || got.DocumentStatus != "active" {
+			t.Errorf("%s: source/status = %q/%q, want %q/active — SELECT and Scan orders disagree",
+				lane, got.DocumentSource, got.DocumentStatus, model.SourceCalendar)
+		}
+
+		none, ok := byDoc[noEvent]
+		if !ok {
+			t.Fatalf("%s: seeded document %s (NULL occurred_at) not returned", lane, noEvent)
+		}
+		if none.DocumentOccurredAt != nil {
+			t.Errorf("%s: DocumentOccurredAt = %s for a NULL column, want nil", lane, none.DocumentOccurredAt)
+		}
+		if !none.DocumentCollectedAt.UTC().Equal(collectedWithout) {
+			t.Errorf("%s: DocumentCollectedAt = %s, want %s", lane, none.DocumentCollectedAt.UTC(), collectedWithout)
+		}
+	}
+
+	t.Run("SearchFTS", func(t *testing.T) {
+		rows, err := cs.SearchFTS(context.Background(), "zzdummychunkneedle", 50)
+		if err != nil {
+			t.Fatalf("SearchFTS: %v", err)
+		}
+		check(t, "SearchFTS", rows)
+	})
+
+	t.Run("SearchVector", func(t *testing.T) {
+		rows, err := cs.SearchVector(context.Background(), []float32{0.1, 0.2, 0.3}, 50)
+		if err != nil {
+			t.Fatalf("SearchVector: %v", err)
+		}
+		check(t, "SearchVector", rows)
+	})
+}


### PR DESCRIPTION
## 개요
청크 전용 검색 히트의 정렬 순서 결함(#215)과 튜닝 승격 가중치가 서빙에 반영되지 않던 결함(#214)을 수정한다.

## #215 — 청크 전용 히트가 recency 정렬에서 항상 뒤로 갔다
청크 조인이 documents를 이미 JOIN하면서도 occurred_at/collected_at을 선택하지 않아, 청크 단독 히트는 시각을 들고 오지 못했다. 창 검증은 통과하므로 집합은 정확했고 순서만 근사였다 — 미래 창에서 가장 임박한 일정이 청크 단독 히트면 마지막에 표시됐다.

두 컬럼을 선택하고 변환 함수가 채우게 한다. occurred_at은 포인터를 유지한다: NULL을 zero instant로 접으면 하강 분기의 COALESCE와 상승 분기의 "배치 불가" 판정이 한 층 일찍 무너진다.

이 변경은 OccurredRangeChecker를 대체하지 않는다. 창은 WHERE 술어여야 하고, 청크 레인은 자기 LIMIT으로 이미 자른 뒤라 사후 필터링은 후보 축소가 아니라 페이지 축소가 된다. 조인은 ORDER를, checker는 MEMBERSHIP을 담당한다.

## #214 — 승격된 가중치가 서빙에 반영되지 않았다
cmd/tune -promote가 search_weights_history에 active 행을 남겨도 검색 경로가 그 행을 읽지 않아, 피드백 루프의 마지막 고리가 끊겨 있었다.

- 캐시하지 않고 요청마다 읽는다. 쓰는 쪽이 cmd/tune으로 다른 프로세스라 서버 안의 무효화 훅이 그 write를 관측할 수 없다. 캐시의 최선은 "TTL 안에"인데 롤백 절차는 "재기동 없이 다음 요청부터"를 요구하고, 그걸 만족할 만큼 짧은 TTL은 요청마다 읽는 것과 같다. 비용은 partial unique index 위 단일 행 조회다
- 우선순위: 요청별 q.Weights > active 행 > WithWeights > 컴파일 기본값. 요청별이 최상위인 것이 결정적이다 — harness가 후보를 q.Weights로 평가하므로 active 행이 이를 덮으면 모든 후보가 현직 가중치로 측정돼 튜너가 자기 자신과 비교하고 노이즈로 승격한다
- fail-open: 조회 실패나 행 부재는 컴파일 기본값으로 폴백하고 검색은 계속한다. 실패 로그는 분당 1회로 제한한다 — 요청마다 도는 경로라 DB 장애 시 요청당 1줄이 쏟아져 정작 장애 로그를 묻는다
- SEARCH_ACTIVE_WEIGHTS_ENABLED, 기본 off. off는 "조회하고 버림"이 아니라 아예 조회하지 않는다
- cmd/tune에는 이 배선을 붙이지 않는다. baseline이 직전 승격본으로 흘러가 매 실행이 자기 자신과 비교하게 된다

## 검증
- #215 SQL은 일회성 postgres 컨테이너로 실검증했고, 음성 검증도 했다 — SELECT 컬럼 순서를 일부러 뒤집으니 두 레인 모두 스캔 실패했다. 그 하네스가 열 순서 어긋남을 실제로 잡는다는 증거다
- 전체 `go test ./...` 31 ok, PASS 1920, FAIL 0

## 미검증 항목
- 플래그 on 상태의 부하 미측정. `/ask` 처럼 한 요청이 검색을 여러 번 부르는 경로에서는 조회가 그만큼 늘어난다
- `chunks` 실 스키마 대조는 손으로 만든 최소 스키마로만 했다(전체 마이그레이션은 `pg_bigm` 때문에 적용 불가). 추가 컬럼 2개의 쿼리 플랜 영향 미실측
- 브라우저 렌더 무관(백엔드 전용 변경)

## 알려진 위험
- **플래그를 켤 때의 무검증 서빙.** 켜지면 그 시점 active 행이 즉시 서빙에 들어간다. 현재 active 행이 없어 켜도 no-op이지만, 켠 채로 나중에 `-promote`를 돌리면 검증 없이 반영된다. 플래그와 승격은 서로를 게이트하지 않는다 — 의도한 설계지만 운영 시 인지가 필요하다
- #215로 청크 전용 히트의 표시 순서가 바뀐다. 집합은 불변이고 기존 순서가 틀렸던 것이므로 의도한 변화다. 다만 저장된 eval 기대값이 옛 순서를 고정하고 있다면 nDCG가 움직일 수 있다

## 배포 후 확인사항
- **`SEARCH_ACTIVE_WEIGHTS_ENABLED`를 켜지 마라.** active 행이 없고, 검증되지 않은 가중치가 서빙에 들어가면 안 된다. 배선만 넣고 플래그는 off로 둔다
- "지난달에 뭐 있었어"로 `occurred_at` 순서가 여전히 내림차순인지 확인. 응답 전체를 받지 말고 `jq -r '.sources[].occurred_at'`로 필드만 추출할 것 — 응답에 개인정보가 있다

Closes #214, Closes #215

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>