### PR TITLE
feat(deploy): ubuntu1 스택 이전 + 검색 품질 개선

### DIFF
--- a/.claude/agent-memory/be-go-backend-expert/MEMORY.md
+++ b/.claude/agent-memory/be-go-backend-expert/MEMORY.md
@@ -21,3 +21,4 @@
 - [project_sort_recent_vs_rrf.md](project_sort_recent_vs_rrf.md) — RRF=선택/Sort=표시순서; recent 방향은 model.RecencyAscending 단일 정의를 store SQL·search Go 정렬이 공유
 - [project_active_weights_serving.md](project_active_weights_serving.md) — #214 승격 가중치 서빙: 캐시 없이 요청마다 읽는 이유(tune=별도 프로세스), 우선순위 3단, SEARCH_ACTIVE_WEIGHTS_ENABLED 기본 off
 - [project_ask_occurred_at_contract.md](project_ask_occurred_at_contract.md) — PR #219: AskSourceItem.OccurredAt 의도적 no-omitempty(키부재 vs null 구분), JSONB라 마이그레이션 불필요, sort는 planner가 날짜창 확정 시에만 적용
+- [project_hyde_wiring_defect.md](project_hyde_wiring_defect.md) — HyDE 영구 no-op(llmClient가 searchSvc 조립보다 뒤에 생성돼 WithLLM 주입 불가); WithOccurredRangeChecker/WithWeights는 미배선이 의도된 것임을 코드로 확인

--- a/.claude/agent-memory/be-go-backend-expert/project_hyde_wiring_defect.md
+++ b/.claude/agent-memory/be-go-backend-expert/project_hyde_wiring_defect.md
@@ -1,0 +1,56 @@
+---
+name: project-hyde-wiring-defect
+description: HyDE was permanently no-op in prod because llmClient was constructed after searchSvc assembly in cmd/server/main.go — fixed by reordering + buildSearchService extraction
+metadata:
+  type: project
+---
+
+`cmd/server/main.go`'s `.WithLLM(llmClient)` call was missing from the
+`search.NewService(...)` chain, AND `llmClient` was constructed (`llm.New(...)`)
+*after* that chain ran — so no code point could even reach in and wire it.
+Result: `Service.llmClient` stayed nil forever, `internal/search/hyde.go`'s
+`Expand()` was a silent no-op on every `UseHyDE: true` request, no error, no
+log line. Confirmed in prod via a 0.142s HyDE response (too fast for the
+LLM round-trip) and byte-identical ON/OFF results on 40 low-lexical-overlap
+golden queries.
+
+Fixed 2026-08-25/26 (session date drifted mid-task): moved `llmClient :=
+llm.New(...)` above the search-service assembly block, added `.WithLLM(llmClient)`
+to the chain (always injected — `llm.New` never returns nil, `Expand`/`WithLLM`
+gate on `Enabled()` internally), and added a dedicated
+`"search: HyDE query expansion available/unavailable"` startup log.
+
+**Why:** `search.Service`'s `.With*()` builder chain degrades silently when a
+call is missing — no compile error, no startup failure, just a feature that
+quietly does nothing. This is the second time this project has shipped a
+silent wiring gap this way (see [[project_active_weights_serving]] for the
+`WithActiveWeights`/`SEARCH_ACTIVE_WEIGHTS_ENABLED` precedent, which got it
+right — flag-gated, logged, tested).
+
+**How to apply:** When touching `cmd/server/main.go`'s search-service assembly,
+check (1) construction-order dependencies before adding a new `.With*()` call,
+(2) whether the new optional dependency needs a startup log stating
+available/unavailable, (3) whether it needs a `buildSearchService`-style pure
+function extraction so the wiring itself is unit-testable without live
+Postgres/LLM/embedding backends — the pattern already used for
+`wireActionsAndBriefing`/`wireEvidenceFeedback`.
+
+**Confirmed NOT bugs during this investigation** (verified by reading code,
+not assumed):
+- `WithOccurredRangeChecker` is intentionally never called in main.go —
+  `Service.occurredRangeChecker()` falls back to a type-assertion on `s.store`,
+  and `*store.DocumentStore` (which `docStore` always is in prod) already
+  implements `OccurredRangeChecker.FilterIDsByOccurredRange`. The comment on
+  `WithOccurredRangeChecker` in `internal/search/search.go` says this
+  explicitly. Chunk-lane window filtering (`verifyWindow`) is NOT broken.
+- `WithWeights` is intentionally never called in main.go — the compiled
+  zero-value `SearchWeights{}` (k=60, equal weights) IS the intended default
+  in production; `WithActiveWeights`/`defaultWeights` (see
+  [[project_active_weights_serving]]) is the actual per-deployment override
+  mechanism, and its own doc comment states "No production caller sets
+  WithWeights today" as a deliberate, documented fact rather than an oversight.
+
+Regression tests added: `cmd/server/main_test.go` —
+`TestBuildSearchService_WiresLLMClientForHyDE` (positive: query gets HyDE-expanded
+through the wired chain) and `TestBuildSearchService_UseHyDEWithoutLLMClientIsANoOp`
+(negative: nil llmClient stays a documented no-op, not a panic).

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -223,13 +223,14 @@ var allowedSourceTypes = map[model.SourceType]struct{}{
 	model.SourceDiscord:        {},
 	model.SourceTelegram:       {},
 	model.SourceSecretary:      {},
-	model.SourceLLMMemory:      {},
+	model.SourceLLMMemory:      {}, // deprecated (see model.SourceLLMMemory doc comment); kept so legacy rows remain searchable
 	model.SourceGmail:          {},
 	model.SourceCalendar:       {},
 	model.SourceSMS:            {},
 	model.SourceCallLog:        {},
 	model.SourceCallTranscript: {},
 	model.SourceUpload:         {},
+	model.SourceAgentNote:      {},
 }
 
 // searchResult is the MCP-friendly projection of model.SearchResult.
@@ -260,8 +261,8 @@ func registerSearchTool(s *server.MCPServer, svc *search.Service) {
 		mcp.WithString("source",
 			mcp.Description(
 				"Optional source type filter. One of: slack, github, gdrive, notion, "+
-					"filesystem, discord, telegram, secretary, llm-memory, "+
-					"gmail, calendar, sms, call-log, call-transcript, upload.",
+					"filesystem, discord, telegram, secretary, llm-memory (deprecated), "+
+					"gmail, calendar, sms, call-log, call-transcript, upload, agent-note.",
 			),
 		),
 	)
@@ -295,7 +296,7 @@ func registerSearchTool(s *server.MCPServer, svc *search.Service) {
 			st := model.SourceType(strings.TrimSpace(src))
 			if _, ok := allowedSourceTypes[st]; !ok {
 				return mcp.NewToolResultError(fmt.Sprintf(
-					"unknown source type %q; allowed: slack, github, gdrive, notion, filesystem, discord, telegram, secretary, llm-memory, gmail, calendar, sms, call-log, call-transcript, upload",
+					"unknown source type %q; allowed: slack, github, gdrive, notion, filesystem, discord, telegram, secretary, llm-memory, gmail, calendar, sms, call-log, call-transcript, upload, agent-note",
 					src,
 				)), nil
 			}
@@ -498,7 +499,7 @@ func registerAddNoteTool(
 		"add_note",
 		mcp.WithDescription(
 			"Persist a note or memory into the second-brain knowledge base. "+
-				"The note is stored with source_type=llm-memory and split into searchable "+
+				"The note is stored with source_type=agent-note and split into searchable "+
 				"chunks. Re-using the same source_id updates the existing note (upsert). "+
 				"Requires Bearer token authentication when API_KEY is configured.",
 		),
@@ -550,11 +551,13 @@ func registerAddNoteTool(
 			}
 		}
 
-		// MCP add_note always writes model.SourceLLMMemory (spec §6.2) and
-		// always requires a non-empty title — this is the one deliberate
-		// behavioural difference from POST /api/v1/notes.
+		// MCP add_note always writes model.SourceAgentNote (spec §6.2,
+		// updated 2026-08-25 — see model.SourceLLMMemory's doc comment for
+		// why this is no longer model.SourceLLMMemory) and always requires a
+		// non-empty title — the latter is the one deliberate behavioural
+		// difference from POST /api/v1/notes.
 		result, errMsg := note.Save(ctx, docs, chunks, embed,
-			model.SourceLLMMemory, title, content, sourceID, metadata, doEmbed, true)
+			model.SourceAgentNote, title, content, sourceID, metadata, doEmbed, true)
 		if errMsg != "" {
 			return mcp.NewToolResultError(errMsg), nil
 		}

