### PR TITLE
fix(deploy): pgvector 버전 고정 + ubuntu1 PostgreSQL 마이그레이션 스택

### DIFF
--- a/deploy/postgres-ubuntu1/docker-compose.yml
+++ b/deploy/postgres-ubuntu1/docker-compose.yml
@@ -1,0 +1,65 @@
+# ubuntu1 — second-brain PostgreSQL (pgvector + pg_bigm)
+# Tailscale IP: ${NODE1_TAILSCALE_IP} (see deploy/whisper-lb/README.md for the
+# same pattern used by the whisper LB stack on this node)
+#
+# Deploy:
+#   scp deploy/postgres-ubuntu1/docker-compose.yml ubuntu1:~/second-brain-postgres/docker-compose.yml
+#   ssh ubuntu1 'cd ~/second-brain-postgres && docker compose --env-file .env up -d'
+#
+# Port binding is scoped to the Tailscale IP only — same principle as this
+# project's web service (127.0.0.1-only) and the whisper-lb stack
+# (Tailscale-IP-only): personal data must never be reachable on LAN/public.
+#
+# Image is pre-built natively on ubuntu1 (see docs/superpowers/plans/
+# 2026-08-18-postgres-migration-to-ubuntu1.md Task 5) — no `build:` section
+# here, this compose file only references the tag.
+
+services:
+  postgres:
+    image: second-brain-postgres:ubuntu1
+    container_name: second-brain-postgres
+    environment:
+      POSTGRES_DB: second_brain
+      POSTGRES_USER: brain
+      POSTGRES_PASSWORD: ${PG_SUPERUSER_PASSWORD}
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=6GB"
+      - "-c"
+      - "effective_cache_size=18GB"
+      - "-c"
+      - "work_mem=64MB"
+      - "-c"
+      - "maintenance_work_mem=1GB"
+      - "-c"
+      - "max_worker_processes=16"
+      - "-c"
+      - "max_parallel_workers=12"
+      - "-c"
+      - "max_parallel_maintenance_workers=6"
+      - "-c"
+      - "random_page_cost=1.1"
+    # Default Docker /dev/shm (64MB) is too small for parallel HNSW index
+    # builds with maintenance_work_mem >= 1GB — PostgreSQL's dynamic shared
+    # memory segments for parallel maintenance workers live in /dev/shm, not
+    # shared_buffers. Discovered during the 2026-08-19 macmini->ubuntu1
+    # migration restore: idx_documents_embedding / idx_documents_summary_embedding
+    # / idx_chunks_embedding all failed with "could not resize shared memory
+    # segment ... No space left on device" until this was raised.
+    shm_size: "6gb"
+    volumes:
+      - pgdata_ubuntu1:/var/lib/postgresql/data
+    ports:
+      # Tailscale IP only — never LAN/public. Mirrors deploy/whisper-lb/ubuntu1.
+      - "${NODE1_TAILSCALE_IP}:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U brain -d second_brain"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+volumes:
+  pgdata_ubuntu1:

--- a/deploy/postgres/Dockerfile
+++ b/deploy/postgres/Dockerfile
@@ -1,11 +1,19 @@
-# Extends pgvector/pgvector:pg16 with the pg_bigm extension for Korean 2-gram
+# Extends pgvector/pgvector with the pg_bigm extension for Korean 2-gram
 # partial matching. Migration 006_bigm.sql requires this.
 #
 # The base image provides pgvector; pg_bigm is built from source because it
 # is not shipped in Debian's default PostgreSQL repositories.
-FROM pgvector/pgvector:pg16
+#
+# Base image is pinned to the exact pgvector version currently running in
+# production (vector.control default_version = 0.8.2, confirmed against the
+# live macmini container 2026-08-19) instead of the moving `pg16` tag, which
+# had already drifted to bundle pgvector 0.8.6 by the time this was checked.
+# pg_dump does not emit a VERSION clause for `CREATE EXTENSION vector`, so an
+# unpinned base image would silently install whatever `default_version` the
+# base image happens to carry at build time on restore.
+FROM pgvector/pgvector:0.8.2-pg16
 
-ARG PG_BIGM_REF=master
+ARG PG_BIGM_REF=v1.2-20250903
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
## 요약

macmini -> ubuntu1 PostgreSQL 프로덕션 마이그레이션(2026-08-19)이 완료되었고, 그 과정에서 나온 인프라 코드 변경을 반영합니다.

