### PR TITLE
fix(ask): SSE sources[] occurred_at 노출 + 정렬 주석 정리

### DIFF
--- a/internal/api/ask.go
+++ b/internal/api/ask.go
@@ -24,16 +24,31 @@ type AskRequest struct {
 	ConversationID string `json:"conversation_id,omitempty"`
 }
 
-// AskSourceItem mirrors web/src/lib/types.ts:122-127 EXACTLY — field names
+// AskSourceItem mirrors web/src/lib/types.ts:132-138 EXACTLY — field names
 // and JSON types are a wire contract with the already-shipped frontend, not
 // free to rename. id is mandatory: it is the only future path to
 // (query, document_id, thumbs) feedback labels (see feedback.go's
-// FeedbackRequest.DocumentID).
+// FeedbackRequest.DocumentID). The line range is a hint for humans, not an
+// enforced contract — it drifts whenever either file is edited independently
+// (it already has once); TestAskHandler_SSEFieldNames is what actually pins
+// the JSON keys.
+//
+// OccurredAt deliberately has NO omitempty. This field exists to let a
+// client verify #215's recency-sort direction against real traffic — a
+// document without a known event time still needs the key present with a
+// JSON null so "no event time" (null) is distinguishable from "the server
+// has not shipped this field yet" (missing key). Before this field existed,
+// a deployment check that expected occurred_at could not tell those two
+// cases apart and misread an absent field as a sort bug (issue #218). Every
+// call site that fills this struct (mapAskSources, toAskSourceItems) must
+// pass through whatever *time.Time it has, nil included, rather than
+// skipping the field.
 type AskSourceItem struct {
-	ID         string  `json:"id"`
-	Title      string  `json:"title"`
-	SourceType string  `json:"source_type"`
-	Score      float64 `json:"score"`
+	ID         string     `json:"id"`
+	Title      string     `json:"title"`
+	SourceType string     `json:"source_type"`
+	Score      float64    `json:"score"`
+	OccurredAt *time.Time `json:"occurred_at"`
 }
 
 // askConversationPayload is the "conversation" SSE event body. It is sent
@@ -391,6 +406,7 @@ func mapAskSources(results []*model.SearchResult) []AskSourceItem {
 			Title:      r.Document.Title,
 			SourceType: string(r.Document.SourceType),
 			Score:      r.Score,
+			OccurredAt: r.Document.OccurredAt,
 		})
 	}
 	return items