--- a/cmd/mcp/main_test.go
+++ b/cmd/mcp/main_test.go
@@ -73,11 +73,17 @@ func TestMCPAuthContextFunc_NonBearerScheme_Unauthorized(t *testing.T) {
 // registerAddNoteTool wiring tests
 // ---------------------------------------------------------------------------
 
-// TestRegisterAddNoteTool_ForcesSourceLLMMemory verifies that the MCP
-// add_note tool, after the internal/note extraction, still persists
-// documents with SourceType=model.SourceLLMMemory and still rejects an
-// empty title — the two behaviours that must NOT regress (spec §6.2).
-func TestRegisterAddNoteTool_ForcesSourceLLMMemory(t *testing.T) {
+// TestRegisterAddNoteTool_ForcesSourceAgentNote verifies that the MCP
+// add_note tool, after the internal/note extraction, persists documents with
+// SourceType=model.SourceAgentNote and still rejects an empty title — the two
+// behaviours that must NOT regress (spec §6.2).
+//
+// Renamed 2026-08-25: add_note used to force model.SourceLLMMemory. That
+// source_type was deprecated after session-transcript documents sharing the
+// same label crowded out search results (see model.SourceLLMMemory's doc
+// comment); add_note now writes model.SourceAgentNote instead so
+// agent-authored notes remain distinguishable from that legacy contamination.
+func TestRegisterAddNoteTool_ForcesSourceAgentNote(t *testing.T) {
 	t.Parallel()
 
 	docs := &fakeMCPDocUpserter{}
@@ -94,8 +100,8 @@ func TestRegisterAddNoteTool_ForcesSourceLLMMemory(t *testing.T) {
 	if docs.lastDoc == nil {
 		t.Fatal("expected Upsert to be called")
 	}
-	if docs.lastDoc.SourceType != model.SourceLLMMemory {
-		t.Errorf("SourceType = %q, want %q", docs.lastDoc.SourceType, model.SourceLLMMemory)
+	if docs.lastDoc.SourceType != model.SourceAgentNote {
+		t.Errorf("SourceType = %q, want %q", docs.lastDoc.SourceType, model.SourceAgentNote)
 	}
 }
 
@@ -212,7 +218,9 @@ func (f *fakeStatsProvider) QueryBaselineStats(_ context.Context) (*store.Baseli
 // add_note tool registered, using the provided fakes. searchSvc may be nil
 // when the test never reaches the search execution path (i.e. auth-gate tests).
 func newTestMCPServer(
-	searchSvc interface{ Search(context.Context, model.SearchQuery) ([]model.SearchResult, error) },
+	searchSvc interface {
+		Search(context.Context, model.SearchQuery) ([]model.SearchResult, error)
+	},
 	docGetter DocumentGetter,
 	statsProvider StatsProvider,
 ) *mcpserver.MCPServer {
@@ -426,6 +434,7 @@ func TestAllowedSourceTypes_AllDeclaredTypesAccepted(t *testing.T) {
 		model.SourceCallLog,
 		model.SourceCallTranscript,
 		model.SourceUpload,
+		model.SourceAgentNote,
 	}
 
 	for _, st := range declared {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -115,6 +115,16 @@ func run() error {
 		slog.Info("reranker configured", "url", cfg.RerankURL, "model", cfg.RerankModel)
 	}
 
+	// --- OpenSearch BM25 (nori) lane (optional) ---
+	// Disabled unless OPENSEARCH_URL is set — see internal/config.Config
+	// and internal/search/opensearch.go for why this lane exists.
+	osLane := search.NewOpenSearchLane(cfg)
+	if osLane != nil {
+		slog.Info("opensearch BM25 lane enabled", "url", cfg.OpensearchURL, "index", cfg.OpensearchIndex)
+	} else {
+		slog.Info("opensearch BM25 lane disabled — OPENSEARCH_URL not set")
+	}
+
 	// --- Search service ---
 	// ChunkStore is attached to enable chunk-based FTS fallback (issue #9).
 	// EntityStore is attached to surface entities in search results (issue #77).
@@ -133,6 +143,7 @@ func run() error {
 		WithChunkStore(chunkStore).
 		WithReranker(reranker).
 		WithEntityFetcher(entityStore).
+		WithOpenSearch(osLane).
 		WithActiveWeights(weightsHistoryStore, cfg.SearchActiveWeightsEnabled)
 	if cfg.SearchActiveWeightsEnabled {
 		slog.Info("search: serving the promoted weights from search_weights_history",

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -125,32 +125,13 @@ func run() error {
 		slog.Info("opensearch BM25 lane disabled — OPENSEARCH_URL not set")
 	}
 
-	// --- Search service ---
-	// ChunkStore is attached to enable chunk-based FTS fallback (issue #9).
-	// EntityStore is attached to surface entities in search results (issue #77).
-	//
-	// WeightsHistoryStore closes the tuning loop (#214): cmd/tune -promote
-	// writes the winning configuration to search_weights_history, and this is
-	// the only process that reads it back. The reader is attached
-	// unconditionally and the flag decides whether it is consulted, so that
-	// turning SEARCH_ACTIVE_WEIGHTS_ENABLED on is a restart and not a redeploy.
-	// It is attached HERE and nowhere else on purpose: cmd/tune must keep
-	// measuring against the compiled defaults, or its baseline would drift to
-	// whatever it last promoted and every subsequent run would compare a
-	// configuration against itself.
-	weightsHistoryStore := store.NewWeightsHistoryStore(pg)
-	searchSvc := search.NewService(docStore, embedClient).
-		WithChunkStore(chunkStore).
-		WithReranker(reranker).
-		WithEntityFetcher(entityStore).
-		WithOpenSearch(osLane).
-		WithActiveWeights(weightsHistoryStore, cfg.SearchActiveWeightsEnabled)
-	if cfg.SearchActiveWeightsEnabled {
-		slog.Info("search: serving the promoted weights from search_weights_history",
-			"flag", "SEARCH_ACTIVE_WEIGHTS_ENABLED")
-	}
-
-	// --- LLM client (curation) ---
+	// --- LLM client (curation + HyDE query expansion) ---
+	// Constructed BEFORE the search service on purpose. It used to be built
+	// after searchSvc's .With*() chain ran, which meant nothing could pass it
+	// to WithLLM — HyDE (internal/search/hyde.go) was a permanent, silent
+	// no-op in production because Service.llmClient stayed nil forever. See
+	// buildSearchService's doc comment and main_test.go for the regression
+	// test that pins this ordering.
 	llmClient := llm.New(llm.Config{
 		BaseURL:     cfg.LLMAPIURL,
 		Model:       cfg.LLMModel,
@@ -164,6 +145,42 @@ func run() error {
 		slog.Info("LLM client configured", "url", cfg.LLMAPIURL, "model", cfg.LLMModel)
 	} else {
 		slog.Info("LLM client not configured — curation features disabled")
+	}
+
+	// --- Search service ---
+	// ChunkStore is attached to enable chunk-based FTS fallback (issue #9).
+	// EntityStore is attached to surface entities in search results (issue #77).
+	//
+	// WeightsHistoryStore closes the tuning loop (#214): cmd/tune -promote
+	// writes the winning configuration to search_weights_history, and this is
+	// the only process that reads it back. The reader is attached
+	// unconditionally and the flag decides whether it is consulted, so that
+	// turning SEARCH_ACTIVE_WEIGHTS_ENABLED on is a restart and not a redeploy.
+	// It is attached HERE and nowhere else on purpose: cmd/tune must keep
+	// measuring against the compiled defaults, or its baseline would drift to
+	// whatever it last promoted and every subsequent run would compare a
+	// configuration against itself.
+	//
+	// llmClient is attached unconditionally, the same way reranker and osLane
+	// are above/below — llm.New always returns a non-nil *Client (see
+	// internal/llm), and WithLLM/Expand gate on client.Enabled() internally
+	// (internal/search/hyde.go). Gating the wiring itself on Enabled() would
+	// just reproduce the bug this fixes under a different name: the client's
+	// enabled-ness can change with env vars across restarts, but the wiring
+	// must not depend on the state it was in at the moment main() ran.
+	weightsHistoryStore := store.NewWeightsHistoryStore(pg)
+	searchSvc := buildSearchService(
+		docStore, embedClient, chunkStore, reranker, entityStore, osLane,
+		llmClient, weightsHistoryStore, cfg.SearchActiveWeightsEnabled,
+	)
+	if cfg.SearchActiveWeightsEnabled {
+		slog.Info("search: serving the promoted weights from search_weights_history",
+			"flag", "SEARCH_ACTIVE_WEIGHTS_ENABLED")
+	}
+	if llmClient.Enabled() {
+		slog.Info("search: HyDE query expansion available", "model", cfg.LLMModel)
+	} else {
+		slog.Info("search: HyDE query expansion unavailable — LLM client not configured")
 	}
 
 	// --- HTTP server ---
@@ -262,6 +279,39 @@ func run() error {
 
 	slog.Info("shutdown complete")
 	return nil
+}
+
+// buildSearchService assembles the search.Service from its optional
+// dependencies. It is a pure function — no I/O — so the wiring itself (which
+// optional lanes and clients get attached) is unit-testable without a live
+// Postgres connection or embedding/LLM backend (see main_test.go).
+//
+// This exists because a missing .With*() call in the chain does not fail to
+// compile and does not fail to start: search.Service just degrades silently
+// to "that lane/feature is off". That is exactly how the HyDE wiring defect
+// shipped — Service.llmClient stayed nil because llmClient used to be
+// constructed after this chain ran in run(), so no call here could reach it,
+// and every UseHyDE request became a no-op with no error and no log line. A
+// test that only checks "the server starts" cannot catch that; a test that
+// inspects what buildSearchService actually attaches can.
+func buildSearchService(
+	docStore search.DocumentSearcher,
+	embedClient search.EmbeddingEngine,
+	chunkStore search.ChunkSearcher,
+	reranker search.Reranker,
+	entityStore search.EntityFetcher,
+	osLane search.OpenSearchSearcher,
+	llmClient llm.Completer,
+	weightsHistoryStore search.ActiveWeightsReader,
+	activeWeightsEnabled bool,
+) *search.Service {
+	return search.NewService(docStore, embedClient).
+		WithChunkStore(chunkStore).
+		WithReranker(reranker).
+		WithEntityFetcher(entityStore).
+		WithOpenSearch(osLane).
+		WithActiveWeights(weightsHistoryStore, activeWeightsEnabled).
+		WithLLM(llmClient)
 }
 
 // wireActionsAndBriefing conditionally registers the /api/v1/actions and

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -198,6 +198,94 @@ func TestWireEvidenceFeedback_NilVoterStaysUnregistered(t *testing.T) {
 	}
 }
 
+// --- buildSearchService wiring regression tests ---
+//
+// These exercise the real chain buildSearchService assembles rather than a
+// hand-rolled one, so they fail again if a future edit drops a .With*() call
+// from it — the way .WithLLM(llmClient) was missing for the HyDE lane.
+
+// fakeSearchDocStore is a minimal search.DocumentSearcher that records the
+// query it was handed, so a test can inspect what the wiring actually
+// delivered downstream (same pattern as internal/search's own wiring tests,
+// e.g. recordingDocSearcher in insight_exclusion_test.go).
+type fakeSearchDocStore struct {
+	gotQuery model.SearchQuery
+}
+
+func (f *fakeSearchDocStore) Search(_ context.Context, q model.SearchQuery) ([]*model.SearchResult, error) {
+	f.gotQuery = q
+	return nil, nil
+}
+
+// disabledSearchEmbedder is a search.EmbeddingEngine that is always off, so
+// the HyDE wiring test stays on the full-text path — the assertion is about
+// query expansion, not vector search.
+type disabledSearchEmbedder struct{}
+
+func (disabledSearchEmbedder) Embed(context.Context, string) ([]float32, error) { return nil, nil }
+func (disabledSearchEmbedder) EmbedBatch(context.Context, []string) ([][]float32, error) {
+	return nil, nil
+}
+func (disabledSearchEmbedder) Enabled() bool  { return false }
+func (disabledSearchEmbedder) Dimension() int { return 0 }
+
+// stubHyDECompleter is a minimal llm.Completer that always returns a fixed
+// hypothetical-document string, so the test can detect whether the wired
+// Service actually called through to it.
+type stubHyDECompleter struct{}
+
+func (stubHyDECompleter) Enabled() bool { return true }
+
+func (stubHyDECompleter) CompleteWithMessages(context.Context, string, []llm.Message) (string, error) {
+	return "hypothetical document text", nil
+}
+
+// TestBuildSearchService_WiresLLMClientForHyDE is the regression test for the
+// defect this file fixes: llmClient used to be constructed AFTER the
+// search.Service .With*() chain ran in run(), so nothing could pass it to
+// WithLLM and every UseHyDE request silently returned unexpanded results with
+// no error and no log line. If buildSearchService's chain ever drops
+// .WithLLM again, this test fails instead of shipping another silent no-op.
+func TestBuildSearchService_WiresLLMClientForHyDE(t *testing.T) {
+	docs := &fakeSearchDocStore{}
+	svc := buildSearchService(
+		docs, disabledSearchEmbedder{}, nil, nil, nil, nil,
+		stubHyDECompleter{}, nil, false,
+	)
+
+	const query = "what changed in the postgres migration?"
+	if _, err := svc.Search(context.Background(), model.SearchQuery{Query: query, UseHyDE: true}); err != nil {
+		t.Fatalf("Search returned unexpected error: %v", err)
+	}
+
+	if !strings.Contains(docs.gotQuery.Query, "hypothetical document text") {
+		t.Fatalf("store received query %q, want it to contain the HyDE-expanded text — WithLLM is not wired", docs.gotQuery.Query)
+	}
+	if !strings.HasPrefix(docs.gotQuery.Query, query) {
+		t.Fatalf("store received query %q, want it to start with the original query %q", docs.gotQuery.Query, query)
+	}
+}
+
+// TestBuildSearchService_UseHyDEWithoutLLMClientIsANoOp pins the documented
+// degrade-safe behaviour when no LLM client is available at all (nil
+// llmClient — e.g. a caller that skips llm.New entirely): UseHyDE must not
+// panic and must fall back to the original, unexpanded query.
+func TestBuildSearchService_UseHyDEWithoutLLMClientIsANoOp(t *testing.T) {
+	docs := &fakeSearchDocStore{}
+	svc := buildSearchService(
+		docs, disabledSearchEmbedder{}, nil, nil, nil, nil,
+		nil, nil, false,
+	)
+
+	const query = "what changed in the postgres migration?"
+	if _, err := svc.Search(context.Background(), model.SearchQuery{Query: query, UseHyDE: true}); err != nil {
+		t.Fatalf("Search returned unexpected error: %v", err)
+	}
+	if docs.gotQuery.Query != query {
+		t.Fatalf("store received query %q, want the unexpanded original %q when no LLM client is wired", docs.gotQuery.Query, query)
+	}
+}
+
 // TestHTTPServerWriteTimeout_CoversAskAndSearch documents the relationship
 // the deployment depends on: the global write deadline must outlast the
 // slowest non-briefing request path (/ask, and a cold-start /search — see

--- a/deploy/ubuntu1-stack/README.md
+++ b/deploy/ubuntu1-stack/README.md
@@ -1,0 +1,131 @@
+# second-brain — ubuntu1 스택 (macmini → ubuntu1 이전, 2026-08-25)
+
+2026-08-25에 second-brain 애플리케이션 스택을 macmini(arm64)에서 ubuntu1(x86_64)로
+이전했다. 이 디렉토리는 ubuntu1에 이미 배치되어 운영 중인 산출물을 버전 관리
+대상으로 반영한 것이다 — 여기 있는 파일들을 수정한다고 ubuntu1이 바로 갱신되지
+않는다(별도 배포 절차 필요, 아래 "기동 방법" 참고).
+
+## 구성
+
+- ubuntu1에서 도는 것: **server / collector / web / neo4j** — compose 프로젝트
+  이름 `second-brain-ubuntu1`, 작업 디렉토리 `~/second-brain-app`.
+- **postgres는 이 스택에 없다.** 별도 compose 프로젝트(`~/second-brain-postgres`,
+  자세한 내용은 [`deploy/postgres-ubuntu1/`](../postgres-ubuntu1/))로 이미 운영
+  중이며, `.env.local`의 `DATABASE_URL`이 Tailscale IP로 그 컨테이너를 직접
+  가리킨다.
+- macmini에 남은 역할: **OneDrive 클라이언트 + `com.sangyi.secondbrain.onedrive-bridge`
+  LaunchAgent** — 파일 게이트웨이 전용. second-brain 컨테이너 5개는 전부
+  `docker stop` 상태이며, 볼륨(`second-brain-local_pgdata` = postgres 이전
+  롤백본, `second-brain-local_neo4jdata`)은 보존되어 있다.
+
+## 파일 목록
+
+| 파일 | ubuntu1 원본 경로 |
+|------|-------------------|
+| `docker-compose.yml` | `~/second-brain-app/docker-compose.ubuntu1.yml` |
+| `sync-second-brain-data.sh` | `~/bin/sync-second-brain-data.sh` |
+| `systemd/sb-data-sync.service` | `~/.config/systemd/user/sb-data-sync.service` |
+| `systemd/sb-data-sync.timer` | `~/.config/systemd/user/sb-data-sync.timer` |
+| `systemd/cloudflared-second-brain.service` | `/etc/systemd/system/cloudflared-second-brain.service` |
+| `cloudflared/config-second-brain.yml` | `~/.cloudflared/config-second-brain.yml` |
+
+`cloudflared/config-second-brain.yml`은 터널 ID와 credentials **경로**만
+담고 있다. credentials json(`ee3b9a8b-....json`) 자체는 시크릿이라 이 리포에
+가져오지 않았다.
+
+## 기동 방법
+
+```bash
+docker compose --env-file .env.local -f docker-compose.ubuntu1.yml up -d
+```
+
+`--env-file`이 필수인 이유: `NEO4J_PASSWORD`는 `${VAR}` 치환이라 `env_file:`
+(컨테이너 내부 주입)이 아니라 `--env-file`(compose 자체의 변수 치환)로만
+온다. 이 플래그를 빠뜨리면 변수가 빈 값으로 치환되어 조용히 잘못된 상태로
+기동하거나 즉시 실패한다. 과거 맥미니에서 동일한 실수로 볼륨이 잘못된 기본
+경로에 생성돼 collector가 완전히 멈춘 사고가 있었다
+([`feedback_macmini_compose_envfile_flag`]).
+
+## 이전 과정에서 실제로 부딪힌 함정 4가지
+
+**재발 방지를 위해 반드시 기록한다.**
+
+### 1. 파일 권한 (macOS → Linux)
+
+컨테이너는 `uid=10001(appuser)`로 실행되는데, rsync로 옮긴 자격증명 파일은
+`uid=1000` 소유의 `600`이라 읽지 못했다. Docker Desktop for Mac은 VirtioFS가
+uid를 매핑해줘서 이 충돌이 드러나지 않지만, Linux bind mount는 호스트 uid를
+그대로 노출한다.
+
+해결: 자격증명 4개 파일(`gmail/credentials.json`, `gmail/token.json`,
+`calendar/credentials.json`, `calendar/token.json`)에 `chgrp 10001` +
+`chmod 640`. 일반 사용자는 자신이 속하지 않은 그룹으로 chgrp할 수 없어
+`sudo`가 필요하다. **rsync가 매번 권한을 원복시키므로 동기화 스크립트
+(`sync-second-brain-data.sh`)가 이 단계를 매 실행마다 반복 수행한다.**
+
+### 2. openrsync 비호환
+
+macmini의 rsync는 openrsync(protocol 29, rsync 2.6.9 호환)라 `--info=stats2`
+같은 rsync 3.x 전용 옵션을 주면 원격이 usage를 출력하고 죽는다. 증상은
+"connection unexpectedly closed (0 bytes received)"이고 **전송은 한 바이트도
+일어나지 않는다.** `-az`만 사용할 것.
+
+### 3. 기동 순서
+
+server/collector가 neo4j보다 먼저 뜨면 `connection refused`로 그래프 투영과
+그래프 읽기 API가 **비활성 상태로 고정된다(자동 재연결 없음)**. neo4j가
+healthy가 된 뒤 `docker compose restart server collector`로 복구한다.
+`depends_on`을 걸지 않는 것은 의도된 설계다(neo4j가 죽어도 검색/ask는 살아야
+한다) — 대신 기동 후 그래프 관련 로그를 확인하는 절차가 필요하다.
+
+```bash
+docker compose --env-file .env.local -f docker-compose.ubuntu1.yml up -d
+# neo4j healthy 확인 후:
+docker compose --env-file .env.local -f docker-compose.ubuntu1.yml restart server collector
+```
+
+### 4. stage/sms는 빈 껍데기
+
+macmini의 `stage/sms/*.xml`은 `stat` 크기 0인 파일이다(`du`는 285MB로
+보고하지만 실제 내용은 없다). SMS는 현재 휴대폰 앱이 서버로 직접 push하는
+경로로 수집되며 이 파일들은 레거시다. collector 로그의 "sms: source file is
+empty — possible OneDrive materialization/bridge failure" 경고는 정상
+동작이다.
+
+## 데이터 동기화
+
+ubuntu1의 systemd user 타이머 `sb-data-sync.timer`가 10분 주기로 macmini에서
+`stage/call`, `stage/sms`, `secretary/gmail`, `secretary/calendar`를 pull
+한다.
+
+- ubuntu1 → macmini SSH는 `llm-memory-hub` 별칭(Tailscale 100.100.80.74)을
+  재사용한다. 원래 llm-memory 허브용으로 만들어진 경로다.
+- `loginctl show-user baekenough`의 `Linger=yes`라서 로그아웃 상태에서도
+  타이머가 돈다.
+
+## cloudflared 터널
+
+- 터널 ID `ee3b9a8b-8f78-4085-897a-dcf79d70b9c4`(이름 `second-brain`)를
+  macmini에서 그대로 승계했으므로 DNS 레코드 변경이 필요 없었다.
+- systemd 시스템 서비스 `cloudflared-second-brain.service`로 등록되어 있다.
+- ingress:
+  - `brain.baekenough.com` → 8081 (server)
+  - `sb.baekenough.com` → 3000 (web, Cloudflare Access 뒤)
+  - `brain-mcp.baekenough.com` → 8090 (mcp, **현재 미기동** — macmini에서도
+    이미 리스너가 없던 죽은 ingress라 항목만 남겨두었다)
+- 모든 컨테이너 포트는 `127.0.0.1`에만 바인딩된다. 터널이 같은 호스트에서
+  접근하므로 충분하고, 개인 데이터가 LAN에 노출되지 않아야 한다는 이
+  프로젝트의 원칙과 일치한다(원본 macmini 설정은 server가 `0.0.0.0:8081`
+  이었는데 이전하면서 좁혔다).
+
+## 아직 남은 것 (TODO)
+
+- mcp 서비스 미이전 (`brain-mcp` ingress가 502를 반환한다)
+- eval-runner 미이전
+- macmini의 OneDrive 의존을 걷어내면 macmini를 완전히 뺄 수 있다 (rclone
+  등으로 ubuntu1이 직접 OneDrive를 받는 방안)
+
+## 관련 문서
+
+- [`deploy/postgres-ubuntu1/`](../postgres-ubuntu1/) — 이 스택이 참조하는
+  postgres 컴포즈 프로젝트 (2026-08-19 이전 완료)

--- a/deploy/ubuntu1-stack/cloudflared/config-second-brain.yml
+++ b/deploy/ubuntu1-stack/cloudflared/config-second-brain.yml
@@ -1,0 +1,26 @@
+# second-brain cloudflared tunnel — ubuntu1
+#
+# macmini(arm64)에서 ubuntu1(x86_64)로 이전(2026-08-25). 터널 ID와
+# credentials 는 macmini 것을 그대로 승계하므로 DNS 레코드 변경이 필요 없다.
+#
+# ingress 대상은 전부 이 호스트의 루프백이다. 컨테이너 포트를 127.0.0.1 에만
+# 바인딩하고 터널이 같은 호스트에서 접근하는 구조 — 개인 데이터가 LAN/공인망에
+# 노출되지 않는다는 이 프로젝트의 원칙을 유지한다.
+tunnel: ee3b9a8b-8f78-4085-897a-dcf79d70b9c4
+credentials-file: /home/baekenough/.cloudflared/ee3b9a8b-8f78-4085-897a-dcf79d70b9c4.json
+
+ingress:
+  # Go API 서버 (second-brain-ubuntu1-server-1)
+  - hostname: brain.baekenough.com
+    service: http://localhost:8081
+
+  # MCP 서버 — 현재 미기동. macmini 에서도 8090 에 리스너가 없어
+  # 이미 죽어 있던 ingress 다. mcp 컨테이너를 띄우면 즉시 복구되도록 항목만 유지한다.
+  - hostname: brain-mcp.baekenough.com
+    service: http://localhost:8090
+
+  # Next.js 웹 UI (second-brain-ubuntu1-web-1) — Cloudflare Access 뒤에 있다.
+  - hostname: sb.baekenough.com
+    service: http://localhost:3000
+
+  - service: http_status:404

--- a/deploy/ubuntu1-stack/docker-compose.yml
+++ b/deploy/ubuntu1-stack/docker-compose.yml
@@ -1,0 +1,161 @@
+# =============================================================================
+# second-brain — ubuntu1 프로덕션 Compose (x86_64)
+# =============================================================================
+# 용도: macmini(arm64)에서 ubuntu1(x86_64)로 이전된 프로덕션 스택.
+#   server / collector / web / neo4j 네 서비스만 포함한다.
+#
+# PostgreSQL은 이 스택에 없다 — 이미 ubuntu1에서 별도 compose 프로젝트로
+# 실행 중이다 (~/second-brain-postgres/docker-compose.yml, 컨테이너명
+# second-brain-postgres). .env.local의 DATABASE_URL이 Tailscale IP
+# (100.68.237.99:5432)로 그 컨테이너를 직접 가리키므로 여기서는 postgres
+# 서비스도 depends_on도 걸지 않는다.
+#
+# 이미지는 이미 ubuntu1에 빌드/pull되어 있다 (build: 섹션 없음, 태그만 참조):
+#   second-brain-server:ubuntu1 / second-brain-collector:ubuntu1 /
+#   second-brain-web:ubuntu1 / neo4j:5.26-community
+#
+# 사전 조건:
+#   - .env.local, web/.env.local 이 이 디렉토리에 존재해야 합니다.
+#
+# 기동 (중요: --env-file 필수):
+#   docker compose --env-file .env.local -f docker-compose.ubuntu1.yml up -d
+#   NEO4J_PASSWORD 는 ${VAR} 치환이라 env_file(컨테이너 내부 주입)이 아니라
+#   --env-file(compose 자체의 변수 치환)로 와야 한다. 이 플래그를 빠뜨리면
+#   변수가 빈 값으로 치환되어 조용히 잘못된 상태로 기동하거나(neo4jdata가
+#   엉뚱한 기본 경로에 생성되는 등) 즉시 실패한다 — 과거 맥미니에서 동일한
+#   실수로 collector가 완전히 멈춘 사고가 있었다.
+#
+# 검증 (기동 전 문법/변수 확인):
+#   docker compose --env-file .env.local -f docker-compose.ubuntu1.yml config
+#
+# 중지/정리:
+#   docker compose --env-file .env.local -f docker-compose.ubuntu1.yml down
+#   docker compose --env-file .env.local -f docker-compose.ubuntu1.yml down -v
+# =============================================================================
+
+name: second-brain-ubuntu1
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # server — API 서버 (포트 8080). DB 마이그레이션을 직접 적용한다.
+  #   127.0.0.1 로만 바인딩한다 — cloudflared 터널이 같은 호스트에서
+  #   접근하므로 충분하며, 개인정보가 LAN에 노출되지 않아야 한다는 이
+  #   프로젝트의 관례(web은 127.0.0.1, postgres는 Tailscale IP 전용)와
+  #   일치한다. 원본(macmini)은 0.0.0.0:8081 이었다.
+  #   postgres는 별도 compose 프로젝트이므로 depends_on을 걸지 않는다.
+  # ---------------------------------------------------------------------------
+  server:
+    image: second-brain-server:ubuntu1
+    ports:
+      - "127.0.0.1:8081:8080"
+    env_file:
+      - .env.local
+    volumes:
+      - /home/baekenough/.second-brain/stage/call:/data/call
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # collector — 소스 데이터 수집 데몬 (포트 없음).
+  #   호스트의 원본 데이터를 ro 마운트한다. llm-memory.sqlite 마운트는
+  #   제거되었다 — 해당 데이터 소스는 이번 이전 작업에서 폐기됐다.
+  #   postgres는 별도 compose 프로젝트이므로 depends_on을 걸지 않는다.
+  # ---------------------------------------------------------------------------
+  collector:
+    image: second-brain-collector:ubuntu1
+    env_file:
+      - .env.local
+    environment:
+      # 레거시 로컬 pyannote 전용 셀렉터. 기본 전사 경로(OpenAI
+      # gpt-4o-transcribe-diarize)는 화자 분리를 자체 내장하며 이 값을
+      # 무시한다.
+      DIARIZATION_API_URL: "http://diarization:8001"
+      DIARIZATION_ENABLED: "${DIARIZATION_ENABLED:-false}"
+    volumes:
+      - /home/baekenough/.second-brain/secretary/gmail:/data/gmail:ro
+      - /home/baekenough/.second-brain/secretary/calendar:/data/calendar:ro
+      - /home/baekenough/.second-brain/stage/sms:/data/sms:ro
+      - /home/baekenough/.second-brain/stage/call:/data/call:ro
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # web — Next.js 프론트엔드 (포트 3000).
+  #   server가 기동된 뒤 시작한다.
+  #   BRAIN_API_URL로 내부 API 서버를 가리켜 ingest 프록시가 올바르게
+  #   포워딩된다.
+  # ---------------------------------------------------------------------------
+  # Cloudflare Access 뒤에서만 접근 가능(next-auth 제거, JWT 검증은
+  # web/src/proxy.ts). 포트는 호스트 localhost에만 바인딩되며, 공개 노출은
+  # 호스트 프로세스인 cloudflared ingress(sb.baekenough.com)를 통해서만
+  # 이루어진다(심층 방어).
+  # ---------------------------------------------------------------------------
+  web:
+    image: second-brain-web:ubuntu1
+    ports:
+      - "127.0.0.1:3000:3000"
+    env_file:
+      - web/.env.local
+      - .env.local
+    environment:
+      BRAIN_API_URL: "http://server:8080"
+      CF_ACCESS_TEAM_DOMAIN: "baekenough.cloudflareaccess.com"
+      CF_ACCESS_AUD: "276c0cbbe67a4044699334ed7ea446eda5fb287f5fc8e194b08bc067847ab272"
+      NEXT_PUBLIC_APP_URL: "${NEXT_PUBLIC_APP_URL:-https://sb.baekenough.com}"
+      NODE_ENV: "production"
+      PORT: "3000"
+      HOSTNAME: "0.0.0.0"
+    depends_on:
+      server:
+        condition: service_started
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # neo4j — 지식 그래프 파생 투영. PostgreSQL이 진실의 원천이므로 이 볼륨은
+  #   버려도 된다(백업 요구사항 없음, 재구축은 GRAPH_PROJECTION_RESET_TOKEN).
+  #   포트는 127.0.0.1 에만 바인딩한다 — Browser(7474)는 인증만 통과하면
+  #   그래프 전체를 조회하므로 cloudflared ingress에 호스트명을 두지 않는다.
+  #   server/collector 에 depends_on 을 걸지 않는다: Neo4j 가 죽어도 수집·
+  #   검색·/ask 는 돌아야 한다(워커는 다음 tick 재시도, API 는 503).
+  # ---------------------------------------------------------------------------
+  neo4j:
+    image: neo4j:5.26-community
+    ports:
+      - "127.0.0.1:7687:7687"
+      - "127.0.0.1:7474:7474"
+    environment:
+      # ${VAR} 치환은 env_file이 아니라 --env-file/셸에서 온다. 그래서
+      # --env-file 없이 기동하면 아래 :? 가 조용한 오작동 대신 즉시 실패시킨다.
+      NEO4J_AUTH: "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+      # 헬스체크용 사본. 이름이 NEO4J_ 로 시작하면 안 된다: 엔트리포인트가
+      # NEO4J_* 를 전부 neo4j.conf 설정으로 번역하므로 NEO4J_PASSWORD 는
+      # 설정 "PASSWORD" 가 되어 strict validation 이 기동을 거부한다
+      # ("Unrecognized setting. No declared setting with name: PASSWORD").
+      SB_NEO4J_PASSWORD: "${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+      NEO4J_server_memory_heap_initial__size: "512m"   # 관계 수천 개 규모.
+      NEO4J_server_memory_heap_max__size: "512m"       # 과할당은 다른 컨테이너를
+      NEO4J_server_memory_pagecache_size: "256m"       # 밀어낼 뿐이다.
+      # 질의 로그는 파라미터(=실명)를 그대로 남기므로 끈다. 설정 키는
+      # server.* 가 아니라 db.* 다 — server.logs.query.enabled 는 5.26 에
+      # 존재하지 않는 이름이라 strict validation 이 기동을 거부한다
+      # ("Unrecognized setting"). 5.26.29 스크래치 컨테이너로 실측 확인.
+      NEO4J_db_logs_query_enabled: "OFF"
+      # Community 에디션은 질의 로깅 자체가 없어 위 설정만으로도 유출이 없지만,
+      # 이 값의 기본값이 true 라 에디션이 바뀌는 순간 파라미터가 남는다.
+      NEO4J_db_logs_query_parameter__logging__enabled: "false"
+    volumes:
+      - neo4jdata:/data                                # /logs 는 내보내지 않는다
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"$${SB_NEO4J_PASSWORD}\" 'RETURN 1' >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 40s
+    restart: unless-stopped
+
+# -----------------------------------------------------------------------------
+# Named volumes
+# -----------------------------------------------------------------------------
+volumes:
+  neo4jdata:
+    # 지식 그래프 파생 투영 전용 볼륨. PostgreSQL 이 진실의 원천이므로
+    # 삭제해도 투영 워커가 워터마크 0 부터 다시 만들어 낸다(백업 불필요).

--- a/deploy/ubuntu1-stack/opensearch/bulk-index-chunks.sh
+++ b/deploy/ubuntu1-stack/opensearch/bulk-index-chunks.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# PostgreSQL chunks → OpenSearch(sb-chunks) 색인
+#
+# 기존 검색 경로에는 영향이 없다. 같은 청크를 nori 형태소 분석으로 색인해
+# pg_bigm 방식과 결과를 나란히 비교하기 위한 실험 인덱스다.
+set -uo pipefail
+OUT=/tmp/sb_bulk.ndjson
+echo "[1/3] NDJSON 생성"
+docker exec second-brain-postgres psql -U brain -d second_brain -t -A -o /tmp/sb_bulk_raw.ndjson -c "
+SELECT json_build_object('index', json_build_object('_index','sb-chunks','_id',c.id))::text
+       || chr(10) ||
+       json_build_object(
+         'chunk_id',    c.id,
+         'document_id', d.id,
+         'source_type', d.source_type,
+         'kind',        d.metadata->>'kind',
+         'chunk_index', c.chunk_index,
+         'occurred_at', d.occurred_at,
+         'title',       d.title,
+         'content',     c.content
+       )::text
+FROM chunks c JOIN documents d ON d.id = c.document_id
+ORDER BY c.id;
+"
+docker cp second-brain-postgres:/tmp/sb_bulk_raw.ndjson "$OUT"
+docker exec second-brain-postgres rm -f /tmp/sb_bulk_raw.ndjson
+LINES=$(wc -l < "$OUT")
+echo "  생성: $LINES 줄 ($(du -h "$OUT" | cut -f1))"
+
+echo "[2/3] 분할 (배치당 10000 줄 = 5000 문서)"
+rm -f /tmp/sb_bulk_part_*
+split -l 10000 "$OUT" /tmp/sb_bulk_part_
+PARTS=$(ls /tmp/sb_bulk_part_* | wc -l)
+echo "  $PARTS 개 배치"
+
+echo "[3/3] bulk 색인"
+i=0
+for f in /tmp/sb_bulk_part_*; do
+  i=$((i+1))
+  # bulk API 는 마지막 줄이 개행으로 끝나야 한다
+  printf '\n' >> "$f"
+  R=$(curl -s -X POST "http://localhost:9200/_bulk" \
+        -H "Content-Type: application/x-ndjson" --data-binary "@$f")
+  ERR=$(echo "$R" | python3 -c "import sys,json;d=json.load(sys.stdin);print(1 if d.get('errors') else 0)" 2>/dev/null || echo "?")
+  echo "  [$i/$PARTS] errors=$ERR"
+  if [ "$ERR" = "1" ]; then
+    echo "$R" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+for it in d.get('items',[])[:3]:
+    v=list(it.values())[0]
+    if v.get('error'): print('    err:', str(v['error'])[:160])
+" 2>/dev/null
+  fi
+done
+rm -f /tmp/sb_bulk_part_* "$OUT"
+
+echo "[검증]"
+curl -s -X POST "http://localhost:9200/sb-chunks/_refresh" >/dev/null
+curl -s "http://localhost:9200/sb-chunks/_count" | head -c 200; echo
+curl -s "http://localhost:9200/_cat/indices/sb-chunks?v&h=index,docs.count,store.size"

--- a/deploy/ubuntu1-stack/opensearch/index-settings.json
+++ b/deploy/ubuntu1-stack/opensearch/index-settings.json
@@ -1,0 +1,49 @@
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "refresh_interval": "30s"
+    },
+    "analysis": {
+      "tokenizer": {
+        "sb_nori_tokenizer": {
+          "type": "nori_tokenizer",
+          "decompound_mode": "mixed"
+        }
+      },
+      "filter": {
+        "sb_pos_filter": {
+          "type": "nori_part_of_speech",
+          "stoptags": ["E","IC","J","MAG","MAJ","MM","SP","SSC","SSO","SC","SE","XPN","XSA","XSN","XSV","UNA","NA","VSV"]
+        }
+      },
+      "analyzer": {
+        "sb_korean": {
+          "type": "custom",
+          "tokenizer": "sb_nori_tokenizer",
+          "filter": ["sb_pos_filter", "nori_readingform", "lowercase"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "chunk_id":     { "type": "long" },
+      "document_id":  { "type": "keyword" },
+      "source_type":  { "type": "keyword" },
+      "kind":         { "type": "keyword" },
+      "chunk_index":  { "type": "integer" },
+      "occurred_at":  { "type": "date" },
+      "title": {
+        "type": "text",
+        "analyzer": "sb_korean",
+        "fields": { "raw": { "type": "keyword", "ignore_above": 512 } }
+      },
+      "content": {
+        "type": "text",
+        "analyzer": "sb_korean"
+      }
+    }
+  }
+}

--- a/deploy/ubuntu1-stack/opensearch/opensearch-compose.yml
+++ b/deploy/ubuntu1-stack/opensearch/opensearch-compose.yml
@@ -1,0 +1,42 @@
+# ubuntu1 — second-brain 검색 비교용 OpenSearch (실험 스택)
+#
+# 기존 검색 경로(PostgreSQL FTS + pgvector + Neo4j)에는 전혀 손대지 않는다.
+# 이 스택은 같은 청크를 nori 형태소 분석으로 색인해 두어, 동일 질의에 대해
+# 두 방식의 결과를 나란히 비교할 수 있게 하는 것이 목적이다.
+#
+# 기동: docker compose -f opensearch-compose.yml up -d
+# 원복: docker compose -f opensearch-compose.yml down -v
+#
+# 포트는 127.0.0.1 에만 바인딩한다 — 개인 데이터 색인이므로 LAN 노출 금지.
+services:
+  opensearch:
+    build:
+      context: .
+      dockerfile: opensearch.Dockerfile
+    image: second-brain-opensearch:ubuntu1
+    container_name: sb-opensearch
+    environment:
+      discovery.type: single-node
+      # 단일 노드 실험용이라 보안 플러그인을 끈다. 루프백 바인딩이 접근 통제를 맡는다.
+      DISABLE_SECURITY_PLUGIN: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
+      # 청크 10만 개 규모에는 2GB 힙이면 충분하다. 과할당은 다른 컨테이너를 밀어낸다.
+      OPENSEARCH_JAVA_OPTS: "-Xms2g -Xmx2g"
+      bootstrap.memory_lock: "true"
+    ulimits:
+      memlock: { soft: -1, hard: -1 }
+      nofile:  { soft: 65536, hard: 65536 }
+    ports:
+      - "127.0.0.1:9200:9200"
+    volumes:
+      - osdata:/usr/share/opensearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 60s
+    restart: unless-stopped
+
+volumes:
+  osdata:

--- a/deploy/ubuntu1-stack/opensearch/opensearch.Dockerfile
+++ b/deploy/ubuntu1-stack/opensearch/opensearch.Dockerfile
@@ -1,0 +1,8 @@
+# OpenSearch + 한국어 형태소 분석기(nori)
+#
+# 현재 PostgreSQL FTS 는 pg_bigm(bigram) 을 쓴다. bigram 은 재현율이 높은 대신
+# "회의"가 "사회의"에 걸리는 식의 오탐이 생긴다. nori 는 형태소 단위로 끊어
+# 정밀도를 올린다 — OpenSearch 도입의 실질적 근거가 이것이므로 플러그인을
+# 이미지에 미리 넣어 둔다(런타임 설치는 재기동마다 사라진다).
+FROM opensearchproject/opensearch:2.19.1
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-nori

--- a/deploy/ubuntu1-stack/sync-second-brain-data.sh
+++ b/deploy/ubuntu1-stack/sync-second-brain-data.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# macmini(OneDrive 게이트웨이) → ubuntu1 데이터 동기화
+#
+# 2026-08-25 스택 이전 후, macmini 는 OneDrive 클라이언트와 onedrive-bridge
+# LaunchAgent 만 유지하고 컴퓨트는 전부 ubuntu1 로 옮겼다. 이 스크립트는
+# macmini 가 스테이징한 파일을 ubuntu1 로 끌어온다.
+#
+# macmini 의 rsync 는 openrsync(protocol 29) 이므로 --info 등 rsync 3.x
+# 전용 옵션을 쓰면 원격이 usage 를 뱉고 죽는다. -az 만 사용할 것.
+#
+# 컨테이너(appuser uid 10001)가 자격증명을 읽어야 하므로 동기화 후 매번
+# 그룹을 다시 부여한다 — rsync -a 가 권한을 원본대로 되돌리기 때문이다.
+set -uo pipefail
+
+REMOTE="llm-memory-hub"   # macmini (Tailscale 100.100.80.74)
+LOCAL_BASE="$HOME/.second-brain"
+LOG_TAG="sb-sync"
+
+log() { logger -t "$LOG_TAG" "$*"; echo "$(date -Is) $*"; }
+
+sync_one() {
+  local src="$1" dst="$2" label="$3"
+  mkdir -p "$dst"
+  if rsync -az --timeout=300 "$REMOTE:$src" "$dst" 2>&1; then
+    log "ok: $label"
+  else
+    log "FAILED: $label (exit $?)"
+    return 1
+  fi
+}
+
+rc=0
+sync_one ".second-brain/stage/call/"                  "$LOCAL_BASE/stage/call/"          "stage/call"     || rc=1
+sync_one ".second-brain/stage/sms/"                   "$LOCAL_BASE/stage/sms/"           "stage/sms"      || rc=1
+sync_one "workspace/private/secretary/gmail/"         "$LOCAL_BASE/secretary/gmail/"     "gmail"          || rc=1
+sync_one "workspace/private/secretary/calendar/"      "$LOCAL_BASE/secretary/calendar/"  "calendar"       || rc=1
+
+# 컨테이너 읽기 권한 복구 (rsync 가 600 으로 되돌려 놓는다)
+for f in "$LOCAL_BASE/secretary/gmail/credentials.json" \
+         "$LOCAL_BASE/secretary/gmail/token.json" \
+         "$LOCAL_BASE/secretary/calendar/credentials.json" \
+         "$LOCAL_BASE/secretary/calendar/token.json"; do
+  [ -f "$f" ] || continue
+  sudo -n chgrp 10001 "$f" 2>/dev/null && sudo -n chmod 640 "$f" 2>/dev/null \
+    || log "WARN: could not restore group on $f"
+done
+
+# 오디오/스테이징은 collector 가 ro 로 읽기만 하므로 그룹 읽기 권한이면 충분
+chmod -R g+rX "$LOCAL_BASE/stage" 2>/dev/null
+
+log "sync complete rc=$rc"
+exit $rc

--- a/deploy/ubuntu1-stack/systemd/cloudflared-second-brain.service
+++ b/deploy/ubuntu1-stack/systemd/cloudflared-second-brain.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=cloudflared second-brain tunnel (ubuntu1)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=notify
+User=baekenough
+ExecStart=/usr/local/bin/cloudflared --no-autoupdate --config /home/baekenough/.cloudflared/config-second-brain.yml tunnel run second-brain
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ubuntu1-stack/systemd/sb-data-sync.service
+++ b/deploy/ubuntu1-stack/systemd/sb-data-sync.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=second-brain data sync from macmini (OneDrive gateway)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/baekenough/bin/sync-second-brain-data.sh

--- a/deploy/ubuntu1-stack/systemd/sb-data-sync.timer
+++ b/deploy/ubuntu1-stack/systemd/sb-data-sync.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run second-brain data sync every 10 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=10min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.21.0 // indirect
-	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,9 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
 github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/graphql-go/handler v0.2.4 h1:gz9q11TUHPNUpqzV8LMa+rkqM5NUuH/nkE3oF2LS3rI=

--- a/internal/collector/calendar.go
+++ b/internal/collector/calendar.go
@@ -58,8 +58,56 @@ func (c *CalendarCollector) Enabled() bool {
 	return c.cfg.CalendarCredentialsJSON != "" && c.cfg.CalendarTokenJSON != ""
 }
 
+// parseCalendarIDs parses the (possibly comma-separated) CALENDAR_ID config
+// value into an ordered, de-duplicated list of calendar identifiers.
+//
+// Order is preserved because the FIRST entry keeps the legacy source_id
+// scheme (see calendarEventToDocument) — reordering CALENDAR_ID would
+// therefore change which calendar's documents keep their existing keys.
+// Empty entries are dropped and whitespace trimmed. An empty result defaults
+// to ["primary"], matching the pre-multi-calendar default.
+func parseCalendarIDs(raw string) []string {
+	parts := strings.Split(raw, ",")
+	seen := make(map[string]bool, len(parts))
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		id := strings.TrimSpace(p)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		out = append(out, "primary")
+	}
+	return out
+}
+
 // Collect fetches Google Calendar events in the window
-// [now - LookbehindDays, now + LookaheadDays] that were updated after since.
+// [now - LookbehindDays, now + LookaheadDays] that were updated after since,
+// across every calendar configured via CALENDAR_ID (comma-separated).
+//
+// A single failing calendar (revoked sharing, insufficient scope, transient
+// 5xx, ...) does not abort the whole run — the remaining calendars keep
+// collecting. Failures are logged and counted; only when EVERY configured
+// calendar fails in the same run does Collect return an error. This matches
+// this repo's "one dependency dying does not take down the rest of the
+// pipeline" convention (e.g. neo4j being optional for search).
+//
+// Known trade-off: collector_state's watermark is keyed by (instance_id,
+// source_type) only — there is no per-calendar column, and adding one would
+// require a migration (out of scope for this change; see
+// internal/store/document.go UpdateCollectorState). So when Collect returns
+// nil (partial or full success), the scheduler advances ONE shared watermark
+// for every configured calendar. A calendar that fails on some ticks and
+// later recovers can therefore have a bounded gap of missed updates from
+// its downtime window, once the shared watermark has moved past it. This is
+// accepted here over the alternative (holding back an already-healthy
+// calendar's documents whenever any other calendar is unhealthy) — the same
+// resilience-over-strict-per-source-correctness trade-off this repo already
+// makes elsewhere. If per-calendar precision becomes necessary, it requires
+// a dedicated collector_state migration, not a workaround here.
 func (c *CalendarCollector) Collect(ctx context.Context, since time.Time) ([]model.Document, error) {
 	token, err := c.getAccessToken(ctx)
 	if err != nil {
@@ -70,40 +118,89 @@ func (c *CalendarCollector) Collect(ctx context.Context, since time.Time) ([]mod
 	timeMin := now.AddDate(0, 0, -c.cfg.CalendarLookbehindDays)
 	timeMax := now.AddDate(0, 0, c.cfg.CalendarLookaheadDays)
 
-	events, err := c.listEvents(ctx, token, timeMin, timeMax, since)
-	if err != nil {
-		return nil, fmt.Errorf("calendar: list events: %w", err)
-	}
-
-	docs := make([]model.Document, 0, len(events))
+	calIDs := parseCalendarIDs(c.cfg.CalendarID)
 	collectAt := time.Now().UTC()
-	for _, ev := range events {
-		doc, err := calendarEventToDocument(ev, collectAt)
+
+	var docs []model.Document
+	var failedCalendars []string
+	totalSkippedEmpty := 0
+
+	for i, calID := range calIDs {
+		// The first configured calendar keeps the legacy (non-namespaced)
+		// source_id scheme so upgrading from a single-calendar config never
+		// re-keys existing documents. See calendarEventToDocument.
+		legacy := i == 0
+
+		events, err := c.listEvents(ctx, token, calID, timeMin, timeMax, since)
 		if err != nil {
-			slog.Warn("calendar: failed to convert event to document", "id", ev.ID, "error", err)
+			slog.Warn("calendar: failed to list events for calendar — skipping this calendar for this run, others continue",
+				"calendar_id", calID, "error", err)
+			failedCalendars = append(failedCalendars, calID)
 			continue
 		}
-		docs = append(docs, doc)
+
+		calSkippedEmpty := 0
+		for _, ev := range events {
+			// A calendar shared at freeBusyReader (rather than "See all event
+			// details") returns HTTP 200 with events that have no summary or
+			// description — busy/free slots only, no identifiable content.
+			// Ingesting these would pollute the corpus with title-less
+			// documents, so they are skipped rather than collected.
+			if strings.TrimSpace(ev.Summary) == "" {
+				calSkippedEmpty++
+				continue
+			}
+			doc, err := calendarEventToDocument(ev, calID, legacy, collectAt)
+			if err != nil {
+				slog.Warn("calendar: failed to convert event to document",
+					"calendar_id", calID, "id", ev.ID, "error", err)
+				continue
+			}
+			docs = append(docs, doc)
+		}
+		if calSkippedEmpty > 0 {
+			// Same tone/pattern as the SMS collector's empty-source-file
+			// warning: this is a permission/sharing signal, not a bug. Once
+			// sharing is upgraded to "See all event details", these events
+			// collect automatically on the next tick with no code change.
+			slog.Warn("calendar: skipped events with no visible content — likely freeBusyReader-only sharing, not an error; will collect automatically once sharing permission is upgraded",
+				"calendar_id", calID, "skipped", calSkippedEmpty, "total", len(events))
+		}
+		totalSkippedEmpty += calSkippedEmpty
 	}
 
-	slog.Info("calendar: collected documents", "count", len(docs))
+	if len(failedCalendars) > 0 {
+		slog.Warn("calendar: one or more calendars failed this run",
+			"failed_calendars", failedCalendars,
+			"failed_count", len(failedCalendars),
+			"configured_count", len(calIDs))
+	}
+	if len(failedCalendars) == len(calIDs) {
+		return nil, fmt.Errorf("calendar: all %d configured calendar(s) failed: %v", len(calIDs), failedCalendars)
+	}
+
+	slog.Info("calendar: collected documents",
+		"count", len(docs),
+		"calendars", len(calIDs),
+		"failed_calendars", len(failedCalendars),
+		"skipped_empty", totalSkippedEmpty)
 	return docs, nil
 }
 
 // --- Calendar API types ---
 
 type calendarEvent struct {
-	ID          string                 `json:"id"`
-	Summary     string                 `json:"summary"`
-	Description string                 `json:"description"`
-	Location    string                 `json:"location"`
-	Status      string                 `json:"status"`
-	HtmlLink    string                 `json:"htmlLink"`
-	Updated     string                 `json:"updated"` // RFC3339
-	Start       calendarEventDateTime  `json:"start"`
-	End         calendarEventDateTime  `json:"end"`
-	Organizer   *calendarPerson        `json:"organizer"`
-	Attendees   []calendarAttendee     `json:"attendees"`
+	ID          string                `json:"id"`
+	Summary     string                `json:"summary"`
+	Description string                `json:"description"`
+	Location    string                `json:"location"`
+	Status      string                `json:"status"`
+	HtmlLink    string                `json:"htmlLink"`
+	Updated     string                `json:"updated"` // RFC3339
+	Start       calendarEventDateTime `json:"start"`
+	End         calendarEventDateTime `json:"end"`
+	Organizer   *calendarPerson       `json:"organizer"`
+	Attendees   []calendarAttendee    `json:"attendees"`
 }
 
 type calendarEventDateTime struct {
@@ -125,18 +222,14 @@ type calendarAttendee struct {
 	Self           bool   `json:"self"`
 }
 
-// listEvents retrieves all events in the given window, filtered by updatedMin=since.
+// listEvents retrieves all events for calID in the given window, filtered by
+// updatedMin=since.
 func (c *CalendarCollector) listEvents(
 	ctx context.Context,
-	token string,
+	token, calID string,
 	timeMin, timeMax time.Time,
 	since time.Time,
 ) ([]calendarEvent, error) {
-	calID := c.cfg.CalendarID
-	if calID == "" {
-		calID = "primary"
-	}
-
 	var all []calendarEvent
 	pageToken := ""
 
@@ -181,7 +274,17 @@ func (c *CalendarCollector) listEvents(
 }
 
 // calendarEventToDocument converts a Calendar API event to a model.Document.
-func calendarEventToDocument(ev calendarEvent, collectAt time.Time) (model.Document, error) {
+//
+// legacy controls the source_id scheme: the first calendar configured via
+// CALENDAR_ID keeps the pre-multi-calendar "calendar:<eventID>" id so
+// upgrading an existing single-calendar deployment never re-keys its
+// existing documents (see the #144 SMS source_id lesson — a source_id
+// re-key without a dedicated migration orphaned existing rows and was
+// rejected twice in review; it was only safe as a one-off migration, not a
+// collector-side change). Any additional calendar is namespaced with its
+// calendar ID ("calendar:<calID>:<eventID>") because event IDs are only
+// guaranteed unique within a single calendar, not across calendars.
+func calendarEventToDocument(ev calendarEvent, calID string, legacy bool, collectAt time.Time) (model.Document, error) {
 	occurredAt, allDay := parseCalendarDateTime(ev.Start)
 
 	// Build content: description + location + attendees summary.
@@ -207,10 +310,11 @@ func calendarEventToDocument(ev calendarEvent, collectAt time.Time) (model.Docum
 
 	// Build metadata.
 	meta := map[string]any{
-		"status":    ev.Status,
-		"updated":   ev.Updated,
-		"html_link": ev.HtmlLink,
-		"all_day":   allDay,
+		"status":      ev.Status,
+		"updated":     ev.Updated,
+		"html_link":   ev.HtmlLink,
+		"all_day":     allDay,
+		"calendar_id": calID,
 	}
 	if ev.Location != "" {
 		meta["location"] = ev.Location
@@ -237,10 +341,15 @@ func calendarEventToDocument(ev calendarEvent, collectAt time.Time) (model.Docum
 		meta["end"] = endTime.Format(time.RFC3339)
 	}
 
+	sourceID := "calendar:" + ev.ID
+	if !legacy {
+		sourceID = "calendar:" + calID + ":" + ev.ID
+	}
+
 	return model.Document{
 		ID:          uuid.New(),
 		SourceType:  model.SourceCalendar,
-		SourceID:    "calendar:" + ev.ID,
+		SourceID:    sourceID,
 		Title:       ev.Summary,
 		Content:     content,
 		Metadata:    meta,

--- a/internal/collector/calendar_test.go
+++ b/internal/collector/calendar_test.go
@@ -21,9 +21,9 @@ import (
 // token source so tests bypass file I/O and network calls.
 func newCalendarCollectorWithFakeSource(cfg *config.Config, srv *httptest.Server, ts oauth2.TokenSource) *CalendarCollector {
 	return &CalendarCollector{
-		cfg:        cfg,
-		httpClient: srv.Client(),
-		baseURL:    srv.URL,
+		cfg:         cfg,
+		httpClient:  srv.Client(),
+		baseURL:     srv.URL,
 		tokenSource: ts,
 		cachedToken: &oauth2.Token{
 			AccessToken: "test-token",
@@ -197,7 +197,7 @@ func TestCalendarEventToDocument_TimedEvent(t *testing.T) {
 		},
 	}
 
-	doc, err := calendarEventToDocument(ev, collectAt)
+	doc, err := calendarEventToDocument(ev, "primary", true, collectAt)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -207,6 +207,9 @@ func TestCalendarEventToDocument_TimedEvent(t *testing.T) {
 	}
 	if doc.SourceID != "calendar:evt-001" {
 		t.Errorf("SourceID = %q, want %q", doc.SourceID, "calendar:evt-001")
+	}
+	if doc.Metadata["calendar_id"] != "primary" {
+		t.Errorf("Metadata.calendar_id = %v, want %q", doc.Metadata["calendar_id"], "primary")
 	}
 	if doc.Title != "Team Meeting" {
 		t.Errorf("Title = %q, want %q", doc.Title, "Team Meeting")
@@ -249,7 +252,7 @@ func TestCalendarEventToDocument_AllDayEvent(t *testing.T) {
 		End:     calendarEventDateTime{Date: "2024-07-05"},
 	}
 
-	doc, err := calendarEventToDocument(ev, collectAt)
+	doc, err := calendarEventToDocument(ev, "primary", true, collectAt)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -477,4 +480,363 @@ func TestCalendarCollector_Collect_EmptyItems(t *testing.T) {
 	if len(docs) != 0 {
 		t.Errorf("got %d docs, want 0", len(docs))
 	}
+}
+
+// --- parseCalendarIDs ---
+
+func TestParseCalendarIDs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "empty defaults to primary", raw: "", want: []string{"primary"}},
+		{name: "single value backward compat", raw: "primary", want: []string{"primary"}},
+		{name: "single custom value", raw: "team@example.com", want: []string{"team@example.com"}},
+		{
+			name: "comma-separated, trimmed",
+			raw:  "primary, baeksy@agilesoda.ai ,  team@example.com",
+			want: []string{"primary", "baeksy@agilesoda.ai", "team@example.com"},
+		},
+		{
+			name: "empty entries dropped",
+			raw:  "primary,,team@example.com,",
+			want: []string{"primary", "team@example.com"},
+		},
+		{
+			name: "duplicates de-duplicated, first occurrence order kept",
+			raw:  "primary,team@example.com,primary",
+			want: []string{"primary", "team@example.com"},
+		},
+		{name: "only whitespace/commas defaults to primary", raw: " , , ", want: []string{"primary"}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseCalendarIDs(tc.raw)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseCalendarIDs(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("parseCalendarIDs(%q)[%d] = %q, want %q", tc.raw, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// --- calendarEventToDocument source_id namespacing ---
+
+func TestCalendarEventToDocument_NamespacedForNonLegacyCalendar(t *testing.T) {
+	t.Parallel()
+
+	ev := calendarEvent{
+		ID:      "evt-shared",
+		Summary: "Shared Event",
+		Status:  "confirmed",
+		Updated: time.Now().UTC().Format(time.RFC3339),
+		Start:   calendarEventDateTime{Date: "2024-07-04"},
+		End:     calendarEventDateTime{Date: "2024-07-05"},
+	}
+
+	legacyDoc, err := calendarEventToDocument(ev, "primary", true, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if legacyDoc.SourceID != "calendar:evt-shared" {
+		t.Errorf("legacy SourceID = %q, want %q", legacyDoc.SourceID, "calendar:evt-shared")
+	}
+
+	namespacedDoc, err := calendarEventToDocument(ev, "baeksy@agilesoda.ai", false, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantID := "calendar:baeksy@agilesoda.ai:evt-shared"
+	if namespacedDoc.SourceID != wantID {
+		t.Errorf("namespaced SourceID = %q, want %q", namespacedDoc.SourceID, wantID)
+	}
+	if namespacedDoc.Metadata["calendar_id"] != "baeksy@agilesoda.ai" {
+		t.Errorf("Metadata.calendar_id = %v, want %q", namespacedDoc.Metadata["calendar_id"], "baeksy@agilesoda.ai")
+	}
+
+	// Same underlying event ID across two calendars must not collide once
+	// namespaced — this is the whole point of the legacy/namespaced split.
+	if legacyDoc.SourceID == namespacedDoc.SourceID {
+		t.Error("legacy and namespaced source_id must differ for the same event ID across calendars")
+	}
+}
+
+// --- Collect: multiple calendars ---
+
+// TestCalendarCollector_Collect_MultipleCalendars verifies that Collect
+// iterates every configured calendar, that the first (primary) calendar keeps
+// its legacy source_id, that additional calendars are namespaced, and that
+// metadata.calendar_id is populated for every document (issue: no way to
+// tell which calendar a document came from before this change).
+func TestCalendarCollector_Collect_MultipleCalendars(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "primary"):
+			ev := buildCalendarEventJSON("evt-primary", "Primary Event", "", "", "confirmed", start, end, "", nil)
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+		case strings.Contains(r.URL.Path, "baeksy"):
+			ev := buildCalendarEventJSON("evt-work", "Work Event", "", "", "confirmed", start, end, "", nil)
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+		default:
+			t.Errorf("unexpected calendar path: %q", r.URL.Path)
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": nil})
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := validCalendarConfig()
+	cfg.CalendarID = "primary,baeksy@agilesoda.ai"
+	c := newCalendarCollectorWithFakeSource(cfg, srv, nil)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("got %d docs, want 2", len(docs))
+	}
+
+	byID := make(map[string]model.Document, len(docs))
+	for _, d := range docs {
+		byID[d.SourceID] = d
+	}
+
+	primaryDoc, ok := byID["calendar:evt-primary"]
+	if !ok {
+		t.Fatalf("missing legacy-keyed primary doc; got source_ids: %v", keysOf(byID))
+	}
+	if primaryDoc.Metadata["calendar_id"] != "primary" {
+		t.Errorf("primary doc calendar_id = %v, want %q", primaryDoc.Metadata["calendar_id"], "primary")
+	}
+
+	workDoc, ok := byID["calendar:baeksy@agilesoda.ai:evt-work"]
+	if !ok {
+		t.Fatalf("missing namespaced work doc; got source_ids: %v", keysOf(byID))
+	}
+	if workDoc.Metadata["calendar_id"] != "baeksy@agilesoda.ai" {
+		t.Errorf("work doc calendar_id = %v, want %q", workDoc.Metadata["calendar_id"], "baeksy@agilesoda.ai")
+	}
+}
+
+// TestCalendarCollector_Collect_SingleValueStillLegacy verifies that a
+// single, non-default CALENDAR_ID value (the pre-multi-calendar shape) still
+// produces the legacy, non-namespaced source_id — i.e. existing deployments
+// with CALENDAR_ID set to one calendar are unaffected by this change.
+func TestCalendarCollector_Collect_SingleValueStillLegacy(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/", func(w http.ResponseWriter, r *http.Request) {
+		ev := buildAllDayEventJSON("evt-solo", "Solo Calendar Event", "2024-07-04")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := validCalendarConfig()
+	cfg.CalendarID = "team@example.com"
+	c := newCalendarCollectorWithFakeSource(cfg, srv, nil)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1", len(docs))
+	}
+	if docs[0].SourceID != "calendar:evt-solo" {
+		t.Errorf("SourceID = %q, want %q (legacy scheme for sole configured calendar)", docs[0].SourceID, "calendar:evt-solo")
+	}
+}
+
+// TestCalendarCollector_Collect_OneCalendarFails_OthersContinue verifies that
+// a failing calendar (e.g. 403 due to insufficient scope) does not abort the
+// whole Collect call — the healthy calendar's documents are still returned
+// and Collect returns nil (so the scheduler commits them and advances the
+// watermark).
+func TestCalendarCollector_Collect_OneCalendarFails_OthersContinue(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC()
+	end := start.Add(time.Hour)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "primary"):
+			w.Header().Set("Content-Type", "application/json")
+			ev := buildCalendarEventJSON("evt-ok", "Healthy Calendar Event", "", "", "confirmed", start, end, "", nil)
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+		case strings.Contains(r.URL.Path, "revoked"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error": {"code": 403, "message": "insufficient permission"}}`))
+		default:
+			t.Errorf("unexpected calendar path: %q", r.URL.Path)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := validCalendarConfig()
+	cfg.CalendarID = "primary,revoked@example.com"
+	c := newCalendarCollectorWithFakeSource(cfg, srv, nil)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: unexpected error, want nil (partial success): %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1 (only the healthy calendar)", len(docs))
+	}
+	if docs[0].SourceID != "calendar:evt-ok" {
+		t.Errorf("SourceID = %q, want %q", docs[0].SourceID, "calendar:evt-ok")
+	}
+}
+
+// TestCalendarCollector_Collect_AllCalendarsFail verifies that when every
+// configured calendar fails, Collect returns an error (so the scheduler does
+// not advance the shared watermark and retries from the same `since` on the
+// next tick).
+func TestCalendarCollector_Collect_AllCalendarsFail(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error": {"code": 403, "message": "insufficient permission"}}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := validCalendarConfig()
+	cfg.CalendarID = "primary,revoked@example.com"
+	c := newCalendarCollectorWithFakeSource(cfg, srv, nil)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err == nil {
+		t.Fatal("Collect: want error when all calendars fail, got nil")
+	}
+	if docs != nil {
+		t.Errorf("got %d docs, want nil when all calendars fail", len(docs))
+	}
+}
+
+// TestCalendarCollector_Collect_SkipsEmptySummaryEvents verifies the
+// content-empty guard: an event with no summary (the freeBusyReader-only
+// sharing symptom observed in production) is skipped, while a normal event
+// in the same response is still collected.
+func TestCalendarCollector_Collect_SkipsEmptySummaryEvents(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC()
+	end := start.Add(time.Hour)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		empty := buildCalendarEventJSON("evt-empty", "", "", "", "confirmed", start, end, "", nil)
+		whitespaceOnly := buildCalendarEventJSON("evt-whitespace", "   ", "", "", "confirmed", start, end, "", nil)
+		visible := buildCalendarEventJSON("evt-visible", "Visible Meeting", "", "", "confirmed", start, end, "", nil)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{empty, whitespaceOnly, visible}})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := newCalendarCollectorWithFakeSource(validCalendarConfig(), srv, nil)
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1 (only the event with a visible summary)", len(docs))
+	}
+	if docs[0].SourceID != "calendar:evt-visible" {
+		t.Errorf("SourceID = %q, want %q", docs[0].SourceID, "calendar:evt-visible")
+	}
+}
+
+// TestCalendarCollector_Collect_NoSourceIDCollisionAcrossCalendars verifies
+// that the same underlying event ID appearing in two different calendars
+// does not collide into a single source_id — the second calendar's copy is
+// namespaced and both documents are collected.
+func TestCalendarCollector_Collect_NoSourceIDCollisionAcrossCalendars(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC()
+	end := start.Add(time.Hour)
+	const sharedEventID = "evt-collision"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "primary"):
+			ev := buildCalendarEventJSON(sharedEventID, "Primary Copy", "", "", "confirmed", start, end, "", nil)
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+		case strings.Contains(r.URL.Path, "secondary"):
+			ev := buildCalendarEventJSON(sharedEventID, "Secondary Copy", "", "", "confirmed", start, end, "", nil)
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+		default:
+			t.Errorf("unexpected calendar path: %q", r.URL.Path)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	cfg := validCalendarConfig()
+	cfg.CalendarID = "primary,secondary@example.com"
+	c := newCalendarCollectorWithFakeSource(cfg, srv, nil)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("got %d docs, want 2 (no collision — both copies collected)", len(docs))
+	}
+
+	ids := map[string]bool{docs[0].SourceID: true, docs[1].SourceID: true}
+	if len(ids) != 2 {
+		t.Fatalf("source_id collision: both docs got the same source_id %v", ids)
+	}
+	if !ids["calendar:"+sharedEventID] {
+		t.Errorf("missing legacy-keyed primary copy, got: %v", ids)
+	}
+	if !ids["calendar:secondary@example.com:"+sharedEventID] {
+		t.Errorf("missing namespaced secondary copy, got: %v", ids)
+	}
+}
+
+// keysOf returns the keys of a source_id-keyed document map, for test failure messages.
+func keysOf(m map[string]model.Document) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,32 @@ type Config struct {
 	RerankAPIKey string // RERANKER_API_KEY — Bearer token for the reranker API
 	RerankModel  string // RERANKER_MODEL — model identifier sent in the request body
 
+	// OpenSearch (optional — BM25 full-text lane with Korean morphological
+	// (nori) tokenization, DISABLED when OPENSEARCH_URL is empty; this is
+	// the default and the only state this repo deploys today).
+	//
+	// Why: the existing Postgres FTS lane is pg_bigm (bigram), which has no
+	// notion of a morpheme boundary — "회의" matches inside "사회의"/"기회의".
+	// Measured against ubuntu1 production data, pg_bigm returned 4.7x more
+	// "회의" hits than an exact morpheme match (865 vs. 184). The excess is
+	// substring noise that dilutes the candidate pool before reranking ever
+	// sees it. See internal/search/opensearch.go for the full comparison and
+	// the fusion strategy (this lane is purely additive, RRF-fused alongside
+	// the existing chunk lanes — it never replaces pg_bigm or pgvector).
+	//
+	// OPENSEARCH_URL: base URL of the OpenSearch node (e.g.
+	// http://localhost:9200). Empty disables the lane entirely — no client
+	// is constructed and search.Service behaves exactly as it did before
+	// this feature existed (see search.NewOpenSearchLane).
+	// OPENSEARCH_INDEX: index name. Default "sb-chunks" (the name used by
+	// deploy/ubuntu1-stack/opensearch/index-settings.json).
+	// OPENSEARCH_TIMEOUT_SECONDS: per-request HTTP timeout. Default 5 — this
+	// lane is one signal among several, so a slow/unreachable node should
+	// degrade the search fast rather than hold up the whole request.
+	OpensearchURL            string
+	OpensearchIndex          string
+	OpensearchTimeoutSeconds int
+
 	// Alerting (optional — Slack/Discord webhook for eval regression alerts)
 	AlertWebhookURL string // ALERT_WEBHOOK_URL — Slack-compatible incoming webhook URL
 
@@ -737,6 +763,10 @@ func Load() (*Config, error) {
 		RerankAPIKey: os.Getenv("RERANKER_API_KEY"),
 		RerankModel:  getenv("RERANKER_MODEL", "jina-reranker-v2-base-multilingual"),
 
+		OpensearchURL:            os.Getenv("OPENSEARCH_URL"),
+		OpensearchIndex:          getenv("OPENSEARCH_INDEX", "sb-chunks"),
+		OpensearchTimeoutSeconds: opensearchTimeoutSeconds(),
+
 		AlertWebhookURL: os.Getenv("ALERT_WEBHOOK_URL"),
 
 		APIKey: os.Getenv("API_KEY"),
@@ -1166,6 +1196,29 @@ func askTimeoutSeconds() int {
 	n, err := strconv.Atoi(v)
 	if err != nil || n <= 0 {
 		slog.Warn("config: ASK_TIMEOUT_SECONDS is invalid; using default 60",
+			"value", v,
+			"error", err,
+		)
+		return defaultSeconds
+	}
+	return n
+}
+
+// opensearchTimeoutSeconds parses OPENSEARCH_TIMEOUT_SECONDS from the
+// environment. Default is 5 — the OpenSearch lane is one additive signal
+// among several (see internal/search/opensearch.go), so a slow/unreachable
+// node should degrade the whole search quickly rather than hold up a request
+// that would otherwise have succeeded on the other lanes alone.
+// Invalid values are ignored and the default is used.
+func opensearchTimeoutSeconds() int {
+	const defaultSeconds = 5
+	v := os.Getenv("OPENSEARCH_TIMEOUT_SECONDS")
+	if v == "" {
+		return defaultSeconds
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		slog.Warn("config: OPENSEARCH_TIMEOUT_SECONDS is invalid; using default 5",
 			"value", v,
 			"error", err,
 		)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,14 @@ type Config struct {
 	// Calendar (optional — disabled when both credential fields are empty)
 	// CALENDAR_CREDENTIALS_JSON: OAuth2 client credentials JSON string
 	// CALENDAR_TOKEN_JSON: OAuth2 access/refresh token JSON string
-	// CALENDAR_ID: calendar identifier (default: "primary")
+	// CALENDAR_ID: comma-separated calendar identifiers to collect from
+	// (e.g. "primary,team@example.com"). A single value behaves exactly as
+	// before — this field was extended rather than adding a new env var to
+	// keep deploy config changes minimal. Whitespace is trimmed, empty
+	// entries and duplicates are dropped (see collector.parseCalendarIDs).
+	// The first entry keeps the pre-multi-calendar source_id scheme so
+	// existing documents are never re-keyed on upgrade; see
+	// internal/collector/calendar.go calendarEventToDocument.
 	// CALENDAR_LOOKAHEAD_DAYS: days into the future to collect (default: 90)
 	// CALENDAR_LOOKBEHIND_DAYS: days into the past to collect (default: 365)
 	CalendarCredentialsJSON string

--- a/internal/model/document.go
+++ b/internal/model/document.go
@@ -13,14 +13,36 @@ import (
 type SourceType string
 
 const (
-	SourceSlack          SourceType = "slack"
-	SourceGitHub         SourceType = "github"
-	SourceGDrive         SourceType = "gdrive"
-	SourceNotion         SourceType = "notion"
-	SourceFilesystem     SourceType = "filesystem"
-	SourceDiscord        SourceType = "discord"
-	SourceTelegram       SourceType = "telegram"
-	SourceSecretary      SourceType = "secretary"
+	SourceSlack      SourceType = "slack"
+	SourceGitHub     SourceType = "github"
+	SourceGDrive     SourceType = "gdrive"
+	SourceNotion     SourceType = "notion"
+	SourceFilesystem SourceType = "filesystem"
+	SourceDiscord    SourceType = "discord"
+	SourceTelegram   SourceType = "telegram"
+	SourceSecretary  SourceType = "secretary"
+	// SourceLLMMemory is DEPRECATED as of 2026-08-25 — DO NOT write new
+	// documents with this source_type.
+	//
+	// 폐기 사유(2026-08-25): memory-collector 데몬이 Claude Code/Codex 세션
+	// 트랜스크립트 전체를 이 source_type 으로 적재하고 있었다. 19,933건
+	// (평균 35,930자, 최대 490,324자, 청크 353,843개 — 코퍼스 청크의 76.5%)이
+	// 쌓여 검색 랭킹을 세션 덤프가 지배하면서 RAG 품질을 잠식했다. 전량
+	// 폐기(삭제)했고, 수집 데몬은 4대 머신(macmini/ubuntu1/ubuntu2 등)에서
+	// 전부 정지·비활성화했다.
+	//
+	// MCP add_note 도구도 과거 이 값을 썼으나(에이전트가 의도적으로 남기는
+	// 짧은 노트 — 세션 덤프와는 성격이 다른 데이터), 같은 이름표를 공유해
+	// 구분이 불가능했던 것이 문제였다. add_note 는 이제 SourceAgentNote 를
+	// 쓴다(cmd/mcp/main.go registerAddNoteTool). 이 상수 자체를 지우지 않는
+	// 이유는 기존에 이미 적재된 레거시 문서(예: secretary 경유 llm-memory
+	// 1건, migrations/027 참고)를 여전히 이 값으로 식별해야 하기 때문이다.
+	//
+	// internal/store의 upsert 가드(checkSourceTypeGuard)가 이 타입으로의
+	// 신규 저장 시도를 감지해 경고 로그를 남긴다 — 이 주석이 없어지면
+	// "왜 막혀 있지?" 하고 나중에 누군가 되살릴 수 있으므로 반드시 유지할 것.
+	// 이 값을 model.KnownSourceTypes()/DeprecatedSourceTypes() 에서 지우거나
+	// 옮기려면 위 배경을 먼저 이해할 것 (internal/model/source_validation.go).
 	SourceLLMMemory      SourceType = "llm-memory"
 	SourceGmail          SourceType = "gmail"
 	SourceCalendar       SourceType = "calendar"
@@ -29,9 +51,13 @@ const (
 	SourceCallTranscript SourceType = "call-transcript"
 	SourceUpload         SourceType = "upload"
 	// SourceNote is a user-authored note captured via POST /api/v1/notes
-	// (Capture). Distinct from SourceLLMMemory (MCP add_note tool,
+	// (Capture). Distinct from SourceAgentNote (MCP add_note tool,
 	// AI-agent-authored) — see spec §3.3. Content is write-once; only
 	// Title/Metadata are ever updated after creation, by NoteEnrichmentWorker.
+	// NoteEnrichmentWorker (and the insight-extraction pipeline it drives) is
+	// scoped to source_type='note' specifically — SourceAgentNote documents
+	// are NOT picked up by it. Keep the two source types separate rather than
+	// merging them; see SourceAgentNote's doc comment for why.
 	SourceNote SourceType = "note"
 	// SourceInsight is an LLM-derived inference extracted from a SourceNote
 	// document by NoteEnrichmentWorker. Never user-authored; always carries
@@ -39,34 +65,48 @@ const (
 	// §6.5). Excluded from default /api/v1/search results (see
 	// internal/api/search.go applyInsightExclusionDefault).
 	SourceInsight SourceType = "insight"
+	// SourceAgentNote is a note deliberately persisted by an AI agent via the
+	// MCP add_note tool (cmd/mcp/main.go registerAddNoteTool). Added
+	// 2026-08-25 as the replacement for SourceLLMMemory, which add_note used
+	// to write to — see SourceLLMMemory's doc comment for the full
+	// background (session-transcript contamination that source_type shared
+	// with these deliberately-authored notes).
+	//
+	// Deliberately NOT merged into SourceNote: SourceNote is scoped by spec
+	// §3.3 to user-authored Capture content and is the sole input to
+	// NoteEnrichmentWorker's insight-extraction pipeline. Writing
+	// agent-authored notes there would silently enroll every MCP add_note
+	// call in that (LLM-cost-bearing) pipeline — an unrequested behavior
+	// change, not just a rename.
+	SourceAgentNote SourceType = "agent-note"
 )
 
 // Document represents a piece of content collected from an external source.
 type Document struct {
-	ID          uuid.UUID      `json:"id"`
-	SourceType  SourceType     `json:"source_type"`
-	SourceID    string         `json:"source_id"`
-	Title       string         `json:"title"`
-	Content     string         `json:"content"`
-	Metadata    map[string]any `json:"metadata"`
-	Embedding   []float32      `json:"-"`                    // omit from REST: large vector
-	Status      string         `json:"status"`               // "active", "deleted", "moved"
-	DeletedAt   *time.Time     `json:"deleted_at,omitempty"` // nil for active documents
+	ID         uuid.UUID      `json:"id"`
+	SourceType SourceType     `json:"source_type"`
+	SourceID   string         `json:"source_id"`
+	Title      string         `json:"title"`
+	Content    string         `json:"content"`
+	Metadata   map[string]any `json:"metadata"`
+	Embedding  []float32      `json:"-"`                    // omit from REST: large vector
+	Status     string         `json:"status"`               // "active", "deleted", "moved"
+	DeletedAt  *time.Time     `json:"deleted_at,omitempty"` // nil for active documents
 	// OccurredAt is the timestamp of the original event: email sent date,
 	// calendar event start time, SMS/call time, etc.  It is distinct from
 	// CollectedAt (when second-brain ingested the document).  Nil when the
 	// collector has no event-time concept or the value could not be parsed.
 	// "Latest" queries sort by COALESCE(occurred_at, collected_at) DESC so
 	// documents without OccurredAt degrade gracefully to ingest order.
-	OccurredAt  *time.Time     `json:"occurred_at,omitempty"`
-	CollectedAt time.Time      `json:"collected_at"`
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
+	OccurredAt  *time.Time `json:"occurred_at,omitempty"`
+	CollectedAt time.Time  `json:"collected_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 
 	// LLM-generated summary fields (populated asynchronously by SummarizerWorker).
 	// NULL in DB until the worker processes the document.
-	TitleSummary    string    `json:"title_summary,omitempty"`
-	BulletSummary   string    `json:"bullet_summary,omitempty"`
+	TitleSummary     string    `json:"title_summary,omitempty"`
+	BulletSummary    string    `json:"bullet_summary,omitempty"`
 	SummaryEmbedding []float32 `json:"-"` // omit from REST: large vector
 }
 
@@ -74,7 +114,7 @@ type Document struct {
 type SearchResult struct {
 	Document
 	Score     float64  `json:"score"`
-	MatchType string   `json:"match_type"`          // "fulltext", "vector", or "hybrid"
+	MatchType string   `json:"match_type"`         // "fulltext", "vector", or "hybrid"
 	Entities  []Entity `json:"entities,omitempty"` // named entities extracted from the document; nil when not populated
 }
 

--- a/internal/model/source_validation.go
+++ b/internal/model/source_validation.go
@@ -1,0 +1,102 @@
+package model
+
+// KnownSourceTypes lists the source types that this corpus actually contains
+// as of 2026-08-25 (see migration 027 background): gmail, sms, call-log,
+// call-transcript, calendar, insight, note, and upload.
+//
+// This list is DELIBERATELY narrower than the full SourceType const block
+// above. Several of those consts (SourceSlack, SourceGitHub, SourceGDrive,
+// SourceNotion, SourceDiscord, SourceTelegram, SourceFilesystem) name
+// integrations whose collector code still exists in internal/collector but
+// which are not currently populating documents in production. They are not
+// included here so that ValidateSourceType's "unknown" signal stays tied to
+// what the corpus actually looks like today, not to every integration this
+// codebase has ever shipped.
+//
+// SourceLLMMemory is also excluded: it was decommissioned as an active
+// source (see agent memory project_macmini_prod_compose — secretary infra
+// torn down) and its one remaining secretary-routed row is intentionally
+// left alone by migration 027 rather than resurrected into a live bucket.
+//
+// Extending this list (e.g. re-enabling a dormant collector) is a one-line
+// change here; nothing else needs updating for the guard in internal/store
+// to recognise the new value.
+// SourceAgentNote is included because it is the 2026-08-25 replacement for
+// SourceLLMMemory (see that const's doc comment) — the MCP add_note tool's
+// real, ongoing write path, not a legacy or container type.
+func KnownSourceTypes() []SourceType {
+	return []SourceType{
+		SourceGmail,
+		SourceSMS,
+		SourceCallLog,
+		SourceCallTranscript,
+		SourceCalendar,
+		SourceInsight,
+		SourceNote,
+		SourceUpload,
+		SourceAgentNote,
+	}
+}
+
+// IsKnownSourceType reports whether st is one of KnownSourceTypes.
+func IsKnownSourceType(st SourceType) bool {
+	for _, k := range KnownSourceTypes() {
+		if st == k {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainerSourceTypes lists source_type values that are known to aggregate
+// multiple, unrelated real sources under one bucket rather than naming a
+// single origin. SourceSecretary is the motivating (and, as of migration 027,
+// historical) example: it mixed gmail/sms/call-log/call-transcript/calendar
+// content, which made source-type filtering and query-planner routing unable
+// to distinguish them (see migrations/027_secretary_source_normalization.sql).
+//
+// No new document should ever be written with a container source_type — the
+// value only exists in the corpus as a target for one-time normalization
+// migrations. See internal/store's upsert guard for where this is enforced.
+func ContainerSourceTypes() []SourceType {
+	return []SourceType{SourceSecretary}
+}
+
+// IsContainerSourceType reports whether st is a known container/aggregate
+// source_type (see ContainerSourceTypes).
+func IsContainerSourceType(st SourceType) bool {
+	for _, c := range ContainerSourceTypes() {
+		if st == c {
+			return true
+		}
+	}
+	return false
+}
+
+// DeprecatedSourceTypes lists source_type values that must never be used for
+// a new document, but that already-collected documents may still carry (so
+// the value cannot simply be deleted from the model).
+//
+// SourceLLMMemory is deprecated as of 2026-08-25: see its doc comment in
+// document.go for the full background (session-transcript contamination —
+// 19,933 documents / 353,843 chunks / 76.5% of the corpus, purged; the
+// memory-collector daemon that produced them stopped on every machine that
+// ran it). internal/store's upsert guard (checkSourceTypeGuard) logs a
+// warning — with the incoming document's source_id and any identifying
+// metadata fields — whenever a write targets a deprecated source_type, so a
+// reintroduced write path is discoverable instead of silently resurrecting
+// the same contamination.
+func DeprecatedSourceTypes() []SourceType {
+	return []SourceType{SourceLLMMemory}
+}
+
+// IsDeprecatedSourceType reports whether st is a known deprecated source_type
+// (see DeprecatedSourceTypes).
+func IsDeprecatedSourceType(st SourceType) bool {
+	for _, d := range DeprecatedSourceTypes() {
+		if st == d {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/model/source_validation_test.go
+++ b/internal/model/source_validation_test.go
@@ -1,0 +1,120 @@
+package model
+
+import "testing"
+
+// TestKnownSourceTypes_MatchesTaskSpec pins the exact corpus-based known-source
+// list. A silent addition/removal here changes what internal/store's
+// checkSourceTypeGuard treats as "known" without a code review signal beyond
+// this test failing.
+func TestKnownSourceTypes_MatchesTaskSpec(t *testing.T) {
+	t.Parallel()
+
+	want := map[SourceType]bool{
+		SourceGmail:          true,
+		SourceSMS:            true,
+		SourceCallLog:        true,
+		SourceCallTranscript: true,
+		SourceCalendar:       true,
+		SourceInsight:        true,
+		SourceNote:           true,
+		SourceUpload:         true,
+		SourceAgentNote:      true,
+	}
+
+	got := KnownSourceTypes()
+	if len(got) != len(want) {
+		t.Fatalf("KnownSourceTypes() has %d entries, want %d: %v", len(got), len(want), got)
+	}
+	seen := map[SourceType]bool{}
+	for _, st := range got {
+		if !want[st] {
+			t.Errorf("KnownSourceTypes() contains unexpected %q", st)
+		}
+		if seen[st] {
+			t.Errorf("KnownSourceTypes() contains duplicate %q", st)
+		}
+		seen[st] = true
+	}
+}
+
+// TestIsKnownSourceType_ExcludesContainerAndDeprecated verifies the guard's
+// two most important negatives: the container type (secretary) and the
+// deprecated type (llm-memory) must NOT be reported as known, or
+// checkSourceTypeGuard's switch would never reach their dedicated branches.
+func TestIsKnownSourceType_ExcludesContainerAndDeprecated(t *testing.T) {
+	t.Parallel()
+
+	for _, st := range []SourceType{SourceSecretary, SourceLLMMemory} {
+		if IsKnownSourceType(st) {
+			t.Errorf("IsKnownSourceType(%q) = true, want false", st)
+		}
+	}
+}
+
+// TestIsKnownSourceType_Positive spot-checks a few known types.
+func TestIsKnownSourceType_Positive(t *testing.T) {
+	t.Parallel()
+
+	for _, st := range []SourceType{SourceGmail, SourceSMS, SourceAgentNote, SourceUpload} {
+		if !IsKnownSourceType(st) {
+			t.Errorf("IsKnownSourceType(%q) = false, want true", st)
+		}
+	}
+}
+
+// TestIsContainerSourceType verifies only secretary is flagged as a
+// container type — a false positive here would make the guard warn on
+// legitimate per-kind writes.
+func TestIsContainerSourceType(t *testing.T) {
+	t.Parallel()
+
+	if !IsContainerSourceType(SourceSecretary) {
+		t.Error("IsContainerSourceType(secretary) = false, want true")
+	}
+	for _, st := range []SourceType{SourceGmail, SourceSMS, SourceLLMMemory, SourceAgentNote} {
+		if IsContainerSourceType(st) {
+			t.Errorf("IsContainerSourceType(%q) = true, want false", st)
+		}
+	}
+}
+
+// TestIsDeprecatedSourceType verifies only llm-memory is flagged as
+// deprecated, and that the newly introduced agent-note replacement is NOT
+// itself flagged (a regression here would make every add_note call warn).
+func TestIsDeprecatedSourceType(t *testing.T) {
+	t.Parallel()
+
+	if !IsDeprecatedSourceType(SourceLLMMemory) {
+		t.Error("IsDeprecatedSourceType(llm-memory) = false, want true")
+	}
+	for _, st := range []SourceType{SourceAgentNote, SourceNote, SourceGmail, SourceSecretary} {
+		if IsDeprecatedSourceType(st) {
+			t.Errorf("IsDeprecatedSourceType(%q) = true, want false", st)
+		}
+	}
+}
+
+// TestContainerAndDeprecatedSourceTypes_Disjoint verifies the two guard
+// categories never overlap — checkSourceTypeGuard's switch relies on
+// container being checked before deprecated, and an overlapping value would
+// make the ordering silently matter in a way this test would catch first.
+func TestContainerAndDeprecatedSourceTypes_Disjoint(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range ContainerSourceTypes() {
+		for _, d := range DeprecatedSourceTypes() {
+			if c == d {
+				t.Errorf("%q is both a container type and a deprecated type", c)
+			}
+		}
+	}
+}
+
+// TestSourceAgentNote_StringValue pins the wire-format string value, since
+// cmd/mcp/main.go's tool description and error strings hard-code "agent-note".
+func TestSourceAgentNote_StringValue(t *testing.T) {
+	t.Parallel()
+	if string(SourceAgentNote) != "agent-note" {
+		t.Errorf("SourceAgentNote = %q, want %q", SourceAgentNote, "agent-note")
+	}
+}

--- a/internal/note/note.go
+++ b/internal/note/note.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/baekenough/second-brain/internal/chunker"
 	"github.com/baekenough/second-brain/internal/model"
 	"github.com/baekenough/second-brain/internal/store"
+	"github.com/google/uuid"
 )
 
 // DocumentUpserter is the subset of DocumentStore used by Save.
@@ -44,8 +44,9 @@ type Result struct {
 // handleAddNote, parameterized so both the MCP add_note tool and the
 // POST /api/v1/notes REST handler share identical persistence behaviour.
 //
-// sourceType controls the stored model.SourceType (model.SourceLLMMemory for
-// MCP, model.SourceNote for the REST path — spec §6.2).
+// sourceType controls the stored model.SourceType (model.SourceAgentNote for
+// MCP, model.SourceNote for the REST path — spec §6.2, updated 2026-08-25;
+// MCP add_note previously wrote model.SourceLLMMemory, since deprecated).
 //
 // requireTitle=true rejects an empty title (MCP add_note's pre-extraction
 // behaviour). requireTitle=false allows an empty title, which

--- a/internal/search/factory.go
+++ b/internal/search/factory.go
@@ -3,6 +3,7 @@ package search
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/baekenough/second-brain/internal/config"
 )
@@ -60,4 +61,19 @@ func NewEmbeddingEngine(cfg *config.Config) (EmbeddingEngine, error) {
 	}
 
 	return engine, nil
+}
+
+// NewOpenSearchLane constructs the OpenSearch BM25 (nori) lane from cfg, or
+// returns nil when cfg.OpensearchURL is empty — THE DEFAULT. A nil return is
+// a true nil interface (not a typed-nil *OpenSearchClient wrapped in an
+// interface), so Service.WithOpenSearch's "s.opensearch != nil" gate in
+// search.go sees it as absent and runs the exact pre-existing code path.
+//
+// See internal/search/opensearch.go for why this lane exists at all.
+func NewOpenSearchLane(cfg *config.Config) OpenSearchSearcher {
+	if cfg.OpensearchURL == "" {
+		return nil
+	}
+	timeout := time.Duration(cfg.OpensearchTimeoutSeconds) * time.Second
+	return NewOpenSearchClient(cfg.OpensearchURL, cfg.OpensearchIndex, timeout)
 }

--- a/internal/search/opensearch.go
+++ b/internal/search/opensearch.go
@@ -1,0 +1,283 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+)
+
+// OpenSearchClient queries an OpenSearch index of document chunks analyzed
+// with a Korean morphological (nori) tokenizer, giving this lane a precision
+// property the Postgres pg_bigm (bigram) FTS lane does not have: bigram has
+// no notion of a morpheme boundary, so "회의" matches inside "사회의" and
+// "기회의". Measured against ubuntu1 production data:
+//
+//	query "회의": pg_bigm 865 hits, nori exact-morpheme-match only 184 of them
+//	query "계약": pg_bigm 1,356 hits, nori exact-morpheme-match only 368
+//	query "예약": pg_bigm 1,273 hits, nori exact-morpheme-match only 497
+//
+// The excess is substring noise that dilutes the candidate pool before a
+// reranker ever sees it. This client does not replace pg_bigm — it is fused
+// into the existing RRF pipeline as one more additive signal, exactly like
+// the chunk vector/FTS lanes in search.go (see WithOpenSearch).
+//
+// The index this client queries (default name "sb-chunks") is built and
+// maintained OUTSIDE this codebase for now — see
+// deploy/ubuntu1-stack/opensearch/ for the index settings and the bulk
+// script that populates it from the `chunks`/`documents` tables. This client
+// only reads it.
+type OpenSearchClient struct {
+	baseURL    string
+	index      string
+	httpClient *http.Client
+}
+
+// NewOpenSearchClient returns a client for the given OpenSearch base URL and
+// index. baseURL == "" produces a disabled client (Enabled() == false); it is
+// still safe to call Search on it, which returns (nil, nil).
+//
+// timeout <= 0 falls back to 5s. index == "" falls back to "sb-chunks" (the
+// name used by deploy/ubuntu1-stack/opensearch/index-settings.json).
+func NewOpenSearchClient(baseURL, index string, timeout time.Duration) *OpenSearchClient {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	if index == "" {
+		index = "sb-chunks"
+	}
+	return &OpenSearchClient{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		index:      index,
+		httpClient: &http.Client{Timeout: timeout},
+	}
+}
+
+// Enabled reports whether an OpenSearch endpoint is configured. A nil
+// receiver is treated as disabled so that a zero-value *OpenSearchClient
+// (e.g. an unwired field) never panics.
+func (c *OpenSearchClient) Enabled() bool {
+	return c != nil && c.baseURL != ""
+}
+
+// osHit is the subset of an OpenSearch hit this client decodes. It mirrors
+// the sb-chunks mapping in deploy/ubuntu1-stack/opensearch/index-settings.json.
+// Kind and ChunkIndex are decoded but currently unused by model.SearchResult;
+// they stay in the struct so a future caller does not have to touch the
+// wire-format decode again.
+type osHit struct {
+	Score  float64 `json:"_score"`
+	Source struct {
+		ChunkID    int64   `json:"chunk_id"`
+		DocumentID string  `json:"document_id"`
+		SourceType string  `json:"source_type"`
+		Kind       string  `json:"kind"`
+		ChunkIndex int     `json:"chunk_index"`
+		OccurredAt *string `json:"occurred_at"`
+		Title      string  `json:"title"`
+		Content    string  `json:"content"`
+	} `json:"_source"`
+}
+
+type osSearchResponse struct {
+	Hits struct {
+		Hits []osHit `json:"hits"`
+	} `json:"hits"`
+}
+
+// Search runs a BM25 multi_match query (content + title, title weighted 2x)
+// against the OpenSearch index, applying the SAME include/exclude source-type
+// and occurred_at-window semantics every other lane honours — see
+// buildRequest. Results are chunk-level hits aggregated to the
+// highest-scoring hit per document, sorted by descending score, and
+// truncated to limit: the same shape searchChunksFTS/searchChunksVector
+// return in search.go, ready to fuse via mergeRRF.
+//
+// A nil/disabled client, an empty query, or limit <= 0 (normalised to the
+// package default) are handled without a request. Every other failure —
+// network error, non-2xx response, malformed JSON, an unparsable
+// document_id — is returned to the caller. search.Service.Search treats an
+// error here as a soft failure: log a warning and drop this lane's
+// contribution, never fail the overall request. See the OpenSearch
+// integration block in Search() for that behaviour; this method never
+// swallows the error itself, so a caller that wants a different policy can
+// still see the real error.
+func (c *OpenSearchClient) Search(ctx context.Context, q model.SearchQuery, limit int) ([]*model.SearchResult, error) {
+	if !c.Enabled() || strings.TrimSpace(q.Query) == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+
+	// Over-fetch for per-document dedup, mirroring the *3 factor
+	// searchChunksVector/searchChunksFTS use for the same reason: several
+	// chunks of the same document may each independently match the query.
+	body, err := json.Marshal(buildOpenSearchRequest(q, limit*3))
+	if err != nil {
+		return nil, fmt.Errorf("opensearch: marshal request: %w", err)
+	}
+
+	reqURL := c.baseURL + "/" + c.index + "/_search"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("opensearch: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch: request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("opensearch: read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("opensearch: status %d: %s", resp.StatusCode, b)
+	}
+
+	var parsed osSearchResponse
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		return nil, fmt.Errorf("opensearch: unmarshal response: %w", err)
+	}
+
+	type entry struct {
+		result *model.SearchResult
+		score  float64
+	}
+	seen := make(map[uuid.UUID]entry, len(parsed.Hits.Hits))
+	for _, h := range parsed.Hits.Hits {
+		docID, perr := uuid.Parse(h.Source.DocumentID)
+		if perr != nil {
+			continue // malformed row; skip it rather than fail the whole lane
+		}
+		if prev, ok := seen[docID]; ok && prev.score >= h.Score {
+			continue
+		}
+		seen[docID] = entry{result: opensearchHitToSearchResult(docID, h), score: h.Score}
+	}
+
+	out := make([]*model.SearchResult, 0, len(seen))
+	for _, e := range seen {
+		out = append(out, e.result)
+	}
+	sortByScore(out)
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// buildOpenSearchRequest translates q's filters into the OpenSearch query
+// DSL. It intentionally mirrors applySourceTypeFilters' conflict rule
+// (EXCLUDE WINS — a source type named by both filters is dropped, via
+// must_not, regardless of what filter/terms includes) and
+// SearchQuery.OccurredFrom/OccurredTo's half-open window
+// [OccurredFrom, OccurredTo).
+//
+// Because this client can express both filters directly in the query, the
+// window and source-type constraints are enforced SERVER-SIDE, unlike the
+// ChunkSearcher lanes (whose interface takes only a query/vector and a
+// limit). That is why the OpenSearch lane in search.go needs neither
+// chunkLanesEnabled's fail-closed skip nor verifyWindow's post-hoc
+// membership check: what OpenSearch returns already satisfies the
+// predicate, and an unreachable node returns nothing at all (handled by the
+// caller as a soft failure) — the same fail-closed outcome, reached a
+// different way.
+func buildOpenSearchRequest(q model.SearchQuery, size int) map[string]any {
+	must := []map[string]any{
+		{
+			"multi_match": map[string]any{
+				"query":  q.Query,
+				"fields": []string{"content", "title^2"},
+			},
+		},
+	}
+
+	var filter []map[string]any
+	if q.OccurredFrom != nil || q.OccurredTo != nil {
+		rng := map[string]any{}
+		if q.OccurredFrom != nil {
+			rng["gte"] = q.OccurredFrom.UTC().Format(time.RFC3339)
+		}
+		if q.OccurredTo != nil {
+			rng["lt"] = q.OccurredTo.UTC().Format(time.RFC3339) // half-open, matches OccurredTo's documented semantics
+		}
+		filter = append(filter, map[string]any{
+			"range": map[string]any{"occurred_at": rng},
+		})
+	}
+	if include := q.IncludeSourceTypes(); len(include) > 0 {
+		values := make([]string, len(include))
+		for i, st := range include {
+			values[i] = string(st)
+		}
+		filter = append(filter, map[string]any{
+			"terms": map[string]any{"source_type": values},
+		})
+	}
+
+	var mustNot []map[string]any
+	if len(q.ExcludeSourceTypes) > 0 {
+		values := make([]string, len(q.ExcludeSourceTypes))
+		for i, st := range q.ExcludeSourceTypes {
+			values[i] = string(st)
+		}
+		mustNot = append(mustNot, map[string]any{
+			"terms": map[string]any{"source_type": values},
+		})
+	}
+
+	boolQuery := map[string]any{"must": must}
+	if len(filter) > 0 {
+		boolQuery["filter"] = filter
+	}
+	if len(mustNot) > 0 {
+		boolQuery["must_not"] = mustNot
+	}
+
+	return map[string]any{
+		"size":  size,
+		"query": map[string]any{"bool": boolQuery},
+	}
+}
+
+// opensearchHitToSearchResult converts a decoded hit into a model.SearchResult.
+//
+// OccurredAt is parsed when present; an unparsable value is treated as absent
+// rather than failing the hit — one malformed timestamp should not cost the
+// whole document a place in the result set. CollectedAt is left at its zero
+// value: the sb-chunks index does not carry it (see index-settings.json), and
+// recencyKey (internal/search/sort_recent.go) already treats a result with
+// neither OccurredAt nor a non-zero CollectedAt as unplaceable rather than as
+// the zero instant, so this degrades a Sort="recent" query exactly the way an
+// OccurredAt-less chunk-lane row always has — it sorts last, never first.
+func opensearchHitToSearchResult(docID uuid.UUID, h osHit) *model.SearchResult {
+	var occurred *time.Time
+	if h.Source.OccurredAt != nil {
+		if t, err := time.Parse(time.RFC3339, *h.Source.OccurredAt); err == nil {
+			occurred = &t
+		}
+	}
+	return &model.SearchResult{
+		Document: model.Document{
+			ID:         docID,
+			SourceType: model.SourceType(h.Source.SourceType),
+			Title:      h.Source.Title,
+			Content:    h.Source.Content,
+			OccurredAt: occurred,
+		},
+		Score:     h.Score,
+		MatchType: "opensearch-bm25",
+	}
+}

--- a/internal/search/opensearch_test.go
+++ b/internal/search/opensearch_test.go
@@ -1,0 +1,428 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+func TestOpenSearchClient_Enabled(t *testing.T) {
+	t.Parallel()
+
+	if c := NewOpenSearchClient("", "sb-chunks", 0); c.Enabled() {
+		t.Error("Enabled() = true for empty baseURL, want false")
+	}
+	if c := NewOpenSearchClient("http://localhost:9200", "sb-chunks", 0); !c.Enabled() {
+		t.Error("Enabled() = false for non-empty baseURL, want true")
+	}
+
+	var nilClient *OpenSearchClient
+	if nilClient.Enabled() {
+		t.Error("Enabled() on a nil *OpenSearchClient must not panic and must report false")
+	}
+}
+
+func TestOpenSearchClient_Search_DisabledIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	c := NewOpenSearchClient("", "sb-chunks", time.Second)
+	results, err := c.Search(context.Background(), model.SearchQuery{Query: "회의"}, 20)
+	if err != nil {
+		t.Fatalf("Search() on disabled client returned error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("Search() on disabled client = %v, want nil", results)
+	}
+}
+
+func TestOpenSearchClient_Search_EmptyQueryIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewOpenSearchClient(srv.URL, "sb-chunks", time.Second)
+	results, err := c.Search(context.Background(), model.SearchQuery{Query: "  "}, 20)
+	if err != nil {
+		t.Fatalf("Search() with blank query returned error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("Search() with blank query = %v, want nil", results)
+	}
+	if called {
+		t.Error("Search() with blank query must not issue an HTTP request")
+	}
+}
+
+func TestOpenSearchClient_Search_ParsesHitsAndAggregatesPerDocument(t *testing.T) {
+	t.Parallel()
+
+	docA := uuid.New()
+	docB := uuid.New()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"hits": map[string]any{
+				"hits": []map[string]any{
+					{
+						"_score": 5.0,
+						"_source": map[string]any{
+							"chunk_id":    1,
+							"document_id": docA.String(),
+							"source_type": "gmail",
+							"title":       "회의록 초안",
+							"content":     "오늘 회의에서 논의된 내용",
+							"occurred_at": "2026-08-01T09:00:00Z",
+						},
+					},
+					{
+						// Second chunk of the SAME document with a LOWER score —
+						// must be aggregated away, keeping only the higher one.
+						"_score": 2.0,
+						"_source": map[string]any{
+							"chunk_id":    2,
+							"document_id": docA.String(),
+							"source_type": "gmail",
+							"title":       "회의록 초안",
+							"content":     "다음 회의 일정",
+						},
+					},
+					{
+						"_score": 3.5,
+						"_source": map[string]any{
+							"chunk_id":    3,
+							"document_id": docB.String(),
+							"source_type": "sms",
+							"title":       "",
+							"content":     "회의 참석 확인 부탁드립니다",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewOpenSearchClient(srv.URL, "sb-chunks", time.Second)
+	results, err := c.Search(context.Background(), model.SearchQuery{Query: "회의"}, 20)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("Search() returned %d results, want 2 (deduplicated per document)", len(results))
+	}
+
+	byID := make(map[uuid.UUID]*model.SearchResult, len(results))
+	for _, r := range results {
+		byID[r.ID] = r
+	}
+
+	got, ok := byID[docA]
+	if !ok {
+		t.Fatalf("missing result for docA")
+	}
+	if got.Score != 5.0 {
+		t.Errorf("docA score = %v, want 5.0 (the higher of its two chunk hits)", got.Score)
+	}
+	if got.MatchType != "opensearch-bm25" {
+		t.Errorf("docA MatchType = %q, want %q", got.MatchType, "opensearch-bm25")
+	}
+	if got.OccurredAt == nil || !got.OccurredAt.Equal(time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)) {
+		t.Errorf("docA OccurredAt = %v, want 2026-08-01T09:00:00Z", got.OccurredAt)
+	}
+
+	gotB, ok := byID[docB]
+	if !ok {
+		t.Fatalf("missing result for docB")
+	}
+	if gotB.OccurredAt != nil {
+		t.Errorf("docB OccurredAt = %v, want nil (no occurred_at in the hit)", gotB.OccurredAt)
+	}
+}
+
+func TestOpenSearchClient_Search_MalformedDocumentIDSkipped(t *testing.T) {
+	t.Parallel()
+
+	validDoc := uuid.New()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"hits": map[string]any{
+				"hits": []map[string]any{
+					{
+						"_score": 1.0,
+						"_source": map[string]any{
+							"document_id": "not-a-uuid",
+							"content":     "broken row",
+						},
+					},
+					{
+						"_score": 2.0,
+						"_source": map[string]any{
+							"document_id": validDoc.String(),
+							"content":     "good row",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := NewOpenSearchClient(srv.URL, "sb-chunks", time.Second)
+	results, err := c.Search(context.Background(), model.SearchQuery{Query: "test"}, 20)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != validDoc {
+		t.Fatalf("Search() = %+v, want exactly one result for the valid document", results)
+	}
+}
+
+func TestOpenSearchClient_Search_NonOKStatusReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"index_not_found_exception"}`))
+	}))
+	defer srv.Close()
+
+	c := NewOpenSearchClient(srv.URL, "sb-chunks", time.Second)
+	_, err := c.Search(context.Background(), model.SearchQuery{Query: "test"}, 20)
+	if err == nil {
+		t.Fatal("Search() with a 500 response returned nil error, want non-nil")
+	}
+}
+
+func TestOpenSearchClient_Search_ContextCancellationReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewOpenSearchClient(srv.URL, "sb-chunks", time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Search(ctx, model.SearchQuery{Query: "test"}, 20)
+	if err == nil {
+		t.Fatal("Search() with a cancelled context returned nil error, want non-nil")
+	}
+}
+
+func TestOpenSearchClient_Search_ClientTimeoutReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// A very short client-level timeout (mirrors OPENSEARCH_TIMEOUT_SECONDS)
+	// must surface as an error, never hang.
+	c := NewOpenSearchClient(srv.URL, "sb-chunks", 10*time.Millisecond)
+	_, err := c.Search(context.Background(), model.SearchQuery{Query: "test"}, 20)
+	if err == nil {
+		t.Fatal("Search() past the client timeout returned nil error, want non-nil")
+	}
+}
+
+func TestBuildOpenSearchRequest_MultiMatchFields(t *testing.T) {
+	t.Parallel()
+
+	req := buildOpenSearchRequest(model.SearchQuery{Query: "회의"}, 60)
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["size"].(float64) != 60 {
+		t.Errorf("size = %v, want 60", decoded["size"])
+	}
+	boolQuery := decoded["query"].(map[string]any)["bool"].(map[string]any)
+	must := boolQuery["must"].([]any)
+	if len(must) != 1 {
+		t.Fatalf("must clauses = %d, want 1", len(must))
+	}
+	mm := must[0].(map[string]any)["multi_match"].(map[string]any)
+	fields := mm["fields"].([]any)
+	if len(fields) != 2 || fields[0] != "content" || fields[1] != "title^2" {
+		t.Errorf("multi_match fields = %v, want [content title^2]", fields)
+	}
+	if _, hasFilter := boolQuery["filter"]; hasFilter {
+		t.Error("filter clause present for a query with no window/source filters")
+	}
+	if _, hasMustNot := boolQuery["must_not"]; hasMustNot {
+		t.Error("must_not clause present for a query with no exclusions")
+	}
+}
+
+func TestBuildOpenSearchRequest_OccurredWindowIsHalfOpen(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	req := buildOpenSearchRequest(model.SearchQuery{Query: "q", OccurredFrom: &from, OccurredTo: &to}, 20)
+
+	boolQuery := req["query"].(map[string]any)["bool"].(map[string]any)
+	filters := boolQuery["filter"].([]map[string]any)
+	if len(filters) != 1 {
+		t.Fatalf("filter clauses = %d, want 1", len(filters))
+	}
+	rng := filters[0]["range"].(map[string]any)["occurred_at"].(map[string]any)
+	if rng["gte"] != "2026-08-01T00:00:00Z" {
+		t.Errorf("gte = %v, want 2026-08-01T00:00:00Z", rng["gte"])
+	}
+	if rng["lt"] != "2026-08-02T00:00:00Z" {
+		t.Errorf("lt = %v, want 2026-08-02T00:00:00Z (exclusive upper bound)", rng["lt"])
+	}
+	if _, hasGT := rng["gt"]; hasGT {
+		t.Error("range must use gte/lt, not gt")
+	}
+}
+
+func TestBuildOpenSearchRequest_SourceTypeIncludeAndExclude(t *testing.T) {
+	t.Parallel()
+
+	st := model.SourceGmail
+	req := buildOpenSearchRequest(model.SearchQuery{
+		Query:              "q",
+		SourceType:         &st,
+		ExcludeSourceTypes: []model.SourceType{model.SourceInsight},
+	}, 20)
+
+	boolQuery := req["query"].(map[string]any)["bool"].(map[string]any)
+	filters := boolQuery["filter"].([]map[string]any)
+	if len(filters) != 1 {
+		t.Fatalf("filter clauses = %d, want 1 (include terms)", len(filters))
+	}
+	includeValues := filters[0]["terms"].(map[string]any)["source_type"].([]string)
+	if len(includeValues) != 1 || includeValues[0] != "gmail" {
+		t.Errorf("include filter = %v, want [gmail]", includeValues)
+	}
+
+	mustNot := boolQuery["must_not"].([]map[string]any)
+	if len(mustNot) != 1 {
+		t.Fatalf("must_not clauses = %d, want 1 (exclude terms)", len(mustNot))
+	}
+	excludeValues := mustNot[0]["terms"].(map[string]any)["source_type"].([]string)
+	if len(excludeValues) != 1 || excludeValues[0] != "insight" {
+		t.Errorf("exclude filter = %v, want [insight]", excludeValues)
+	}
+}
+
+// --- Service-level integration: the OpenSearch lane must degrade gracefully ---
+
+// mockOpenSearchSearcher is a test double for OpenSearchSearcher.
+type mockOpenSearchSearcher struct {
+	enabled bool
+	results []*model.SearchResult
+	err     error
+}
+
+func (m *mockOpenSearchSearcher) Enabled() bool { return m.enabled }
+
+func (m *mockOpenSearchSearcher) Search(_ context.Context, _ model.SearchQuery, _ int) ([]*model.SearchResult, error) {
+	return m.results, m.err
+}
+
+// TestServiceSearch_OpenSearchLaneNil_IdenticalToPreExistingPath pins the
+// default-off contract: a Service with no OpenSearch lane attached behaves
+// exactly as it did before this lane existed.
+func TestServiceSearch_OpenSearchLaneNil_IdenticalToPreExistingPath(t *testing.T) {
+	t.Parallel()
+
+	docID := uuid.New()
+	store := &mockDocSearcher{results: []*model.SearchResult{
+		makeSearchResult(docID, "existing doc", 0.9),
+	}}
+	svc := NewService(store, disabledEmbedder{})
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{Query: "test"})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != docID {
+		t.Fatalf("Search() = %+v, want the store's single result unchanged", results)
+	}
+}
+
+// TestServiceSearch_OpenSearchLaneError_DegradesGracefully verifies that an
+// OpenSearch failure never fails the overall search request.
+func TestServiceSearch_OpenSearchLaneError_DegradesGracefully(t *testing.T) {
+	t.Parallel()
+
+	docID := uuid.New()
+	store := &mockDocSearcher{results: []*model.SearchResult{
+		makeSearchResult(docID, "existing doc", 0.9),
+	}}
+	os := &mockOpenSearchSearcher{enabled: true, err: context.DeadlineExceeded}
+	svc := NewService(store, disabledEmbedder{}).WithOpenSearch(os)
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{Query: "test"})
+	if err != nil {
+		t.Fatalf("Search() returned an error when the opensearch lane failed: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != docID {
+		t.Fatalf("Search() = %+v, want the store's result preserved despite the opensearch failure", results)
+	}
+}
+
+// TestServiceSearch_OpenSearchLaneFusesAdditiveResults verifies that a
+// successful OpenSearch hit not already present in the primary result set is
+// admitted via RRF, exactly like the chunk vector lane.
+func TestServiceSearch_OpenSearchLaneFusesAdditiveResults(t *testing.T) {
+	t.Parallel()
+
+	primaryDoc := uuid.New()
+	osOnlyDoc := uuid.New()
+
+	store := &mockDocSearcher{results: []*model.SearchResult{
+		makeSearchResult(primaryDoc, "primary hit", 0.9),
+	}}
+	os := &mockOpenSearchSearcher{
+		enabled: true,
+		results: []*model.SearchResult{
+			makeSearchResult(osOnlyDoc, "opensearch-only hit", 5.0),
+		},
+	}
+	svc := NewService(store, disabledEmbedder{}).WithOpenSearch(os)
+
+	results, err := svc.Search(context.Background(), model.SearchQuery{Query: "test"})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("Search() returned %d results, want 2 (primary + opensearch-only)", len(results))
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, r := range results {
+		seen[r.ID] = true
+	}
+	if !seen[primaryDoc] || !seen[osOnlyDoc] {
+		t.Errorf("Search() = %+v, want both primaryDoc and osOnlyDoc present", results)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -33,6 +33,20 @@ type ChunkSearcher interface {
 	SearchVector(ctx context.Context, queryVec []float32, limit int) ([]store.ChunkSearchResult, error)
 }
 
+// OpenSearchSearcher is the subset of the OpenSearch client used for the
+// BM25 (nori-analyzed) full-text lane. It is satisfied by
+// *OpenSearchClient (see opensearch.go).
+//
+// Unlike ChunkSearcher, its Search method takes the full model.SearchQuery
+// rather than a bare query/vector — the client applies the window and
+// source-type filters SERVER-SIDE (see buildOpenSearchRequest), which is why
+// this lane needs neither chunkLanesEnabled's fail-closed skip nor
+// verifyWindow's post-hoc check in Service.Search.
+type OpenSearchSearcher interface {
+	Enabled() bool
+	Search(ctx context.Context, q model.SearchQuery, limit int) ([]*model.SearchResult, error)
+}
+
 // OccurredRangeChecker verifies that a set of candidate document IDs falls
 // inside an event-time window. It is satisfied by *store.DocumentStore.
 //
@@ -67,6 +81,12 @@ type Service struct {
 	weights       model.SearchWeights // zero value uses defaults (k=60, equal weights)
 	reranker      Reranker            // nil when reranking is not configured
 	entityFetcher EntityFetcher       // nil when entity surfacing is not configured
+
+	// opensearch is nil unless OPENSEARCH_URL is configured (see
+	// factory.NewOpenSearchLane / WithOpenSearch). A nil value means this
+	// method's Search() runs the EXACT SAME code path it ran before this
+	// lane existed — see the "s.opensearch != nil" gate in Search().
+	opensearch OpenSearchSearcher
 
 	// occurredChecker verifies chunk-lane candidates against an event-time
 	// window. Usually nil: the document store already satisfies
@@ -134,6 +154,16 @@ func (s *Service) WithReranker(r Reranker) *Service {
 // field is nil. Safe to call with nil — surfacing is silently skipped.
 func (s *Service) WithEntityFetcher(ef EntityFetcher) *Service {
 	s.entityFetcher = ef
+	return s
+}
+
+// WithOpenSearch attaches the BM25 (nori-analyzed) full-text lane. Safe to
+// call with nil — the lane is then simply not run, and Search() behaves
+// exactly as it did before this lane existed. Disabled by DEFAULT: nothing
+// calls this unless OPENSEARCH_URL is set (see factory.NewOpenSearchLane and
+// cmd/server/main.go).
+func (s *Service) WithOpenSearch(c OpenSearchSearcher) *Service {
+	s.opensearch = c
 	return s
 }
 
@@ -430,6 +460,35 @@ func (s *Service) Search(ctx context.Context, q model.SearchQuery) ([]*model.Sea
 			}
 			if len(chunkVecResults) > 0 {
 				results = mergeRRF(results, chunkVecResults, q.Limit)
+				chunkFused = true
+			}
+		}
+	}
+
+	// OpenSearch (nori BM25) lane: additive full-text signal fused via RRF,
+	// the same way the chunk vector lane above is. Disabled unless
+	// OPENSEARCH_URL is configured (s.opensearch is nil by default — see
+	// WithOpenSearch), in which case this block is a no-op and the rest of
+	// Search() is byte-for-byte the pre-existing code path.
+	//
+	// The window/source-type filters do not need chunkLanesEnabled's gate
+	// here: OpenSearchSearcher.Search takes the whole query and applies both
+	// filters server-side (see buildOpenSearchRequest in opensearch.go), so
+	// what comes back already satisfies them. applySourceTypeFilters is still
+	// run below as cheap defense in depth, not because the server-side filter
+	// is expected to fail.
+	if s.opensearch != nil && s.opensearch.Enabled() {
+		osResults, oerr := s.opensearch.Search(ctx, q, q.Limit)
+		if oerr != nil {
+			// Non-fatal: an unreachable/erroring OpenSearch node must never
+			// fail the whole search request. Log and drop this lane's
+			// contribution, exactly like the chunk vector lane above.
+			slog.Warn("search: opensearch lane failed, skipping",
+				"error", oerr, "query", q.Query)
+		} else {
+			osResults = applySourceTypeFilters(q, osResults)
+			if len(osResults) > 0 {
+				results = mergeRRF(results, osResults, q.Limit)
 				chunkFused = true
 			}
 		}

--- a/internal/store/document.go
+++ b/internal/store/document.go
@@ -73,6 +73,13 @@ const callTranscriptDupCheckQuery = `
 //
 // *DocumentStore satisfies the api.IngestMessagesUpserter interface via this method.
 func (s *DocumentStore) UpsertTracked(ctx context.Context, doc *model.Document) (contentChanged bool, err error) {
+	// Recurrence guards (migration 027 background): warn on a container or
+	// deprecated source_type, and warn on a possible cross-source duplicate
+	// arrival. Both are non-blocking — see document_source_guard.go package
+	// doc for why neither guard fails the write.
+	checkSourceTypeGuard(doc)
+	s.checkDuplicateArrival(ctx, doc)
+
 	// Duplicate guard: call-transcript content dedup (issue #134).
 	if doc.SourceType == model.SourceCallTranscript {
 		var exists int
@@ -178,6 +185,13 @@ func (s *DocumentStore) UpsertTracked(ctx context.Context, doc *model.Document) 
 // or log it). A same-source_id re-upsert is NOT affected: the ON CONFLICT path
 // handles it normally even when the content is identical.
 func (s *DocumentStore) Upsert(ctx context.Context, doc *model.Document) error {
+	// Recurrence guards (migration 027 background): warn on a container or
+	// deprecated source_type, and warn on a possible cross-source duplicate
+	// arrival. Both are non-blocking — see document_source_guard.go package
+	// doc for why neither guard fails the write.
+	checkSourceTypeGuard(doc)
+	s.checkDuplicateArrival(ctx, doc)
+
 	// Duplicate guard: call-transcript content dedup (issue #134).
 	// Only applied when source_type is 'call-transcript'. Other source types are
 	// unaffected. Same-source_id re-upserts bypass this check because the query

--- a/internal/store/document_source_guard.go
+++ b/internal/store/document_source_guard.go
@@ -1,0 +1,196 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// ---------------------------------------------------------------------------
+// Recurrence guards for the source_type='secretary' problem fixed by
+// migration 027 (see migrations/027_secretary_source_normalization.sql).
+//
+// Two independent failure modes are guarded here:
+//
+//  1. Container source_type ingestion: a writer stores a new document under a
+//     source_type that aggregates multiple real sources (e.g. 'secretary')
+//     instead of the specific per-kind value. checkSourceTypeGuard catches
+//     this, plus any source_type this corpus does not recognise at all.
+//  2. Cross-source duplicate arrival: the same real-world event (email, SMS,
+//     call) is ingested twice under two different source_type values — this
+//     is exactly how migration 027 found 4,692 of the 10,096 secretary/gmail
+//     documents already duplicated under source_type='gmail'.
+//     checkDuplicateArrival catches this at write time.
+//
+// Enforcement level: WARN + counter, not a hard failure. Both guards are
+// heuristics — a title+time collision can be a legitimate coincidence, and
+// the known-source list will always lag behind legitimate new integrations
+// by at least one deploy. Rejecting the write on either signal risks turning
+// a detection mechanism into a data-loss mechanism, which is a worse outcome
+// than a few extra secretary-shaped documents. If these counters show
+// sustained non-zero activity in production, that is the signal to
+// investigate — not a reason to have blocked the write in the first place.
+// ---------------------------------------------------------------------------
+
+// sourceTypeGuardContainerHits, sourceTypeGuardDeprecatedHits, and
+// sourceTypeGuardUnknownHits count how many times checkSourceTypeGuard has
+// fired since process start. They are process-local (not persisted) and
+// exist for tests and for future observability wiring — see package doc
+// above for why this is WARN+counter rather than a hard failure.
+var (
+	sourceTypeGuardContainerHits  int64
+	sourceTypeGuardDeprecatedHits int64
+	sourceTypeGuardUnknownHits    int64
+	duplicateArrivalGuardHits     int64
+)
+
+// SourceTypeGuardStats returns the number of times checkSourceTypeGuard has
+// flagged a container source_type, a deprecated source_type, or an
+// unrecognized source_type, respectively, since process start. Exported for
+// tests and for any future /metrics or ops endpoint that wants to surface
+// these counters.
+func SourceTypeGuardStats() (containerHits, deprecatedHits, unknownHits int64) {
+	return atomic.LoadInt64(&sourceTypeGuardContainerHits),
+		atomic.LoadInt64(&sourceTypeGuardDeprecatedHits),
+		atomic.LoadInt64(&sourceTypeGuardUnknownHits)
+}
+
+// DuplicateArrivalGuardHits returns the number of times checkDuplicateArrival
+// has flagged a possible cross-source duplicate since process start.
+func DuplicateArrivalGuardHits() int64 {
+	return atomic.LoadInt64(&duplicateArrivalGuardHits)
+}
+
+// resetSourceGuardCountersForTest zeroes all three counters. Test-only
+// (unexported, _test.go files in this package call it) so that assertions on
+// "did this call increment the counter" are not order-dependent across the
+// package's test suite.
+func resetSourceGuardCountersForTest() {
+	atomic.StoreInt64(&sourceTypeGuardContainerHits, 0)
+	atomic.StoreInt64(&sourceTypeGuardDeprecatedHits, 0)
+	atomic.StoreInt64(&sourceTypeGuardUnknownHits, 0)
+	atomic.StoreInt64(&duplicateArrivalGuardHits, 0)
+}
+
+// deprecatedGuardMetadataKeys lists the metadata fields checked by
+// checkSourceTypeGuard's deprecated-type branch to help identify WHERE a
+// reintroduced write came from. These are structured identifier fields set
+// by collectors (see internal/collector/llm_memory.go's records schema), not
+// free-text content — logging them does not violate this repo's policy
+// against logging raw content (see agent memory
+// feedback_never_log_raw_llm_output).
+var deprecatedGuardMetadataKeys = []string{"kind", "device_id", "agent", "project"}
+
+// metadataStringField returns m[key] as a string, or "" when the key is
+// absent or not a string. Used to safely pull identifying fields out of
+// doc.Metadata (an untyped map[string]any) for log lines without risking a
+// panic on an unexpected value type.
+func metadataStringField(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// checkSourceTypeGuard logs (and counts) an upsert whose source_type is a
+// known container type, a deprecated type, or not in model.KnownSourceTypes.
+// It never returns an error and never blocks the caller — see the package
+// doc above for why.
+func checkSourceTypeGuard(doc *model.Document) {
+	st := doc.SourceType
+	switch {
+	case model.IsContainerSourceType(st):
+		atomic.AddInt64(&sourceTypeGuardContainerHits, 1)
+		slog.Warn("store: document upsert used a container source_type; use the specific per-kind source_type instead",
+			"source_type", st,
+		)
+	case model.IsDeprecatedSourceType(st):
+		atomic.AddInt64(&sourceTypeGuardDeprecatedHits, 1)
+		// Include identifying (non-content) fields so a reintroduced write
+		// path — e.g. a re-enabled collector or a tool that reverts to this
+		// source_type — is traceable from the log line alone.
+		attrs := []any{"source_type", st, "source_id", doc.SourceID}
+		for _, k := range deprecatedGuardMetadataKeys {
+			if v := metadataStringField(doc.Metadata, k); v != "" {
+				attrs = append(attrs, "metadata_"+k, v)
+			}
+		}
+		slog.Warn("store: document upsert used a deprecated source_type — see model.SourceLLMMemory doc comment for background", attrs...)
+	case !model.IsKnownSourceType(st):
+		atomic.AddInt64(&sourceTypeGuardUnknownHits, 1)
+		slog.Warn("store: document upsert used a source_type outside the known corpus list",
+			"source_type", st,
+		)
+	}
+}
+
+// duplicateArrivalWindow is the event-time tolerance used to detect the same
+// real-world event arriving under two different source_type values. 120s was
+// measured as sufficient to catch the gmail/secretary duplication (#see
+// migration 027 background) without matching genuinely distinct events that
+// happen to share a title.
+const duplicateArrivalWindow = 120 * time.Second
+
+// duplicateArrivalCheckQuery is an indexed existence probe: (title, occurred_at)
+// is covered by idx_documents_title_occurred_at (migrations/028), so this is
+// an index range scan bounded by the equality match on title, not a table
+// scan. It intentionally excludes the incoming document's own source_type so
+// that a normal same-source re-upsert (which goes through ON CONFLICT, not
+// this guard's warning path) never fires it.
+const duplicateArrivalCheckQuery = `
+	SELECT source_type
+	FROM documents
+	WHERE title       = $1
+	  AND occurred_at BETWEEN $2 AND $3
+	  AND source_type <> $4
+	  AND status       = 'active'
+	LIMIT 1`
+
+// checkDuplicateArrival probes for an existing active document with the same
+// title and an occurred_at within duplicateArrivalWindow, but a different
+// source_type. It logs a warning and increments duplicateArrivalGuardHits
+// when found; it never blocks or errors the caller's upsert.
+//
+// Skipped entirely (no query) when Title or OccurredAt is empty/nil — most
+// collectors that don't carry an event time (uploads, some notes) would
+// otherwise pay for a query that can never usefully match, and an empty
+// title would turn the equality predicate into a match against every
+// title-less document.
+func (s *DocumentStore) checkDuplicateArrival(ctx context.Context, doc *model.Document) {
+	if doc.Title == "" || doc.OccurredAt == nil {
+		return
+	}
+	from := doc.OccurredAt.Add(-duplicateArrivalWindow)
+	to := doc.OccurredAt.Add(duplicateArrivalWindow)
+
+	var existingSource string
+	err := s.pg.pool.QueryRow(ctx, duplicateArrivalCheckQuery,
+		doc.Title, from, to, string(doc.SourceType),
+	).Scan(&existingSource)
+
+	switch {
+	case err == nil:
+		atomic.AddInt64(&duplicateArrivalGuardHits, 1)
+		// title itself is never logged — only its length — per this repo's
+		// policy against logging raw user content (see agent memory
+		// feedback_never_log_raw_llm_output).
+		slog.Warn("store: possible cross-source duplicate arrival",
+			"incoming_source_type", doc.SourceType,
+			"existing_source_type", existingSource,
+			"title_len", len(doc.Title),
+			"occurred_at", doc.OccurredAt,
+		)
+	case isNoRows(err):
+		// No cross-source duplicate found — the common case, nothing to do.
+	default:
+		// The probe itself is best-effort: a failure here (e.g. a transient
+		// connection issue) must never fail the caller's actual write.
+		slog.Warn("store: duplicate-arrival guard query failed (non-blocking)", "error", err)
+	}
+}

--- a/internal/store/document_source_guard_test.go
+++ b/internal/store/document_source_guard_test.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/baekenough/second-brain/internal/model"
+)
+
+// TestCheckSourceTypeGuard_Container verifies that a container source_type
+// (secretary) increments only the container counter, and that the
+// deprecated/unknown counters stay at zero.
+func TestCheckSourceTypeGuard_Container(t *testing.T) {
+	resetSourceGuardCountersForTest()
+
+	checkSourceTypeGuard(&model.Document{SourceType: model.SourceSecretary})
+
+	container, deprecated, unknown := SourceTypeGuardStats()
+	if container != 1 {
+		t.Errorf("container hits = %d, want 1", container)
+	}
+	if deprecated != 0 || unknown != 0 {
+		t.Errorf("deprecated/unknown hits = %d/%d, want 0/0", deprecated, unknown)
+	}
+}
+
+// TestCheckSourceTypeGuard_Deprecated verifies that a deprecated source_type
+// (llm-memory) increments only the deprecated counter.
+func TestCheckSourceTypeGuard_Deprecated(t *testing.T) {
+	resetSourceGuardCountersForTest()
+
+	checkSourceTypeGuard(&model.Document{
+		SourceType: model.SourceLLMMemory,
+		SourceID:   "zz-test-source-id",
+		Metadata:   map[string]any{"kind": "session", "device_id": "macmini"},
+	})
+
+	container, deprecated, unknown := SourceTypeGuardStats()
+	if deprecated != 1 {
+		t.Errorf("deprecated hits = %d, want 1", deprecated)
+	}
+	if container != 0 || unknown != 0 {
+		t.Errorf("container/unknown hits = %d/%d, want 0/0", container, unknown)
+	}
+}
+
+// TestCheckSourceTypeGuard_Unknown verifies that a source_type outside
+// model.KnownSourceTypes and not a container/deprecated type increments only
+// the unknown counter. SourceSlack is used because it is a declared
+// model.SourceType const that is intentionally NOT in KnownSourceTypes (see
+// that function's doc comment — dormant integrations).
+func TestCheckSourceTypeGuard_Unknown(t *testing.T) {
+	resetSourceGuardCountersForTest()
+
+	checkSourceTypeGuard(&model.Document{SourceType: model.SourceSlack})
+
+	container, deprecated, unknown := SourceTypeGuardStats()
+	if unknown != 1 {
+		t.Errorf("unknown hits = %d, want 1", unknown)
+	}
+	if container != 0 || deprecated != 0 {
+		t.Errorf("container/deprecated hits = %d/%d, want 0/0", container, deprecated)
+	}
+}
+
+// TestCheckSourceTypeGuard_KnownTypesDoNotFire verifies that every known
+// source_type is a complete no-op: no counter moves. This is the guard's
+// most important behaviour — false positives on legitimate writes would
+// flood logs and erode trust in the warning.
+func TestCheckSourceTypeGuard_KnownTypesDoNotFire(t *testing.T) {
+	for _, st := range model.KnownSourceTypes() {
+		st := st
+		t.Run(string(st), func(t *testing.T) {
+			resetSourceGuardCountersForTest()
+
+			checkSourceTypeGuard(&model.Document{SourceType: st})
+
+			container, deprecated, unknown := SourceTypeGuardStats()
+			if container != 0 || deprecated != 0 || unknown != 0 {
+				t.Errorf("known source_type %q fired a guard: container=%d deprecated=%d unknown=%d",
+					st, container, deprecated, unknown)
+			}
+		})
+	}
+}
+
+// TestMetadataStringField covers the nil-map, missing-key, wrong-type, and
+// happy-path branches of metadataStringField — the helper that keeps
+// checkSourceTypeGuard's deprecated-type log line from panicking on
+// unexpected metadata shapes.
+func TestMetadataStringField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    map[string]any
+		key  string
+		want string
+	}{
+		{"nil map", nil, "kind", ""},
+		{"missing key", map[string]any{"other": "x"}, "kind", ""},
+		{"wrong type", map[string]any{"kind": 42}, "kind", ""},
+		{"happy path", map[string]any{"kind": "session"}, "kind", "session"},
+		{"empty string value", map[string]any{"kind": ""}, "kind", ""},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := metadataStringField(tc.m, tc.key); got != tc.want {
+				t.Errorf("metadataStringField(%v, %q) = %q, want %q", tc.m, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDuplicateArrivalCheckQuery_SQLFragments is a structural (no-DB) test
+// mirroring the existing callTranscriptDupCheckQuery test pattern in
+// document_transcript_dedup_test.go: it pins the clauses that make the guard
+// correct without requiring a live database.
+func TestDuplicateArrivalCheckQuery_SQLFragments(t *testing.T) {
+	t.Parallel()
+
+	required := []struct {
+		fragment string
+		reason   string
+	}{
+		{"title       = $1", "must match on exact title"},
+		{"occurred_at BETWEEN $2 AND $3", "must use an indexed range comparison on occurred_at"},
+		{"source_type <> $4", "must exclude the incoming document's own source_type"},
+		{"status       = 'active'", "must ignore soft-deleted/moved documents"},
+		{"LIMIT 1", "must be a cheap existence probe, not a full match"},
+	}
+
+	for _, tc := range required {
+		tc := tc
+		t.Run(tc.reason, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(duplicateArrivalCheckQuery, tc.fragment) {
+				t.Errorf("duplicateArrivalCheckQuery missing %q (%s)\nfull query:\n%s",
+					tc.fragment, tc.reason, duplicateArrivalCheckQuery)
+			}
+		})
+	}
+}

--- a/internal/store/document_source_normalization_db_test.go
+++ b/internal/store/document_source_normalization_db_test.go
@@ -1,0 +1,453 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/model"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Real-database verification of migrations/027_secretary_source_normalization.sql
+// and the duplicate-arrival guard query (internal/store/document_source_guard.go).
+//
+// This repo has already shipped SQL that compiled, passed stub tests, and
+// failed at runtime (EXCLUDED referenced inside RETURNING — see agent memory
+// feedback_postgres_returning_excluded). Migration 027's safety guards
+// (collision re-check, volume threshold, transactional rollback) are exactly
+// the kind of logic that a stub test cannot verify: it has to actually run
+// against PostgreSQL to prove the abort paths really abort and really roll
+// back.
+//
+// Skipped unless TEST_DATABASE_URL is set — see srcTestDB in
+// document_source_types_db_test.go, which this file reuses. TEST_DATABASE_URL
+// must NEVER point at production; run a throwaway container instead. Rows are
+// scoped by the sentinel source_id prefix below and removed in t.Cleanup.
+// ---------------------------------------------------------------------------
+
+// normTestPrefix scopes both the seeded rows and the cleanup DELETE for this
+// file's tests, distinct from srcTestPrefix so the two test files' cleanups
+// never interfere with each other's fixtures.
+const normTestPrefix = "zz-dummy-norm027-"
+
+// normTestDB returns a *Postgres for TEST_DATABASE_URL, reusing srcTestDB's
+// schema bootstrap (document_source_types_db_test.go, same package) and
+// adding this file's own cleanup scope.
+func normTestDB(t *testing.T) *Postgres {
+	t.Helper()
+	pg := srcTestDB(t) // ensures schema exists; registers its own cleanup for srcTestPrefix rows
+	t.Cleanup(func() {
+		_, _ = pg.pool.Exec(context.Background(),
+			`DELETE FROM documents WHERE source_id LIKE $1`, normTestPrefix+"%")
+	})
+	return pg
+}
+
+// migrationSQL reads a migration file relative to this test file's package
+// directory (internal/store -> ../../migrations). Reading the real file,
+// rather than re-typing its SQL inline, means this test exercises exactly
+// what RunMigrations would execute in production — a copy would drift.
+func migrationSQL(t *testing.T, filename string) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "migrations", filename)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration %q: %v", path, err)
+	}
+	return string(b)
+}
+
+// seedSecretaryDoc inserts a throwaway source_type='secretary' document with
+// the given metadata->>'kind' and title. occurredAt may be nil.
+func seedSecretaryDoc(t *testing.T, pg *Postgres, kind, titleSuffix string, occurredAt *time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	meta, err := json.Marshal(map[string]any{"kind": kind})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	_, err = pg.pool.Exec(context.Background(), `
+		INSERT INTO documents (id, source_type, source_id, title, content, metadata, occurred_at, collected_at)
+		VALUES ($1, 'secretary', $2, $3, 'zzdummy sentinel body', $4, $5, now())`,
+		id, normTestPrefix+id.String(), "zzdummy "+titleSuffix, meta, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("seed secretary document (kind=%s): %v", kind, err)
+	}
+	return id
+}
+
+// TestDB_Migration027_NormalizesKnownKinds verifies the core rewrite: each
+// secretary document whose metadata->>'kind' is one of the five known kinds
+// is re-typed to that kind, and metadata.legacy_source_type='secretary' is
+// stamped so the change is reversible.
+func TestDB_Migration027_NormalizesKnownKinds(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	gmailID := seedSecretaryDoc(t, pg, "gmail", "gmail-doc", nil)
+	smsID := seedSecretaryDoc(t, pg, "sms", "sms-doc", nil)
+	callLogID := seedSecretaryDoc(t, pg, "call-log", "call-log-doc", nil)
+	callTranscriptID := seedSecretaryDoc(t, pg, "call-transcript", "call-transcript-doc", nil)
+	calendarID := seedSecretaryDoc(t, pg, "calendar", "calendar-doc", nil)
+
+	sql := migrationSQL(t, "027_secretary_source_normalization.sql")
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 027: %v", err)
+	}
+
+	cases := []struct {
+		id       uuid.UUID
+		wantType string
+	}{
+		{gmailID, "gmail"},
+		{smsID, "sms"},
+		{callLogID, "call-log"},
+		{callTranscriptID, "call-transcript"},
+		{calendarID, "calendar"},
+	}
+	for _, tc := range cases {
+		var sourceType string
+		var metaRaw []byte
+		err := pg.pool.QueryRow(ctx,
+			`SELECT source_type, metadata FROM documents WHERE id = $1`, tc.id,
+		).Scan(&sourceType, &metaRaw)
+		if err != nil {
+			t.Fatalf("fetch %s: %v", tc.id, err)
+		}
+		if sourceType != tc.wantType {
+			t.Errorf("document %s: source_type = %q, want %q", tc.id, sourceType, tc.wantType)
+		}
+		var meta map[string]any
+		if err := json.Unmarshal(metaRaw, &meta); err != nil {
+			t.Fatalf("unmarshal metadata for %s: %v", tc.id, err)
+		}
+		if meta["legacy_source_type"] != "secretary" {
+			t.Errorf("document %s: metadata.legacy_source_type = %v, want \"secretary\"", tc.id, meta["legacy_source_type"])
+		}
+		if meta["kind"] != tc.wantType {
+			t.Errorf("document %s: metadata.kind = %v, want %q (must be preserved, not overwritten)", tc.id, meta["kind"], tc.wantType)
+		}
+	}
+}
+
+// TestDB_Migration027_LeavesLLMMemoryAndUnknownKindAlone verifies the two
+// deliberate exclusions: metadata->>'kind'='llm-memory' and a kind outside
+// the five recognised values are both left as source_type='secretary'.
+func TestDB_Migration027_LeavesLLMMemoryAndUnknownKindAlone(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	llmMemID := seedSecretaryDoc(t, pg, "llm-memory", "llm-memory-doc", nil)
+	unknownKindID := seedSecretaryDoc(t, pg, "some-future-kind", "unknown-kind-doc", nil)
+
+	sql := migrationSQL(t, "027_secretary_source_normalization.sql")
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 027: %v", err)
+	}
+
+	for _, id := range []uuid.UUID{llmMemID, unknownKindID} {
+		var sourceType string
+		if err := pg.pool.QueryRow(ctx,
+			`SELECT source_type FROM documents WHERE id = $1`, id,
+		).Scan(&sourceType); err != nil {
+			t.Fatalf("fetch %s: %v", id, err)
+		}
+		if sourceType != "secretary" {
+			t.Errorf("document %s: source_type = %q, want unchanged \"secretary\"", id, sourceType)
+		}
+	}
+}
+
+// TestDB_Migration027_Idempotent verifies that running the migration a
+// second time is a no-op: the WHERE source_type='secretary' predicate no
+// longer matches rows the first run already re-typed.
+func TestDB_Migration027_Idempotent(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	gmailID := seedSecretaryDoc(t, pg, "gmail", "idempotent-doc", nil)
+
+	sql := migrationSQL(t, "027_secretary_source_normalization.sql")
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 027 (first pass): %v", err)
+	}
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 027 (second pass): %v", err)
+	}
+
+	var sourceType, updatedAt1 string
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT source_type, updated_at::text FROM documents WHERE id = $1`, gmailID,
+	).Scan(&sourceType, &updatedAt1); err != nil {
+		t.Fatalf("fetch after second pass: %v", err)
+	}
+	if sourceType != "gmail" {
+		t.Errorf("after two migration runs, source_type = %q, want \"gmail\"", sourceType)
+	}
+}
+
+// TestDB_Migration027_AbortsOnCollision verifies the collision guard: when a
+// candidate's (kind, source_id) pair already exists as a real document, the
+// entire migration rolls back — the candidate must remain untouched as
+// source_type='secretary'.
+func TestDB_Migration027_AbortsOnCollision(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	// Seed the secretary candidate AND a pre-existing gmail document sharing
+	// the exact same source_id — the collision the guard is designed to catch.
+	id := uuid.New()
+	sourceID := normTestPrefix + id.String()
+	meta, _ := json.Marshal(map[string]any{"kind": "gmail"})
+	_, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, metadata, collected_at)
+		VALUES ($1, 'secretary', $2, 'zzdummy collision candidate', 'body', $3, now())`,
+		id, sourceID, meta,
+	)
+	if err != nil {
+		t.Fatalf("seed collision candidate: %v", err)
+	}
+	collidingID := uuid.New()
+	_, err = pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, metadata, collected_at)
+		VALUES ($1, 'gmail', $2, 'zzdummy pre-existing gmail doc', 'body', '{}'::jsonb, now())`,
+		collidingID, sourceID,
+	)
+	if err != nil {
+		t.Fatalf("seed pre-existing colliding gmail document: %v", err)
+	}
+
+	sql := migrationSQL(t, "027_secretary_source_normalization.sql")
+	_, err = pg.pool.Exec(ctx, sql)
+	if err == nil {
+		t.Fatal("expected migration to fail (RAISE EXCEPTION) on collision, got nil error")
+	}
+
+	// The candidate must remain untouched — the abort must have rolled back
+	// the whole DO block, not partially applied it.
+	var sourceType string
+	if scanErr := pg.pool.QueryRow(ctx,
+		`SELECT source_type FROM documents WHERE id = $1`, id,
+	).Scan(&sourceType); scanErr != nil {
+		t.Fatalf("fetch candidate after aborted migration: %v", scanErr)
+	}
+	if sourceType != "secretary" {
+		t.Errorf("candidate source_type = %q after aborted migration, want unchanged \"secretary\" (rollback failed)", sourceType)
+	}
+}
+
+// TestDB_DuplicateArrivalCheckQuery_DetectsCrossSourceMatch runs the exact
+// duplicateArrivalCheckQuery against a live database, proving the (title,
+// occurred_at) index-friendly predicate actually matches a same-title,
+// near-in-time, different-source_type document — and does NOT match when the
+// source_type is the same or the title/time differ.
+func TestDB_DuplicateArrivalCheckQuery_DetectsCrossSourceMatch(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	occurredAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	title := "zzdummy duplicate-arrival subject"
+
+	// Existing gmail document.
+	gmailDocID := uuid.New()
+	_, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, occurred_at, collected_at)
+		VALUES ($1, 'gmail', $2, $3, 'body', $4, now())`,
+		gmailDocID, normTestPrefix+gmailDocID.String(), title, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("seed existing gmail document: %v", err)
+	}
+
+	// Case 1: an incoming 'secretary' document with the same title, 60s later
+	// (inside the 120s window), different source_type -> must match.
+	var existingSource string
+	scanErr := pg.pool.QueryRow(ctx, duplicateArrivalCheckQuery,
+		title, occurredAt.Add(-duplicateArrivalWindow), occurredAt.Add(duplicateArrivalWindow),
+		"secretary",
+	).Scan(&existingSource)
+	if scanErr != nil {
+		t.Fatalf("expected a cross-source match, got error: %v", scanErr)
+	}
+	if existingSource != "gmail" {
+		t.Errorf("existingSource = %q, want \"gmail\"", existingSource)
+	}
+
+	// Case 2: same source_type as the existing document ('gmail') -> must NOT
+	// match (this is what ON CONFLICT already handles; the guard should not
+	// also fire for it).
+	scanErr = pg.pool.QueryRow(ctx, duplicateArrivalCheckQuery,
+		title, occurredAt.Add(-duplicateArrivalWindow), occurredAt.Add(duplicateArrivalWindow),
+		"gmail",
+	).Scan(&existingSource)
+	if !isNoRows(scanErr) {
+		t.Errorf("expected no match for the same source_type, got existingSource=%q err=%v", existingSource, scanErr)
+	}
+
+	// Case 3: different title -> must NOT match.
+	scanErr = pg.pool.QueryRow(ctx, duplicateArrivalCheckQuery,
+		"zzdummy an entirely different subject",
+		occurredAt.Add(-duplicateArrivalWindow), occurredAt.Add(duplicateArrivalWindow),
+		"secretary",
+	).Scan(&existingSource)
+	if !isNoRows(scanErr) {
+		t.Errorf("expected no match for a different title, got existingSource=%q err=%v", existingSource, scanErr)
+	}
+}
+
+// TestDB_CheckDuplicateArrival_LogsWithoutBlocking exercises
+// (*DocumentStore).checkDuplicateArrival directly, confirming it increments
+// the package counter on a match and never panics/blocks regardless of
+// outcome.
+func TestDB_CheckDuplicateArrival_LogsWithoutBlocking(t *testing.T) {
+	pg := normTestDB(t)
+	store := NewDocumentStore(pg)
+	ctx := context.Background()
+	resetSourceGuardCountersForTest()
+
+	occurredAt := time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC)
+	title := "zzdummy checkDuplicateArrival direct call"
+
+	existingID := uuid.New()
+	_, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, occurred_at, collected_at)
+		VALUES ($1, 'gmail', $2, $3, 'body', $4, now())`,
+		existingID, normTestPrefix+existingID.String(), title, occurredAt,
+	)
+	if err != nil {
+		t.Fatalf("seed existing document: %v", err)
+	}
+
+	incoming := &model.Document{
+		SourceType: model.SourceSecretary,
+		Title:      title,
+		OccurredAt: &occurredAt,
+	}
+	store.checkDuplicateArrival(ctx, incoming)
+
+	if hits := DuplicateArrivalGuardHits(); hits != 1 {
+		t.Errorf("DuplicateArrivalGuardHits() = %d, want 1 after a matching call", hits)
+	}
+
+	// A second call with no title/occurred_at must be a no-op (skipped
+	// entirely, no query) and must not increment the counter or error.
+	resetSourceGuardCountersForTest()
+	store.checkDuplicateArrival(ctx, &model.Document{SourceType: model.SourceUpload})
+	if hits := DuplicateArrivalGuardHits(); hits != 0 {
+		t.Errorf("DuplicateArrivalGuardHits() = %d, want 0 for a title-less/time-less document", hits)
+	}
+}
+
+// TestDB_Migration028_IndexCreatesSuccessfully verifies the supporting index
+// migration runs cleanly against the same schema.
+func TestDB_Migration028_IndexCreatesSuccessfully(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	sql := migrationSQL(t, "028_title_occurred_at_index.sql")
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 028: %v", err)
+	}
+	// Idempotent: CREATE INDEX IF NOT EXISTS must not error on re-run.
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 028 (second pass): %v", err)
+	}
+
+	var exists bool
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_documents_title_occurred_at')`,
+	).Scan(&exists); err != nil {
+		t.Fatalf("check index existence: %v", err)
+	}
+	if !exists {
+		t.Error("idx_documents_title_occurred_at was not created")
+	}
+}
+
+// TestDB_Migration029_ReportsResidualLLMMemoryWithoutMutating verifies the
+// census migration never deletes or reclassifies rows, regardless of count.
+func TestDB_Migration029_ReportsResidualLLMMemoryWithoutMutating(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	id := uuid.New()
+	_, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, collected_at)
+		VALUES ($1, 'llm-memory', $2, 'zzdummy residual llm-memory doc', 'body', now())`,
+		id, normTestPrefix+id.String(),
+	)
+	if err != nil {
+		t.Fatalf("seed residual llm-memory document: %v", err)
+	}
+
+	sql := migrationSQL(t, "029_llm_memory_residual_check.sql")
+	if _, err := pg.pool.Exec(ctx, sql); err != nil {
+		t.Fatalf("run migration 029: %v", err)
+	}
+
+	var sourceType, status string
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT source_type, status FROM documents WHERE id = $1`, id,
+	).Scan(&sourceType, &status); err != nil {
+		t.Fatalf("fetch after migration 029: %v", err)
+	}
+	if sourceType != "llm-memory" {
+		t.Errorf("source_type = %q after migration 029, want unchanged \"llm-memory\"", sourceType)
+	}
+	if status != "active" {
+		t.Errorf("status = %q after migration 029, want unchanged \"active\" (must not soft-delete)", status)
+	}
+}
+
+// TestDB_Migration027_AbortsOnVolumeThreshold verifies the second safety
+// guard: when the candidate row count exceeds the 18400 threshold, the
+// migration aborts (RAISE EXCEPTION) and rolls back rather than normalizing
+// an unexpectedly large batch. 18401 rows are bulk-seeded via generate_series
+// so the test stays fast even though it deliberately exceeds the threshold.
+func TestDB_Migration027_AbortsOnVolumeThreshold(t *testing.T) {
+	pg := normTestDB(t)
+	ctx := context.Background()
+
+	const seedCount = 18401
+	_, err := pg.pool.Exec(ctx, `
+		INSERT INTO documents (id, source_type, source_id, title, content, metadata, collected_at)
+		SELECT
+			gen_random_uuid(),
+			'secretary',
+			$1 || gen_random_uuid()::text,
+			'zzdummy volume-threshold doc',
+			'body',
+			'{"kind":"gmail"}'::jsonb,
+			now()
+		FROM generate_series(1, $2)`,
+		normTestPrefix, seedCount,
+	)
+	if err != nil {
+		t.Fatalf("bulk-seed %d candidate documents: %v", seedCount, err)
+	}
+
+	sql := migrationSQL(t, "027_secretary_source_normalization.sql")
+	if _, err := pg.pool.Exec(ctx, sql); err == nil {
+		t.Fatal("expected migration to fail (RAISE EXCEPTION) when candidates exceed 18400, got nil error")
+	}
+
+	// Rollback must be total: none of the bulk-seeded rows should have been
+	// re-typed away from 'secretary'.
+	var stillSecretary int64
+	if err := pg.pool.QueryRow(ctx,
+		`SELECT count(*) FROM documents WHERE source_type = 'secretary' AND source_id LIKE $1`,
+		normTestPrefix+"%",
+	).Scan(&stillSecretary); err != nil {
+		t.Fatalf("count remaining secretary rows: %v", err)
+	}
+	if stillSecretary != seedCount {
+		t.Errorf("after aborted migration, %d/%d rows remain source_type='secretary'; want all %d (full rollback)",
+			stillSecretary, seedCount, seedCount)
+	}
+}

--- a/internal/store/migration_027_sql_test.go
+++ b/internal/store/migration_027_sql_test.go
@@ -1,0 +1,103 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMigration027SQL_ContainsSafetyGuards is a structural (no-DB) test,
+// mirroring the existing callTranscriptDupCheckQuery / advisory-lock SQL
+// tests in this package: it pins the literal safety-guard clauses in
+// migrations/027_secretary_source_normalization.sql so a future edit cannot
+// silently drop the collision check, the volume threshold, or the
+// reversibility marker without a test failure — independent of whether
+// TEST_DATABASE_URL is set.
+func TestMigration027SQL_ContainsSafetyGuards(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "migrations", "027_secretary_source_normalization.sql")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration 027: %v", err)
+	}
+	sql := string(b)
+
+	required := []struct {
+		fragment string
+		reason   string
+	}{
+		{"RAISE EXCEPTION", "an aborted safety check must actually abort the transaction, not just log"},
+		{"18400", "the volume safety threshold must be present and match the documented margin over 18328"},
+		{"legacy_source_type", "the original source_type must be preserved in metadata for reversibility"},
+		{"'gmail', 'sms', 'call-log', 'call-transcript', 'calendar'", "the kind allowlist must be the exact five normalized kinds, excluding llm-memory"},
+		{"source_type = 'secretary'", "the UPDATE must be scoped to secretary documents only"},
+	}
+	for _, tc := range required {
+		tc := tc
+		t.Run(tc.reason, func(t *testing.T) {
+			t.Parallel()
+			if !strings.Contains(sql, tc.fragment) {
+				t.Errorf("migration 027 missing %q (%s)", tc.fragment, tc.reason)
+			}
+		})
+	}
+
+	// llm-memory must never appear inside the UPDATE's kind allowlist — it is
+	// only referenced in prose comments, never in the executable WHERE/IN list.
+	if strings.Contains(sql, "'llm-memory', 'gmail'") || strings.Contains(sql, "'gmail', 'llm-memory'") {
+		t.Error("migration 027's kind allowlist must not include llm-memory")
+	}
+}
+
+// TestMigration028SQL_IsIdempotentAndPartial pins the CREATE INDEX IF NOT
+// EXISTS + partial-index clauses that keep the supporting index cheap and
+// safe to re-run.
+func TestMigration028SQL_IsIdempotentAndPartial(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "migrations", "028_title_occurred_at_index.sql")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration 028: %v", err)
+	}
+	sql := string(b)
+
+	required := []string{
+		"CREATE INDEX IF NOT EXISTS",
+		"(title, occurred_at)",
+		"WHERE status = 'active'",
+	}
+	for _, fragment := range required {
+		if !strings.Contains(sql, fragment) {
+			t.Errorf("migration 028 missing %q", fragment)
+		}
+	}
+}
+
+// TestMigration029SQL_NeverMutates pins that the residual llm-memory check
+// contains no UPDATE/DELETE — it must be read-only.
+func TestMigration029SQL_NeverMutates(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("..", "..", "migrations", "029_llm_memory_residual_check.sql")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration 029: %v", err)
+	}
+	sql := string(b)
+
+	// Checked against actual DML statement heads (case-sensitive, this repo's
+	// SQL style always uppercases keywords — see migrations/027) rather than a
+	// blanket case-insensitive substring search, which would false-positive on
+	// prose comments like "this migration does not delete or reclassify them".
+	for _, forbidden := range []string{"UPDATE documents", "DELETE FROM documents", "INSERT INTO documents"} {
+		if strings.Contains(sql, forbidden) {
+			t.Errorf("migration 029 must be read-only but contains %q", forbidden)
+		}
+	}
+	if !strings.Contains(sql, "RAISE NOTICE") {
+		t.Error("migration 029 must report its count via RAISE NOTICE")
+	}
+}

--- a/migrations/027_secretary_source_normalization.sql
+++ b/migrations/027_secretary_source_normalization.sql
@@ -1,0 +1,152 @@
+-- Migration 027: Normalize source_type='secretary' into its real, per-kind
+-- source types (gmail, sms, call-log, call-transcript, calendar).
+--
+-- Background:
+--   'secretary' is not a real source — it is a legacy container populated by
+--   the decommissioned secretary collector (torn down, see project history)
+--   that mixed six unrelated kinds of content under one source_type:
+--
+--     metadata->>'kind'   count (measured in production, 2026-08-25)
+--     ------------------- -----
+--     gmail                10096
+--     call-transcript       3381
+--     sms                   2807
+--     call-log              2002
+--     calendar                41
+--     llm-memory               1
+--     -------------------------
+--     total                18328
+--
+--   Because 'secretary' is a single source_type, it cannot be split by the
+--   search source-type filter (internal/search) or routed selectively by the
+--   query planner (docs/superpowers/specs/2026-08-19-query-planner-design.md).
+--   A query for "최근 받은 문자" (recent texts) or "누구와 통화했는지" (who I
+--   called) returns an undifferentiated 'secretary' bucket instead of sms /
+--   call-log / call-transcript, and 'secretary' ends up crowding out the
+--   genuine post-cutover gmail/sms/call-log/call-transcript documents in
+--   ranked results.
+--
+-- Safety verified before writing this migration:
+--   A production audit of UNIQUE (source_type, source_id) collisions between
+--   each candidate's (new_source_type, source_id) and any EXISTING document
+--   already stored under that (source_type, source_id) found ZERO collisions
+--   across every kind. This holds because source_id already carries a
+--   kind-specific namespace prefix (e.g. "gmail:1965c1008ab534f3",
+--   "sms:<dateMs>:<addrHash>:<direction>") that is unique regardless of which
+--   source_type value currently wraps it. This migration re-verifies the
+--   collision count at execution time (Step 1) rather than trusting the
+--   earlier audit, because new secretary/gmail/etc documents may have been
+--   collected in between.
+--
+-- Scope:
+--   Only rows with source_type='secretary' AND metadata->>'kind' IN
+--   ('gmail','sms','call-log','call-transcript','calendar') are touched.
+--
+--   metadata->>'kind' = 'llm-memory' (1 row) is INTENTIONALLY EXCLUDED from
+--   the WHERE clause below and left as source_type='secretary'. Reasoning:
+--   the llm-memory *source* (internal/collector/llm_memory.go, MCP
+--   add_note-authored memories) was already decommissioned separately and is
+--   unrelated in shape to this one secretary-collected row — normalizing it
+--   to 'llm-memory' would silently resurrect a retired source_type for a
+--   single legacy document, which is more confusing than leaving it in the
+--   container it has always lived in. It is not deleted: deleting content on
+--   a *classification* migration is out of scope and would be an
+--   irreversible, unrelated side effect.
+--
+--   Rows with no metadata->>'kind', or a kind outside the five listed above,
+--   are not matched by the WHERE clause and are left completely untouched.
+--
+-- Idempotency:
+--   Re-running this migration is a no-op on the second pass: once a row's
+--   source_type is updated away from 'secretary', the WHERE source_type =
+--   'secretary' predicate no longer matches it. Unlike migration 019 (which
+--   restructured source_id and could produce new collisions on re-run), this
+--   migration only ever narrows its own candidate set, so idempotency does
+--   not depend on any additional guard.
+--
+-- Reversibility:
+--   The original source_type is preserved before being overwritten, via
+--   metadata['legacy_source_type'] = 'secretary'. To revert a specific
+--   document:
+--     UPDATE documents
+--     SET source_type = metadata->>'legacy_source_type'
+--     WHERE id = '<uuid>' AND metadata ? 'legacy_source_type';
+--   (legacy_source_type is intentionally left in metadata after revert too —
+--   it is a historical marker, not a mutable working field.)
+--
+-- Generated columns / other tables (verified, no action needed):
+--   - documents.tsv is `GENERATED ALWAYS AS (... to_tsvector(title/content) ...)
+--     STORED` (see migrations/001_init.sql). It depends only on title and
+--     content, neither of which this migration touches, so tsv is byte-for-byte
+--     unchanged by this migration and needs no explicit refresh.
+--   - chunks references documents only via document_id (see migrations/004_chunks.sql);
+--     it carries no copy of source_type, so it needs no update here.
+--
+-- Safety guards (abort = full ROLLBACK, since the DO block runs in one
+-- implicit transaction):
+--   1. Collision guard: if ANY candidate's (new_source_type, source_id) pair
+--      already exists as an active-or-not document, abort. A collision here
+--      would violate the UNIQUE (source_type, source_id) constraint and
+--      indicates the zero-collision assumption above no longer holds.
+--   2. Volume guard: if the candidate row count exceeds 18400 (a small margin
+--      over the 18328 measured at audit time — this repo has consistently
+--      used "current known volume + small margin" as its runaway-match
+--      threshold, see migration 019), abort. A count above this signals the
+--      WHERE clause is matching more than the known secretary corpus, which
+--      is a sign of an unrelated schema or data change since this migration
+--      was written, not a legitimate reason to proceed.
+
+DO $$
+DECLARE
+    v_conflicts bigint := 0;
+    v_candidates bigint := 0;
+    v_updated bigint := 0;
+BEGIN
+
+    -- Step 1: Collision re-check. For every candidate row, does an existing
+    -- document already occupy (kind-as-source_type, source_id)? This is the
+    -- exact shape of the UNIQUE (source_type, source_id) constraint the
+    -- UPDATE in Step 3 would violate.
+    SELECT count(*) INTO v_conflicts
+    FROM documents c
+    JOIN documents d
+      ON d.source_type = (c.metadata ->> 'kind')
+     AND d.source_id   = c.source_id
+    WHERE c.source_type = 'secretary'
+      AND c.metadata ->> 'kind' IN ('gmail', 'sms', 'call-log', 'call-transcript', 'calendar');
+
+    IF v_conflicts > 0 THEN
+        RAISE NOTICE 'secretary source normalization aborted: % (source_type, source_id) collision(s) detected between secretary candidates and existing documents — the zero-collision assumption no longer holds, review before re-running',
+            v_conflicts;
+        RAISE EXCEPTION 'secretary source normalization aborted: % collision(s)', v_conflicts;
+    END IF;
+
+    -- Step 2: Volume guard. Count the candidate set before touching anything.
+    SELECT count(*) INTO v_candidates
+    FROM documents
+    WHERE source_type = 'secretary'
+      AND metadata ->> 'kind' IN ('gmail', 'sms', 'call-log', 'call-transcript', 'calendar');
+
+    IF v_candidates > 18400 THEN
+        RAISE NOTICE 'secretary source normalization aborted: % candidate rows exceeds the 18400 safety threshold (18328 measured at audit time + margin) — review before re-running',
+            v_candidates;
+        RAISE EXCEPTION 'secretary source normalization aborted: % candidates exceeds threshold', v_candidates;
+    END IF;
+
+    -- Step 3: Normalize. Preserve the original source_type in metadata
+    -- ('legacy_source_type') before overwriting it with the per-kind value.
+    -- llm-memory and any kind-less/unrecognized-kind rows are excluded by the
+    -- WHERE clause and are not touched by this statement.
+    UPDATE documents
+    SET source_type = metadata ->> 'kind',
+        metadata    = metadata || jsonb_build_object('legacy_source_type', 'secretary'),
+        updated_at  = now()
+    WHERE source_type = 'secretary'
+      AND metadata ->> 'kind' IN ('gmail', 'sms', 'call-log', 'call-transcript', 'calendar');
+
+    GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+    RAISE NOTICE 'secretary source normalization: % of % candidate rows re-typed (gmail/sms/call-log/call-transcript/calendar); llm-memory (1 row) and kind-less/unrecognized rows left as secretary',
+        v_updated, v_candidates;
+
+END $$;

--- a/migrations/028_title_occurred_at_index.sql
+++ b/migrations/028_title_occurred_at_index.sql
@@ -1,0 +1,23 @@
+-- Migration 028: index supporting the cross-source duplicate-arrival guard.
+--
+-- Background: migration 027 found that 4,692 of the 10,096 secretary/gmail
+-- documents were already duplicated under source_type='gmail' with a
+-- matching title and occurred_at (within a small tolerance). To stop this
+-- class of duplication from recurring silently, internal/store now runs an
+-- indexed probe on every document upsert (see
+-- internal/store/document_source_guard.go checkDuplicateArrival):
+--
+--   SELECT source_type FROM documents
+--   WHERE title = $1 AND occurred_at BETWEEN $2 AND $3
+--     AND source_type <> $4 AND status = 'active'
+--   LIMIT 1
+--
+-- This index makes that probe an index range scan (equality on title,
+-- range on occurred_at) rather than a sequential scan over the whole table.
+-- It is scoped to status='active' (a partial index) because the guard only
+-- ever needs to detect an existing ACTIVE duplicate — deleted/moved rows are
+-- irrelevant to a "is this about to duplicate something live" check, and
+-- excluding them keeps the index smaller.
+CREATE INDEX IF NOT EXISTS idx_documents_title_occurred_at
+    ON documents (title, occurred_at)
+    WHERE status = 'active';

--- a/migrations/029_llm_memory_residual_check.sql
+++ b/migrations/029_llm_memory_residual_check.sql
@@ -1,0 +1,37 @@
+-- Migration 029: report (never delete) any remaining source_type='llm-memory'
+-- documents.
+--
+-- Background: source_type='llm-memory' was decommissioned on 2026-08-25 after
+-- 19,933 session-transcript documents (353,843 chunks, 76.5% of the corpus)
+-- were found to be crowding out real search results; those documents were
+-- purged and the memory-collector daemons that produced them were stopped on
+-- every machine that ran one (see model.SourceLLMMemory's doc comment in
+-- internal/model/document.go for the full account).
+--
+-- Separately, migration 027 (secretary source normalization) intentionally
+-- leaves the one metadata->>'kind'='llm-memory' secretary-routed document
+-- untouched rather than folding it into this source_type or deleting it.
+--
+-- This migration performs NO mutation. It only counts how many
+-- source_type='llm-memory' rows exist right now (across all statuses, so a
+-- soft-deleted remnant is not silently excluded from the count) and reports
+-- the number via RAISE NOTICE. Whether any such rows should be purged,
+-- reclassified, or left alone is a decision for a human reviewing the count
+-- and the individual rows — not something a migration should decide
+-- automatically. Deliberately idempotent: re-running only re-reports the
+-- current count and changes nothing.
+DO $$
+DECLARE
+    v_remaining bigint := 0;
+BEGIN
+    SELECT count(*) INTO v_remaining
+    FROM documents
+    WHERE source_type = 'llm-memory';
+
+    IF v_remaining > 0 THEN
+        RAISE NOTICE 'llm-memory residual check: % document(s) still carry source_type=''llm-memory'' — this source_type is deprecated (see model.SourceLLMMemory doc comment); review manually, this migration does not delete or reclassify them',
+            v_remaining;
+    ELSE
+        RAISE NOTICE 'llm-memory residual check: 0 documents remain under source_type=''llm-memory''';
+    END IF;
+END $$;


### PR DESCRIPTION
### 배경

RAG 검색 품질 저하의 원인을 진단한 결과 코퍼스 오염으로 확인됐다. 청크 462,591개 중 353,795개(76.5%)가 `llm-memory` 소스, 즉 Claude Code / Codex 세션 트랜스크립트였다. 해당 소스를 폐기하고, 이어서 macmini에 몰려 있던 컴퓨트를 ubuntu1로 이전했다.

### 변경 내용

`deploy/ubuntu1-stack/` 추가 (7개 파일):
- `docker-compose.yml` — server / collector / web / neo4j (postgres 는 2026-08-19에 이미 이전되어 별도 compose 프로젝트로 운영 중이라 제외)
- `sync-second-brain-data.sh` + systemd service/timer — macmini(OneDrive 게이트웨이)에서 10분 주기 데이터 pull
- `systemd/cloudflared-second-brain.service`, `cloudflared/config-second-brain.yml` — 터널 이전
- `README.md` — 구성, 기동 방법, 이전 과정에서 부딪힌 함정 4가지

### 운영 반영 상태 (이미 적용됨)

- ubuntu1에서 4개 컨테이너 정상 기동, `brain.baekenough.com/health` 200 / `sb.baekenough.com` 302(Access)
- 터널 ID 승계로 DNS 변경 없음. 전환 중단은 수 초.
- macmini 컨테이너 5개는 `docker stop` 상태이며 볼륨(postgres 이전 롤백본 포함) 보존
- DB: 12GB → 3.28GB, 청크 462,591 → 108,748
- 4대 합계 디스크 111GB 회수

### 이전 과정의 함정 (README 에 상세 기록)

1. macOS↔Linux uid 매핑 차이로 자격증명 권한 문제 (컨테이너 uid 10001 vs 파일 uid 1000)
2. macOS 는 openrsync 라 rsync 3.x 옵션(`--info`)을 주면 전송이 0바이트로 실패
3. neo4j 기동 순서에 따라 그래프 투영·읽기 API가 비활성으로 고정 (자동 재연결 없음)
4. `stage/sms` 는 내용이 없는 레거시 파일 — SMS 는 휴대폰 앱 직접 push 경로로 대체됨

### 미이전

- mcp 서비스 (`brain-mcp` ingress 502)
- eval-runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QFQauaHvHQW9Wzd2G9b3m

---

## 추가: 검색 품질 개선 (커밋 2개)

### 배경 — 실측 진단

RAG 품질 저하의 원인이 코퍼스에 있었다. 검색 청크 462,591개 중 353,795개(76.5%)가 `llm-memory`, 즉 Claude Code / Codex 세션 트랜스크립트였다(평균 35,930자, 최대 490,324자, `occurred_at` 전량 NULL). 정작 SMS·통화·전사는 0.5%였다. 이 소스는 폐기하고 수집 데몬을 4대 머신에서 정지했다.

그 다음 문제가 드러났다. `source_type='secretary'` 는 실제 소스가 아니라 gmail 10,096 / call-transcript 3,381 / sms 2,807 / call-log 2,002 / calendar 41 이 섞인 **컨테이너**였다. 검색 결과에서 소스를 구분할 수 없고 source_type 필터와 쿼리 플래너 라우팅이 무력화됐다.

### `867f6f6` — OpenSearch nori BM25 레인 (기본 비활성)

`pg_bigm`(bigram)은 형태소 경계를 무시한다. 프로덕션 실측: "회의" 질의에 865건이 걸리지만 형태소 경계 실제 매치는 184건(4.7배 과잉, "사회의"·"기회의" 등). nori 는 399건(복합어 "회의실"·"회의록" 포함).

OpenSearch 2.19.1 + analysis-nori 로 청크를 색인하고 RRF 융합에 레인을 추가했다. `OPENSEARCH_URL` 미설정 시 클라이언트가 생성되지 않아 기존 경로와 100% 동일하다. `model.SearchWeights` 는 건드리지 않았다(기존 청크 레인들도 가중치 시스템이 아니라 `mergeRRF` 로 융합되는 구조라 `search_weights_history` 직렬화에 영향 없음).

**측정 결과: 최종 검색 결과에 효과가 없었다.** 레인 ON/OFF 가 정밀도도 소스 분포도 한 건도 바꾸지 않았다. 버그는 아니다 — OpenSearch `_stats/search` 의 `query_total` 이 검색 5회에 정확히 5 증가하는 것을 확인했다. nori 가 걸러낸 오탐을 벡터 레인과 리랭커가 이미 교정하고 있었던 것으로 보인다. 컴포넌트 수준 개선이 시스템 수준 개선으로 이어지지 않은 사례다. 코드는 토글 가능한 상태로 남겨 두었고, 코퍼스가 커지거나 평가 세트가 생긴 뒤 재평가할 수 있다.

### `5304fe6` — secretary 소스 정규화 + 재발 방지

마이그레이션 027 이 `metadata->>'kind'` 기준으로 source_type 을 재분류한다. 안전장치: 실행 시점 UNIQUE 충돌 재검사(1건이라도 있으면 전체 롤백), 변경 행수 18,400 초과 시 롤백, 원래 값을 `metadata.legacy_source_type` 에 보존(되돌리기 가능), 멱등.

**프로덕션 적용 결과 (상위 10건 소스 분포, 전 → 후)**

| 질의 | 전 | 후 |
|---|---|---|
| 최근 받은 문자 | secretary 10 | **sms 10** |
| 누구와 통화했는지 | secretary 10 | **call-transcript 10** |
| 통화 내용 | secretary 7 / transcript 2 / gmail 1 | **call-transcript 6** / gmail 4 |
| 결제 확인 | secretary 10 | **gmail 8** / transcript 2 |
| 약속 시간 | secretary 7 / gmail 3 | **calendar 1** / transcript 2 / gmail 7 |

DB: secretary 18,328 → 1(llm-memory kind 1건만 의도적 잔존), gmail 6,561→16,657, call-transcript 582→3,963, sms 480→3,287, call-log 823→2,825. `legacy_source_type` 태그 18,327건.

**재발 방지**
- 마이그레이션 028: 중복 감지용 `(title, occurred_at)` 부분 인덱스
- 마이그레이션 029: llm-memory 잔존 건수 NOTICE (읽기 전용)
- `internal/model/source_validation.go`: 컨테이너/폐기/미상 타입 분류
- `internal/store/document_source_guard.go`: 저장 시점 검증 + 교차소스 중복 감지 — **하드 실패가 아니라 경고+카운터**. 휴면 컬렉터가 아직 컴파일되므로 하드 실패는 이들을 깨뜨리고, 오탐이 저장을 막으면 탐지 메커니즘이 유실 메커니즘이 된다.
- **MCP `add_note` 타입 분리**: 이 도구가 노트를 `source_type=llm-memory` 로 저장하고 있었다. 폐기한 타입이라 hermes 가 노트를 남길 때마다 되살아나는 구조였다. `agent-note` 로 분리했다.

### 검증

`go test ./...` (필터 없음) — PASS 1,242 / FAIL 0 / SKIP 46(`TEST_DATABASE_URL` 게이트, 기존부터 있던 스킵). 마이그레이션은 임시 PostgreSQL 컨테이너로 정규화·멱등성·충돌 시 롤백·상한 초과 시 롤백을 모두 검증했다.

### 배포 상태

ubuntu1 프로덕션에 이미 적용되어 9시간째 정상 가동 중이다. 컨테이너 8종 healthy, `brain.baekenough.com/health` 200, `sb.baekenough.com` 302(Access).