- **`deploy/postgres/Dockerfile`**: base image를 `pgvector/pgvector:pg16`(버전 없는 이동 태그, 현재 시점 pgvector 0.8.6으로 드리프트)에서 프로덕션과 동일한 `pgvector/pgvector:0.8.2-pg16`으로 고정. `pg_dump`는 `CREATE EXTENSION vector`에 VERSION 절을 붙이지 않기 때문에, 고정하지 않으면 복원 시 조용히 다른 pgvector 버전이 설치되어 HNSW 인덱스 동작이 소스와 달라질 수 있습니다. 컨테이너는 정상 기동하고 확장/인덱스도 만들어지므로 이 실패는 일반적인 검증을 통과해버립니다. `ARG PG_BIGM_REF`도 `master`에서 `v1.2-20250903` 태그로 고정했습니다.
- **`deploy/postgres-ubuntu1/docker-compose.yml`** (신규): ubuntu1(x86_64) 측 PostgreSQL 스택.
  - 사전 빌드된 `second-brain-postgres:ubuntu1` 이미지를 참조 (크로스아키텍처 QEMU 빌드 회피, ubuntu1에서 네이티브 빌드)
  - 포트를 Tailscale 인터페이스에만 바인딩 — LAN/공인 노출 없음 (`deploy/whisper-lb`와 동일 패턴)
  - `shm_size: "6gb"` — 실제 장애로 발견된 설정. 기본 `/dev/shm`(64MB)이 `pg_restore`의 `maintenance_work_mem=4GB` 옵션에 부족해 HNSW 인덱스 3개(`idx_documents_embedding`, `idx_documents_summary_embedding`, `idx_chunks_embedding`) 생성이 `No space left on device`로 실패했습니다.

## 프로덕션 검증 결과 (이미 완료·검증됨)

| 항목 | 소스(macmini) | 타깃(ubuntu1) |
|---|---|---|
| documents / chunks | 46,603 / 462,340 | 동일 |
| entities / relations / ask_sessions | 7,836 / 3,181 / 19 | 동일 |
| NULL 임베딩 (doc/summary/chunk) | 0 / 3 / 0 | 동일 |
| `vector` 확장 | 0.8.2 | 0.8.2 (핀 유효 확인) |
| 테이블 / 인덱스 | 16 / 64 | 16 / 64 |
| ANN sanity 겹침 | — | 8/10 (기준 ≥8/10 충족) |

- 다운타임: 17:50:19 ~ 19:00:12 KST (약 70분)
- `/api/v1/stats` → total 46,603 (프로덕션 API가 새 DB에서 서빙 확인)
- `/api/v1/search` 2회 정상 (알려진 버그 #195 미발현)
- `EXPLAIN` 확인: `Index Scan using idx_documents_embedding`(HNSW), `Bitmap Index Scan on idx_chunks_content_bigm`(pg_bigm) — 인덱스 실사용 확인
- ubuntu1 `pg_stat_activity`: macmini Tailscale IP(`100.100.80.74`)에서 9개 연결 확인
- macmini 로컬 postgres는 덤프 시점 상태로 살아 있음 — 롤백 경로 유지

## 계획서와 어긋난 지점 (정직성 노트)

1. **예상 밖 실패 모드**: 마이그레이션 계획서는 Task 12 실패 시나리오로 `pg_bigm` 버전 불일치만 상정했으나, 실제로는 `/dev/shm` 부족이라는 다른 실패 모드가 발생했습니다.
2. **비밀번호 교체 사건**: 최초 생성된 비밀번호가 base64 계열이라 `/`와 `+`를 포함했고, `/`가 URL authority를 끊어 `DATABASE_URL` 파싱이 실패했습니다(`server` 재시작 루프). 더 심각한 건 **파서 에러 메시지가 애플리케이션의 비밀번호 마스킹을 우회해 로그에 평문 일부를 출력**한 것입니다. 영숫자 전용 비밀번호로 교체해 해결했습니다.
3. **검증 경로의 함정**: 준비 단계의 확장 검증은 컨테이너 내부 로컬 소켓을, 사전 접속 테스트는 `psql -h/-U` 개별 플래그를 사용했기 때문에 둘 다 URL 파싱을 거치지 않아 이 결함을 놓쳤습니다. 애플리케이션만이 `DATABASE_URL`을 파싱합니다.
4. **미실행 항목**: Task 16(soak 모니터링 T+1h~T+72h), Task 17(`hnsw.ef_search` 재튜닝, 선택), Task 18(별도 후속 예정).

## 후속 조치 필요 (별도 이슈화 권장)

- DB 비밀번호 생성 시 URL 예약문자(`/`, `+`, `@`, `:` 등) 배제 규약
- 접속 문자열 파싱 에러가 시크릿을 노출하지 않도록 마스킹 강화

## 테스트 계획

- [x] 프로덕션 마이그레이션 완료 및 데이터 정합성 검증 (위 표)
- [x] API 서빙 확인 (`/api/v1/stats`, `/api/v1/search`)
- [x] 인덱스 실사용 확인 (`EXPLAIN`)
- [ ] Task 16 soak 모니터링 (T+1h~T+72h, 별도 진행 중)
- [ ] Task 17 `hnsw.ef_search` 재튜닝 (선택, 필요시 별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)