--- a/internal/api/ask_conversations.go
+++ b/internal/api/ask_conversations.go
@@ -102,6 +102,7 @@ func toAskSourceItems(sources []store.AskSource) []AskSourceItem {
 	for _, src := range sources {
 		items = append(items, AskSourceItem{
 			ID: src.ID, Title: src.Title, SourceType: src.SourceType, Score: src.Score,
+			OccurredAt: src.OccurredAt,
 		})
 	}
 	return items

--- a/internal/api/ask_history.go
+++ b/internal/api/ask_history.go
@@ -121,6 +121,7 @@ func (s *Server) saveAskTurn(ctx context.Context, conversationID uuid.UUID, turn
 	for _, src := range sources {
 		storeSources = append(storeSources, store.AskSource{
 			ID: src.ID, Title: src.Title, SourceType: src.SourceType, Score: src.Score,
+			OccurredAt: src.OccurredAt,
 		})
 	}
 

--- a/internal/api/ask_multiturn_test.go
+++ b/internal/api/ask_multiturn_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/baekenough/second-brain/internal/model"
 	"github.com/baekenough/second-brain/internal/store"
@@ -618,5 +619,84 @@ func TestAskConversationDetailHandler_InvalidID_Returns400(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// --- occurred_at wire<->store round trip (issue #218) ---
+
+// TestAskHandler_SaveAskTurn_PreservesOccurredAt covers the wire->store
+// direction of saveAskTurn (ask_history.go): a source's OccurredAt, present
+// in the SSE "sources" payload, must reach the persisted store.AskSession
+// unchanged rather than being dropped during the AskSourceItem ->
+// store.AskSource conversion.
+func TestAskHandler_SaveAskTurn_PreservesOccurredAt(t *testing.T) {
+	t.Parallel()
+	occurredAt := time.Date(2026, 8, 18, 3, 0, 0, 0, time.UTC)
+	doc := docResultWithOccurredAt(model.SourceSMS, "문자 내용", occurredAt)
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{doc}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답"}}
+	sessions := newFakeAskSessionStore()
+	srv := newAskTestServerWithSessions(searcher, &fakeIntentClassifier{}, fakeLLM, sessions)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{"question": "질문"}, "Bearer test-key")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	if len(sessions.insertCalls) != 1 {
+		t.Fatalf("Insert called %d times, want exactly 1", len(sessions.insertCalls))
+	}
+	saved := sessions.insertCalls[0]
+	if len(saved.Sources) != 1 {
+		t.Fatalf("saved.Sources = %v, want 1 item", saved.Sources)
+	}
+	got := saved.Sources[0].OccurredAt
+	if got == nil {
+		t.Fatalf("saved source OccurredAt = nil, want %s", occurredAt)
+	}
+	if !got.Equal(occurredAt) {
+		t.Errorf("saved source OccurredAt = %s, want %s", got, occurredAt)
+	}
+}
+
+// TestAskConversationDetailHandler_ReflectsSourceOccurredAt covers the
+// store->wire direction (toAskSourceItems, ask_conversations.go): a
+// pre-seeded store.AskSession with a set source OccurredAt must surface it
+// unchanged through GET /api/v1/ask/conversations/{id}, and a source with no
+// OccurredAt (mirroring a pre-#218 row that never had the key at all — see
+// store.AskSource's doc comment) must surface as nil rather than the zero
+// time.Time, so a page-refresh reload never fabricates a false event time
+// for older turns.
+func TestAskConversationDetailHandler_ReflectsSourceOccurredAt(t *testing.T) {
+	t.Parallel()
+	occurredAt := time.Date(2026, 8, 15, 12, 30, 0, 0, time.UTC)
+	sessions := newFakeAskSessionStore()
+	conv := uuid.New()
+	sessions.seed(conv, store.AskSession{
+		ID: uuid.New(), ConversationID: conv, TurnIndex: 0,
+		Question: "Q0", Answer: "A0", FinishReason: "stop",
+		Sources: []store.AskSource{
+			{ID: "doc-with-time", Title: "t1", SourceType: "sms", Score: 0.9, OccurredAt: &occurredAt},
+			{ID: "doc-without-time", Title: "t2", SourceType: "gmail", Score: 0.5}, // OccurredAt nil, as a pre-#218 row
+		},
+	})
+	srv := newAskTestServerWithSessions(&fixedDocSearcher{}, &fakeIntentClassifier{}, &fakeAskLLM{enabled: true}, sessions)
+
+	rr := doAskGet(t, srv, "/api/v1/ask/conversations/"+conv.String(), "Bearer test-key")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var out []askConversationTurn
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(out) != 1 || len(out[0].Sources) != 2 {
+		t.Fatalf("out = %+v, want 1 turn with 2 sources", out)
+	}
+	if got := out[0].Sources[0].OccurredAt; got == nil || !got.Equal(occurredAt) {
+		t.Errorf("sources[0].OccurredAt = %v, want %s", got, occurredAt)
+	}
+	if got := out[0].Sources[1].OccurredAt; got != nil {
+		t.Errorf("sources[1].OccurredAt = %v, want nil (pre-#218 row has no captured event time)", got)
 	}
 }

--- a/internal/api/ask_retrieval.go
+++ b/internal/api/ask_retrieval.go
@@ -82,16 +82,21 @@ func assembleRetrieval(ctx context.Context, searcher documentSearcher, params in
 	base.OccurredTo = plan.OccurredTo
 	base.SourceTypes = plan.SourceTypes
 	if plan.OccurredFrom != nil || plan.OccurredTo != nil {
-		// Secondary preference only: within a window, newest-first is the
+		// Secondary preference only: within a window, newest-first (or, for a
+		// window that lies entirely in the future, soonest-first) is the
 		// sensible reading order. Sort can never substitute for the window —
 		// it permutes candidates a lane already selected.
 		//
-		// KNOWN GAP (design §12 R3): Sort="recent" is collected_at DESC. For a
-		// future window ("다음 주 일정") that orders by ingestion time, not by
-		// how soon the event is. The spec leaves the fix (a future-window sort
-		// mode, or reordering in Stage 3) open, so this deliberately keeps the
-		// pre-planner behaviour rather than inventing a third option here.
-		base.Sort = "recent"
+		// Direction is not decided here. model.SearchQuery.RecencyAscending
+		// (issue #215) inspects OccurredFrom against now and flips to
+		// ascending exactly when the whole window lies in the future, so a
+		// future window ("다음 주 일정") returns soonest-first instead of the
+		// old furthest-future-first. Both the store's SQL ORDER BY and
+		// internal/search's post-merge re-sort derive their direction from
+		// that one function, so this call site only has to ask for
+		// SortRecent — it does not need to know which way it currently
+		// points.
+		base.Sort = model.SortRecent
 	}
 
 	// --- params: ranking shaping ---
@@ -111,7 +116,7 @@ func assembleRetrieval(ctx context.Context, searcher documentSearcher, params in
 		// window hides documents). Recency ordering is a RANKING preference and
 		// therefore stays on the params side of the §3.2 split — it never
 		// retrieves anything the lanes did not already select.
-		base.Sort = "recent"
+		base.Sort = model.SortRecent
 	}
 
 	observedQuery, runObserved, insightQuery := splitInsightLane(base, insightM)

--- a/internal/api/ask_test.go
+++ b/internal/api/ask_test.go
@@ -229,6 +229,16 @@ func docResult(sourceType model.SourceType, title string) *model.SearchResult {
 	}
 }
 
+// docResultWithOccurredAt is docResult plus a set Document.OccurredAt — used
+// by the occurred_at wire-contract tests (issue #218) to distinguish "this
+// document has a known event time" from docResult's default nil, which
+// exercises the JSON-null branch instead.
+func docResultWithOccurredAt(sourceType model.SourceType, title string, occurredAt time.Time) *model.SearchResult {
+	r := docResult(sourceType, title)
+	r.Document.OccurredAt = &occurredAt
+	return r
+}
+
 // newAskTestServer wires a Server whose *search.Service is backed by fake
 // in-memory searcher + a disabled embedder (no real DB), and whose
 // intentClassifier field is swapped for a fake (unexported-field access is
@@ -551,10 +561,18 @@ func TestAskHandler_SSEFieldNames(t *testing.T) {
 	if err := json.Unmarshal(raw["sources"], &items); err != nil {
 		t.Fatalf("sources[] not valid JSON: %v", err)
 	}
-	for _, want := range []string{"id", "title", "source_type", "score"} {
+	for _, want := range []string{"id", "title", "source_type", "score", "occurred_at"} {
 		if _, ok := items[0][want]; !ok {
-			t.Errorf("AskSourceItem JSON is missing key %q (types.ts:122-127); got keys=%v", want, mapKeys(items[0]))
+			t.Errorf("AskSourceItem JSON is missing key %q (types.ts:132-138); got keys=%v", want, mapKeys(items[0]))
 		}
+	}
+	// occurred_at must be the JSON literal null, not simply absent — a plain
+	// key-presence check above cannot tell "null" apart from a key that
+	// unmarshaled to some other zero value, and the whole point of dropping
+	// omitempty (AskSourceItem's doc comment, issue #218) is that "no event
+	// time" and "field not shipped" must be visibly different on the wire.
+	if got := string(items[0]["occurred_at"]); got != "null" {
+		t.Errorf("occurred_at = %s, want literal null (docResult sets no OccurredAt)", got)
 	}
 
 	if err := json.Unmarshal([]byte(frames[2].data), &raw); err != nil {
@@ -578,6 +596,39 @@ func mapKeys(m map[string]json.RawMessage) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// TestAskHandler_SourcesOccurredAt_ReflectsDocument is the non-nil
+// counterpart to TestAskHandler_SSEFieldNames' null check: a document with a
+// known event time must have that exact instant on the wire, not just a
+// present key (issue #218 — the deployment check this was written to enable
+// needs occurred_at to actually carry the source's event time, not merely
+// exist).
+func TestAskHandler_SourcesOccurredAt_ReflectsDocument(t *testing.T) {
+	t.Parallel()
+	occurredAt := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	doc := docResultWithOccurredAt(model.SourceSMS, "문자 내용", occurredAt)
+	searcher := &fixedDocSearcher{observed: []*model.SearchResult{doc}}
+	fakeLLM := &fakeAskLLM{enabled: true, chunks: []string{"답변"}}
+	srv := newAskTestServer(searcher, &fakeIntentClassifier{}, fakeLLM)
+
+	rr := doAskRequest(t, srv, nil, map[string]any{"question": "질문"}, "Bearer test-key")
+
+	frames := parseSSEFrames(t, rr.Body.String())
+	var sources askSourcesPayload
+	if err := json.Unmarshal([]byte(frames[1].data), &sources); err != nil {
+		t.Fatalf("unmarshal sources payload: %v; raw=%s", err, frames[1].data)
+	}
+	if len(sources.Sources) != 1 {
+		t.Fatalf("sources = %v, want 1 item", sources.Sources)
+	}
+	got := sources.Sources[0].OccurredAt
+	if got == nil {
+		t.Fatalf("occurred_at = nil, want %s", occurredAt)
+	}
+	if !got.Equal(occurredAt) {
+		t.Errorf("occurred_at = %s, want %s", got, occurredAt)
+	}
 }
 
 // --- date-context fix tests (issue: "내일 일정" produced "현재 시점을 알 수 없다") ---

--- a/internal/store/ask_sessions.go
+++ b/internal/store/ask_sessions.go
@@ -12,15 +12,27 @@ import (
 )
 
 // AskSource mirrors internal/api.AskSourceItem's wire shape (id, title,
-// source_type, score) — that struct lives in internal/api, which this
-// package must not depend on (store is a lower layer than api), so the
-// shape is duplicated here rather than imported. Keep field names/JSON tags
-// in sync with internal/api/ask.go's AskSourceItem if either changes.
+// source_type, score, occurred_at) — that struct lives in internal/api,
+// which this package must not depend on (store is a lower layer than api),
+// so the shape is duplicated here rather than imported. Keep field
+// names/JSON tags in sync with internal/api/ask.go's AskSourceItem if
+// either changes.
+//
+// OccurredAt was added after ask_sessions rows already existed (issue
+// #218); no migration was needed because this struct is marshaled straight
+// into the sources JSONB column (migration 024) rather than its own SQL
+// columns. Rows written before this change have no "occurred_at" key at
+// all, so json.Unmarshal leaves OccurredAt as its zero value, nil — the
+// same value a row written after this change uses for "no known event
+// time". A pre-existing row therefore silently reads back as "no event
+// time" rather than erroring, which is the correct degradation: no
+// backfill can recover a value that was never captured.
 type AskSource struct {
-	ID         string  `json:"id"`
-	Title      string  `json:"title"`
-	SourceType string  `json:"source_type"`
-	Score      float64 `json:"score"`
+	ID         string     `json:"id"`
+	Title      string     `json:"title"`
+	SourceType string     `json:"source_type"`
+	Score      float64    `json:"score"`
+	OccurredAt *time.Time `json:"occurred_at"`
 }
 
 // AskSession represents one row in ask_sessions (migration 024): a single

--- a/internal/store/ask_sessions_test.go
+++ b/internal/store/ask_sessions_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestAskSource_JSON_OccurredAt covers the JSONB round trip (AskSession.Sources
+// marshals straight into the sources column, migration 024 — see
+// AskSource's doc comment) that Insert/scanAskSession rely on, without a real
+// Postgres connection: a set OccurredAt must survive marshal->unmarshal
+// unchanged, a nil OccurredAt must marshal to a literal JSON null (not be
+// omitted — issue #218's whole point is that "no event time" and "field
+// never shipped" must be visibly different on the wire this struct also
+// backs), and JSON that predates this field (no "occurred_at" key at all,
+// simulating a pre-#218 row) must unmarshal to nil rather than error.
+func TestAskSource_JSON_OccurredAt(t *testing.T) {
+	t.Parallel()
+	occurredAt := time.Date(2026, 8, 19, 10, 15, 0, 0, time.UTC)
+
+	t.Run("set value round-trips", func(t *testing.T) {
+		t.Parallel()
+		src := AskSource{ID: "d1", Title: "t", SourceType: "sms", Score: 0.9, OccurredAt: &occurredAt}
+		raw, err := json.Marshal(src)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got AskSource
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.OccurredAt == nil || !got.OccurredAt.Equal(occurredAt) {
+			t.Errorf("OccurredAt = %v, want %s", got.OccurredAt, occurredAt)
+		}
+	})
+
+	t.Run("nil marshals to literal null, not an omitted key", func(t *testing.T) {
+		t.Parallel()
+		src := AskSource{ID: "d2", Title: "t", SourceType: "gmail", Score: 0.5}
+		raw, err := json.Marshal(src)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			t.Fatalf("unmarshal into map: %v", err)
+		}
+		val, ok := fields["occurred_at"]
+		if !ok {
+			t.Fatalf("occurred_at key missing entirely; raw=%s", raw)
+		}
+		if string(val) != "null" {
+			t.Errorf("occurred_at = %s, want literal null", val)
+		}
+	})
+
+	t.Run("pre-#218 JSON with no occurred_at key unmarshals to nil", func(t *testing.T) {
+		t.Parallel()
+		legacy := []byte(`{"id":"d3","title":"t","source_type":"whisper","score":0.7}`)
+		var got AskSource
+		if err := json.Unmarshal(legacy, &got); err != nil {
+			t.Fatalf("unmarshal legacy row: %v", err)
+		}
+		if got.OccurredAt != nil {
+			t.Errorf("OccurredAt = %v, want nil for a row that predates this field", got.OccurredAt)
+		}
+	})
+}

--- a/web/src/app/ask/evidenceFeedback.test.ts
+++ b/web/src/app/ask/evidenceFeedback.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { buildRankMap, nextVote } from "./evidenceFeedback";
+import { buildRankMap, nextVote, sourceOccurredAtLabel } from "./evidenceFeedback";
 import type { AskSourceItem } from "@/lib/types";
 
 /** Dummy sources only — no real titles, names or numbers (plan §privacy). */
-function source(id: string, source_type: AskSourceItem["source_type"]): AskSourceItem {
-  return { id, title: "더미 문서", source_type, score: 0.5 };
+function source(
+  id: string,
+  source_type: AskSourceItem["source_type"],
+  occurred_at: string | null = null,
+): AskSourceItem {
+  return { id, title: "더미 문서", source_type, score: 0.5, occurred_at };
 }
 
 describe("buildRankMap", () => {
@@ -47,5 +51,34 @@ describe("nextVote", () => {
   it("0에서 클릭하면 클릭 값이 된다", () => {
     expect(nextVote(0, 1)).toBe(1);
     expect(nextVote(0, -1)).toBe(-1);
+  });
+});
+
+// #218: `occurred_at`은 항상 키가 존재하고 값은 RFC3339 문자열 또는 null이다.
+// null은 "문서에 발생 시각이 없음"과 "과거 대화 이력이라 이 필드가 생기기
+// 전에 저장됨"을 구분하지 못하지만, 페이로드에 그 둘을 가를 정보가 없으므로
+// sourceOccurredAtLabel은 구분을 시도하지 않고 동일하게 렌더링한다.
+describe("sourceOccurredAtLabel", () => {
+  it("null이면 잘못된 날짜 문자열 없이 대체 텍스트를 반환한다", () => {
+    const label = sourceOccurredAtLabel(null);
+    expect(label).toBe("발생 시각 미상");
+    expect(label).not.toContain("Invalid Date");
+    expect(label).not.toContain("NaN");
+    expect(label).not.toContain("1970");
+  });
+
+  it("유효한 RFC3339 문자열은 연/월/일/시:분을 포함한 형식으로 표시한다", () => {
+    const label = sourceOccurredAtLabel("2026-08-14T09:30:00+09:00");
+    // lib/dates의 formatDateTime과 동일한 형식(런타임 로컬 타임존 기준) —
+    // 절대 시각이 아니라 형식(자릿수/구두점)만 고정한다. 타임존을 고정하지
+    // 않았다는 것 자체가 이 테스트가 확인하려는 계약이다: 어떤 타임존에서
+    // 실행되든 "Invalid Date"/"NaN"이 아니라 이 자리표시자 형식이어야 한다.
+    expect(label).toMatch(/^\d{4}\. \d{2}\. \d{2}\. \d{2}:\d{2}$/);
+    expect(label).not.toContain("Invalid Date");
+    expect(label).not.toContain("NaN");
+  });
+
+  it("빈 문자열도 null과 동일하게 대체 텍스트로 처리한다", () => {
+    expect(sourceOccurredAtLabel("")).toBe("발생 시각 미상");
   });
 });

--- a/web/src/app/ask/evidenceFeedback.ts
+++ b/web/src/app/ask/evidenceFeedback.ts
@@ -9,6 +9,14 @@
  * the toggle rule and the ranking rule can be pinned by cheap tests.
  */
 import type { AskSourceItem, EvidenceVote } from "@/lib/types";
+// Relative, not "@/lib/dates": this module is imported directly by
+// evidenceFeedback.test.ts, and vitest.config.ts does not resolve the "@"
+// alias (only tsconfig.json's paths do, which webpack/Next honours but
+// vitest does not) — a value import via the alias fails at test time even
+// though `tsc --noEmit` and `next build` both resolve it fine. `import type`
+// from "@/lib/types" above is unaffected because type-only imports are
+// erased before either bundler sees them.
+import { formatDateTime } from "../../lib/dates";
 
 /**
  * Whether the thumbs buttons are rendered at all.
@@ -53,4 +61,24 @@ export function buildRankMap(sources: readonly AskSourceItem[]): Record<string, 
  */
 export function nextVote(current: EvidenceVote | undefined, clicked: 1 | -1): EvidenceVote {
   return current === clicked ? 0 : clicked;
+}
+
+/**
+ * Display label for a source card's `occurred_at` (issue #218).
+ *
+ * `null` covers two cases the wire payload cannot distinguish: the document
+ * genuinely has no recorded occurrence time, and (for a turn restored from
+ * conversation history) the row predates this field's existence and was
+ * stored in ask_sessions JSONB before it was captured. There is no
+ * information in the payload to tell these apart, so this function does not
+ * try — both render identically. Same convention as the graph evidence
+ * panel's identical field (app/graph/EvidencePanel.tsx).
+ *
+ * Uses lib/dates's `formatDateTime`, which formats via the runtime's local
+ * timezone (not pinned to KST) — the same convention every other timestamp
+ * in this app already follows (dashboard, document detail, evidence panel).
+ */
+export function sourceOccurredAtLabel(occurredAt: string | null): string {
+  if (!occurredAt) return "발생 시각 미상";
+  return formatDateTime(occurredAt);
 }

--- a/web/src/app/ask/page.tsx
+++ b/web/src/app/ask/page.tsx
@@ -10,7 +10,12 @@ import {
   EvidenceFeedbackDisabledError,
 } from "@/lib/api";
 import type { AskSourceItem, AskConversationSummary, AskLayer, EvidenceVote } from "@/lib/types";
-import { buildRankMap, nextVote, EVIDENCE_FEEDBACK_ENABLED } from "./evidenceFeedback";
+import {
+  buildRankMap,
+  nextVote,
+  sourceOccurredAtLabel,
+  EVIDENCE_FEEDBACK_ENABLED,
+} from "./evidenceFeedback";
 import { getAskLayer, ASK_LAYER_LABELS } from "@/lib/constants";
 import { Button } from "@/components/ui";
 import { MarkdownContent } from "@/app/documents/[id]/MarkdownContent";
@@ -98,6 +103,9 @@ function SourceCard({
 }) {
   const layer = getAskLayer(source.source_type);
   const isInsight = layer === "insight";
+  // See evidenceFeedback.ts's sourceOccurredAtLabel for why `null` renders
+  // the same fallback text regardless of *why* it is null (issue #218).
+  const occurredAtLabel = sourceOccurredAtLabel(source.occurred_at);
   return (
     <div
       className={`rounded-md border px-3 py-2 text-xs ${
@@ -128,6 +136,7 @@ function SourceCard({
           </span>
         )}
       </div>
+      <div className="mt-0.5 text-[11px] text-foreground-subtle">{occurredAtLabel}</div>
     </div>
   );
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -118,12 +118,23 @@ export interface IngestFileResponse {
   accepted: boolean;
 }
 
-/** One entry of the `sources` SSE event (spec §5.1). */
+/** One entry of the `sources` SSE event (spec §5.1).
+ *
+ * `occurred_at` mirrors internal/api/ask.go's `AskSourceItem.OccurredAt
+ * *time.Time` with no `omitempty` (issue #218) — the key is ALWAYS present
+ * in the wire payload, carrying either an RFC3339 string or `null`. It is
+ * intentionally `string | null` here, not `string | undefined` / optional:
+ * an optional field would let a backend regression that drops the key pass
+ * type-checking silently, defeating the point of fixing the key-vs-value
+ * ambiguity that caused #218 in the first place. See SourceCard's use of
+ * this field in app/ask/page.tsx for why `null` and "not present" are not
+ * the same thing on the wire, even though the UI renders them identically. */
 export interface AskSourceItem {
   id: string;
   title: string;
   source_type: SourceType;
   score: number;
+  occurred_at: string | null;
 }
 
 /** Parsed, typed form of the five /api/v1/ask SSE event types (spec §5.1).


### PR DESCRIPTION
## 요약

- **#217**: `ask_retrieval.go`의 `KNOWN GAP (design §12 R3)` 주석이 사실과 어긋나 있었음. PR #213/#215에서 `model.SearchQuery.RecencyAscending(now)`가 이미 정렬 방향을 판정하고 있고, store SQL `ORDER BY`와 `internal/search.sortByRecency`가 그 판정을 공유함을 확인. 주석을 사실대로 재작성하고 `"recent"` 문자열 리터럴 2곳을 `model.SortRecent` 상수로 교체.
- **#218**: `/ask` SSE `sources[]`에 `occurred_at *time.Time` (json:`occurred_at`, **omitempty 미사용**) 추가. 키가 항상 존재해야 "발생 시각 없는 문서"와 "필드 미전송"이 구분되며, 이 혼동이 #218의 근본 원인이었음. `store.AskSource`에도 동일 필드 추가(JSONB 컬럼이라 DB 마이그레이션 불필요, 기존 행은 키 부재로 nil 강등). 프런트 `AskSourceItem.occurred_at`을 `string | null`(non-optional)로 선언하고 근거 카드에 시각 표시(기존 `formatDateTime` / `"발생 시각 미상"` 관례 재사용).

## 검증 완료

- `go build ./...` / `go vet ./...` 통과
- Go 테스트: PASS 583 / FAIL 0 / SKIP 34 (34건은 `TEST_DATABASE_URL` 미설정 기존 DB 게이트, 이번 변경과 무관)
- 프런트: `bun run type-check` / `bun run test`(29건) / `bun run lint` / `bun run build` 전부 통과
- `package-lock.json` 미생성 확인 (bun 사용 리포)
- 신규 테스트: `omitempty` 회귀 검출, wire→store→wire 왕복 보존, 레거시 nil 케이스 + 양성 대조군 4종으로 실제 회귀 검출 확인

## 미검증 (정직하게 남깁니다)

- **브라우저 렌더 미검증.** `next build`로 `/ask` 라우트 컴파일·프리렌더까지만 확인. dev 서버로 실제 SSE 데이터를 받아 근거 카드가 그려지는 모습(줄바꿈, 카드 높이 증가로 인한 레이아웃 영향)은 확인 못함.
- **프로덕션 실트래픽 검증 미수행.** #218의 목적 자체가 "정렬 검증 경로 확보"인데 그 검증은 배포 후에야 가능. 미래 시간창 오름차순도 다음 주 캘린더 일정이 없어 아직 실증 불가.

Closes #217
Closes #218

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>