### PR TITLE
fix(whisper): 통화 녹음 occurred_at을 파일명 UTC 타임스탬프로 파싱

### DIFF
--- a/internal/collector/whisper.go
+++ b/internal/collector/whisper.go
@@ -396,8 +396,30 @@ func labelTranscript(whisperSegs []whisperSegment, diarSegs []diarSegment) (cont
 //	e.g. 01025777190_20260327202518.m4a     →  2026-03-27 20:25:18
 //	     01025777190_20260327202518-1.m4a   →  2026-03-27 20:25:18  (suffix ignored)
 //
-// Times are parsed in time.Local so that the cutover comparison is meaningful
-// regardless of whether the cutover value was constructed in UTC or Local.
+// Both patterns are parsed as UTC, not time.Local. For Pattern B this is
+// empirically confirmed, not assumed: cross-referencing filename timestamps
+// against the independently-sourced, accurate call time in the matching
+// call-log document, the two agreed to the second across every sample
+// checked (2026-08-26 incident investigation — a delayed upload exposed a
+// filename-vs-mtime skew, and the filename/call-log cross-check is what
+// pinned the filename's UTC offset). Pattern A (Voice Recorder app) is
+// device-clock-sourced the same way but has no call-log counterpart to
+// cross-check against, so its UTC-ness is inferred by symmetry, not
+// independently verified.
+//
+// Parsing with time.Local instead is a latent bug, not a stylistic choice:
+// COLLECTOR_CUTOVER (internal/config/config.go's collectorCutover) is always
+// normalised to UTC via .UTC() before being handed to WithCutover, so
+// recordingTime's result is compared against an absolute UTC instant either
+// way (time.Time.Before/After compare instants, not Locations) — parsing
+// with time.Local silently computes the WRONG instant whenever the host's
+// local zone isn't UTC, shifting the comparison by the zone offset (9h for
+// KST). This shipped unnoticed for the same reason the OccurredAt bug did:
+// production's container runs with TZ unset (== UTC), so time.Local == UTC
+// there and the mistake was invisible until observed on a non-UTC host (a
+// KST dev machine) or exposed by a large enough skew. Do not revert this to
+// time.Local — see callRecordingOccurredAt's regression history for the
+// twin of this exact bug.
 var (
 	// reVoiceRecorder matches the 2-digit-year pattern at the END of the stem
 	// (before the extension), allowing arbitrary label characters before it.
@@ -407,30 +429,52 @@ var (
 	reTPhone = regexp.MustCompile(`_(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(?:-\d+)?(?:\.\w+)?$`)
 )
 
+// parseTPhoneFilenameUTC extracts and parses the reTPhone timestamp embedded
+// in filename (Pattern B — TPhoneCallRecords: <anything>_YYYYMMDDHHMMSS[-N].<ext>),
+// as UTC (see the UTC rationale on the var block above reTPhone).
+//
+// Returns (zero, false) when the filename does not match reTPhone, or when
+// the matched digits parse to an implausible date (isPlausibleRecordingTime)
+// — the filename is untrusted, device-controlled input, so a malformed or
+// spoofed value must never be reported as a real recording time.
+//
+// This is the single parsing path shared by recordingTime (Pattern B branch,
+// used for the cutover floor comparison) and callRecordingOccurredAt (used
+// for the stored OccurredAt field), so a future fix to the parsing itself
+// only needs to happen once. The two callers still diverge on fallback
+// POLICY — recordingTime falls back silently to mtime (then tries Pattern A),
+// callRecordingOccurredAt falls back to mtime with a log line and an
+// additional future-timestamp check — and that divergence is intentionally
+// left in each caller rather than folded in here.
+func parseTPhoneFilenameUTC(filename string) (time.Time, bool) {
+	m := reTPhone.FindStringSubmatch(filename)
+	if m == nil {
+		return time.Time{}, false
+	}
+	t := time.Date(atoi(m[1]), time.Month(atoi(m[2])), atoi(m[3]),
+		atoi(m[4]), atoi(m[5]), atoi(m[6]), 0, time.UTC)
+	if !isPlausibleRecordingTime(t) {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
 // recordingTime returns the recording timestamp for the given audio filename.
 //
 // It tries two filename patterns in order:
-//  1. TPhoneCallRecords: <anything>_YYYYMMDDHHMMSS[-N].<ext>
+//  1. TPhoneCallRecords: <anything>_YYYYMMDDHHMMSS[-N].<ext>  (via parseTPhoneFilenameUTC)
 //  2. Voice Recorder:   <label>_YYMMDD_HHMMSS.<ext>  (2-digit year, +2000)
 //
 // If neither pattern matches, or if the parsed date is clearly invalid,
 // the file's mtime is returned unchanged. This ensures files with
 // unparseable names continue to use the existing mtime-based cutover check.
 //
-// All parsed times are in time.Local.
+// All parsed times are UTC — see the UTC rationale on the var block above
+// reTPhone/reVoiceRecorder.
 func recordingTime(filename string, mtime time.Time) time.Time {
 	// Pattern B first (14-digit timestamp is unambiguous and more specific).
-	if m := reTPhone.FindStringSubmatch(filename); m != nil {
-		yr := atoi(m[1])
-		mo := atoi(m[2])
-		dy := atoi(m[3])
-		hr := atoi(m[4])
-		mn := atoi(m[5])
-		sc := atoi(m[6])
-		t := time.Date(yr, time.Month(mo), dy, hr, mn, sc, 0, time.Local)
-		if isPlausibleRecordingTime(t) {
-			return t
-		}
+	if t, ok := parseTPhoneFilenameUTC(filename); ok {
+		return t
 	}
 
 	// Pattern A: 2-digit year.
@@ -441,7 +485,7 @@ func recordingTime(filename string, mtime time.Time) time.Time {
 		hr := atoi(m[4])
 		mn := atoi(m[5])
 		sc := atoi(m[6])
-		t := time.Date(yr, time.Month(mo), dy, hr, mn, sc, 0, time.Local)
+		t := time.Date(yr, time.Month(mo), dy, hr, mn, sc, 0, time.UTC)
 		if isPlausibleRecordingTime(t) {
 			return t
 		}
@@ -468,6 +512,51 @@ func isPlausibleRecordingTime(t time.Time) bool {
 	return t.Year() >= 2000 && t.Year() <= 2100 &&
 		t.Month() >= 1 && t.Month() <= 12 &&
 		t.Day() >= 1 && t.Day() <= 31
+}
+
+// callRecordingOccurredAt returns the OccurredAt value for a TPhoneCallRecords
+// audio file: the actual call time, parsed from the filename's embedded
+// timestamp via parseTPhoneFilenameUTC, NOT the audio file's mtime.
+//
+// Bug this fixes: mtime is when the server SAVED the file, not when the call
+// happened. Normally the phone uploads within seconds of the call ending, so
+// the two are close enough that the difference went unnoticed. When upload is
+// delayed (e.g. a server permission outage — see the incident this function
+// was added for), mtime can lag the real call time by hours, producing a
+// wildly wrong OccurredAt (a 14:44 call recorded as 22:16).
+//
+// Parsing must stay UTC (see parseTPhoneFilenameUTC / the reTPhone var block
+// comment for the empirical evidence). Parsing with time.Local would be
+// silently wrong on any host whose local timezone is not UTC (e.g. a KST dev
+// machine) — this is not a hypothetical: recordingTime shipped exactly this
+// mistake for its cutover comparison, invisible in production only because
+// the container's TZ happens to be UTC. Do not reintroduce time.Local here
+// or in recordingTime.
+//
+// filename must be the base name (matches reTPhone usage elsewhere in this
+// file, e.g. isTPhoneCallPath). Falls back to mtime — logging why — when:
+//   - the filename does not match the reTPhone pattern, or the matched
+//     digits fail isPlausibleRecordingTime (legacy/foreign file names, or a
+//     malformed timestamp — both handled by parseTPhoneFilenameUTC),
+//   - the parsed timestamp is in the future relative to now.
+//
+// The filename is attacker/device-controlled input from the phone, not
+// trusted data — the future check exists because a malformed or spoofed
+// filename must never silently produce a bogus OccurredAt.
+func callRecordingOccurredAt(filename string, mtime, now time.Time) time.Time {
+	t, ok := parseTPhoneFilenameUTC(filename)
+	if !ok {
+		slog.Debug("whisper: filename has no usable embedded call timestamp — using mtime for occurred_at",
+			"filename", filename, "mtime", mtime)
+		return mtime
+	}
+	if t.After(now) {
+		slog.Warn("whisper: filename timestamp is in the future — using mtime for occurred_at",
+			"filename", filename, "parsed", t, "now", now, "mtime", mtime)
+		return mtime
+	}
+
+	return t
 }
 
 // WhisperCollector transcribes audio files via an OpenAI-compatible Whisper
@@ -1268,6 +1357,10 @@ func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTransc
 	}
 
 	mtime := item.info.ModTime().UTC()
+	// occurredAt is the actual call time, parsed from the filename when
+	// possible — NOT mtime (save time). See callRecordingOccurredAt doc
+	// comment for why mtime is unreliable here.
+	occurredAt := callRecordingOccurredAt(filepath.Base(item.path), mtime, now)
 	meta := map[string]any{
 		"relative_path": item.relPath,
 		"language":      c.cfg.WhisperLanguage,
@@ -1407,7 +1500,7 @@ func (c *WhisperCollector) buildDocument(ctx context.Context, item pendingTransc
 		Title:       title,
 		Content:     content,
 		Metadata:    meta,
-		OccurredAt:  &mtime,
+		OccurredAt:  &occurredAt,
 		CollectedAt: now,
 	}, true
 }

--- a/internal/collector/whisper_call_occurred_at_test.go
+++ b/internal/collector/whisper_call_occurred_at_test.go
@@ -1,0 +1,263 @@
+package collector
+
+// whisper_call_occurred_at_test.go — Tests for callRecordingOccurredAt and its
+// wiring into buildDocument's OccurredAt field.
+//
+// Production bug: OccurredAt was set from the audio file's mtime (when the
+// server SAVED the file), not the actual call time. Normally the phone
+// uploads within seconds of the call ending so the difference is invisible.
+// When upload is delayed (server outage, etc.) mtime drifts hours away from
+// the real call time. The TPhoneCallRecords filename embeds the true call
+// time as a UTC timestamp (<number>_YYYYMMDDHHMMSS[-N].<ext>) — confirmed by
+// cross-referencing filename timestamps against independently accurate
+// call-log timestamps, which agreed to the second. This file locks in that
+// fix and specifically guards against parsing the filename timestamp as
+// time.Local (which is wrong on any non-UTC host, e.g. a KST dev machine).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/baekenough/second-brain/internal/config"
+)
+
+// TestCallRecordingOccurredAt_NormalFilename verifies that a well-formed
+// TPhoneCallRecords filename produces an occurred_at parsed from the
+// filename, in UTC, matching the embedded digits exactly.
+func TestCallRecordingOccurredAt_NormalFilename(t *testing.T) {
+	t.Parallel()
+
+	// mtime close to the filename time (normal case — upload right after the call).
+	mtime := time.Date(2026, 8, 26, 5, 44, 40, 0, time.UTC)
+	now := time.Date(2026, 8, 26, 6, 0, 0, 0, time.UTC)
+	filename := "01025777190_20260826054434.m4a"
+
+	got := callRecordingOccurredAt(filename, mtime, now)
+
+	want := time.Date(2026, 8, 26, 5, 44, 34, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("callRecordingOccurredAt() = %v, want %v", got, want)
+	}
+	if got.Location() != time.UTC {
+		t.Errorf("callRecordingOccurredAt() location = %v, want UTC", got.Location())
+	}
+}
+
+// TestCallRecordingOccurredAt_MtimeDriftRegression is the key regression test
+// for the production incident: a 16-hour permission-outage delay between the
+// call (14:44:34 KST = 05:44:34 UTC) and the server saving the file
+// (22:16 KST that night). Before the fix, OccurredAt used mtime and recorded
+// the call ~16.5 hours late. After the fix, the filename timestamp must win.
+func TestCallRecordingOccurredAt_MtimeDriftRegression(t *testing.T) {
+	t.Parallel()
+
+	filename := "01025777190_20260826054434.m4a" // call at 05:44:34 UTC (14:44:34 KST)
+	// Server saved the file ~16.5 hours later (22:16 KST == 13:16 UTC next reckoning
+	// within the same UTC day here since 05:44 + 16.5h stays before midnight UTC).
+	mtime := time.Date(2026, 8, 26, 22, 16, 0, 0, time.UTC)
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+
+	got := callRecordingOccurredAt(filename, mtime, now)
+
+	wantCallTime := time.Date(2026, 8, 26, 5, 44, 34, 0, time.UTC)
+	if !got.Equal(wantCallTime) {
+		t.Errorf("callRecordingOccurredAt() = %v, want filename-derived call time %v (mtime %v must NOT be used)",
+			got, wantCallTime, mtime)
+	}
+	if got.Equal(mtime) {
+		t.Error("callRecordingOccurredAt() returned mtime — the exact bug this function fixes")
+	}
+
+	gap := mtime.Sub(got)
+	if gap < 16*time.Hour {
+		t.Fatalf("test setup error: mtime/filename gap is only %v, want >= 16h to exercise the regression", gap)
+	}
+}
+
+// TestCallRecordingOccurredAt_UnparseableFilename_FallsBackToMtime verifies
+// that filenames not matching the reTPhone pattern fall back to mtime
+// unchanged (legacy files, voice memos, etc).
+func TestCallRecordingOccurredAt_UnparseableFilename_FallsBackToMtime(t *testing.T) {
+	t.Parallel()
+
+	mtime := time.Date(2025, 12, 1, 8, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	filenames := []string{
+		"old_recording.m4a",
+		"notes.txt",
+		"20260101.m4a", // no underscore separator before the date
+		"",
+	}
+
+	for _, filename := range filenames {
+		filename := filename
+		t.Run("fallback:"+filename, func(t *testing.T) {
+			t.Parallel()
+			got := callRecordingOccurredAt(filename, mtime, now)
+			if !got.Equal(mtime) {
+				t.Errorf("filename %q: got %v, want mtime fallback %v", filename, got, mtime)
+			}
+		})
+	}
+}
+
+// TestCallRecordingOccurredAt_FutureTimestamp_FallsBackToMtime verifies the
+// sanity check: a filename timestamp in the future relative to now is
+// rejected as implausible (untrusted, phone-controlled input) and mtime is
+// used instead.
+func TestCallRecordingOccurredAt_FutureTimestamp_FallsBackToMtime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	mtime := now.Add(-time.Minute)
+
+	// Filename claims a call one day in the future relative to now.
+	filename := "01025777190_20260827120000.m4a"
+
+	got := callRecordingOccurredAt(filename, mtime, now)
+	if !got.Equal(mtime) {
+		t.Errorf("callRecordingOccurredAt() = %v, want mtime fallback %v (future timestamp must be rejected)", got, mtime)
+	}
+}
+
+// TestCallRecordingOccurredAt_TooOldTimestamp_FallsBackToMtime verifies the
+// other half of the sanity check: a year before 2000 is implausible.
+func TestCallRecordingOccurredAt_TooOldTimestamp_FallsBackToMtime(t *testing.T) {
+	t.Parallel()
+
+	mtime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Year 1999 — before the isPlausibleRecordingTime floor of 2000.
+	filename := "01025777190_19991231235959.m4a"
+
+	got := callRecordingOccurredAt(filename, mtime, now)
+	if !got.Equal(mtime) {
+		t.Errorf("callRecordingOccurredAt() = %v, want mtime fallback %v (year < 2000 must be rejected)", got, mtime)
+	}
+}
+
+// TestCallRecordingOccurredAt_RejectsKSTMisparse guards specifically against
+// the regression this bug fix could introduce: parsing the filename
+// timestamp with time.Local (or any explicit KST offset) instead of
+// time.UTC. If the implementation ever regresses to that, this test fails
+// because the result would be exactly 9 hours off from the UTC-correct value
+// (Asia/Seoul is UTC+9).
+func TestCallRecordingOccurredAt_RejectsKSTMisparse(t *testing.T) {
+	t.Parallel()
+
+	filename := "01025777190_20260826054434.m4a"
+	mtime := time.Date(2026, 8, 26, 6, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 8, 27, 0, 0, 0, 0, time.UTC)
+
+	got := callRecordingOccurredAt(filename, mtime, now)
+
+	correctUTC := time.Date(2026, 8, 26, 5, 44, 34, 0, time.UTC)
+	if !got.Equal(correctUTC) {
+		t.Fatalf("callRecordingOccurredAt() = %v, want %v (parsed as UTC)", got, correctUTC)
+	}
+
+	kst, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Skipf("Asia/Seoul tzdata unavailable in this environment: %v", err)
+	}
+	// What the buggy KST-parse would have produced: the same wall-clock
+	// digits, but interpreted as KST instead of UTC. Converted to UTC for
+	// comparison, this is 9 hours earlier than the correct UTC value.
+	misparsedAsKST := time.Date(2026, 8, 26, 5, 44, 34, 0, kst)
+	if got.Equal(misparsedAsKST.UTC()) {
+		t.Fatalf("callRecordingOccurredAt() matched the KST-misparse value %v — timestamp must be parsed as UTC, not Local/KST",
+			misparsedAsKST.UTC())
+	}
+	if diff := got.Sub(misparsedAsKST.UTC()); diff != 9*time.Hour {
+		t.Fatalf("sanity check on test itself failed: expected exactly 9h difference from KST-misparse, got %v", diff)
+	}
+}
+
+// TestWhisperCollector_BuildDocument_OccurredAt_UsesFilenameNotMtime is the
+// end-to-end regression test: it drives the file through the real Collect()
+// pipeline (walk -> transcribe -> buildDocument) and asserts the emitted
+// model.Document.OccurredAt reflects the filename-derived call time, not the
+// file's mtime, when the two diverge by many hours.
+func TestWhisperCollector_BuildDocument_OccurredAt_UsesFilenameNotMtime(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srv, _ := newWhisperTestServer(t, "occurred_at regression transcript")
+
+	// Call happened at 05:44:34 UTC; the file was only saved 16+ hours later
+	// (simulating the permission-outage delayed upload).
+	callTime := time.Date(2026, 8, 26, 5, 44, 34, 0, time.UTC)
+	mtime := time.Date(2026, 8, 26, 22, 16, 0, 0, time.UTC)
+	filename := "01025777190_20260826054434.m4a"
+	writeDummyAudio(t, dir, filename, mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "whisper-1",
+		WhisperLanguage: "ko",
+	}
+	c := makeWhisperCollector(cfg, srv)
+	c.WithIndexedIDs(map[string]struct{}{})
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1", len(docs))
+	}
+
+	doc := docs[0]
+	if doc.OccurredAt == nil {
+		t.Fatal("doc.OccurredAt is nil")
+	}
+	if !doc.OccurredAt.Equal(callTime) {
+		t.Errorf("doc.OccurredAt = %v, want filename-derived call time %v (mtime %v must NOT be used)",
+			doc.OccurredAt, callTime, mtime)
+	}
+	if doc.OccurredAt.Equal(mtime) {
+		t.Error("doc.OccurredAt equals mtime — the exact production bug this test guards against")
+	}
+}
+
+// TestWhisperCollector_BuildDocument_OccurredAt_UnparseableFallsBackToMtime
+// covers the legacy-filename fallback path through the full pipeline.
+func TestWhisperCollector_BuildDocument_OccurredAt_UnparseableFallsBackToMtime(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srv, _ := newWhisperTestServer(t, "legacy transcript")
+
+	mtime := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	filename := "voice_memo.m4a" // no embedded timestamp
+	writeDummyAudio(t, dir, filename, mtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "whisper-1",
+		WhisperLanguage: "ko",
+	}
+	c := makeWhisperCollector(cfg, srv)
+	c.WithIndexedIDs(map[string]struct{}{})
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1", len(docs))
+	}
+
+	doc := docs[0]
+	if doc.OccurredAt == nil {
+		t.Fatal("doc.OccurredAt is nil")
+	}
+	if !doc.OccurredAt.Equal(mtime) {
+		t.Errorf("doc.OccurredAt = %v, want mtime fallback %v (no filename timestamp to parse)", doc.OccurredAt, mtime)
+	}
+}

--- a/internal/collector/whisper_recording_time_test.go
+++ b/internal/collector/whisper_recording_time_test.go
@@ -210,8 +210,10 @@ func TestWhisperCollector_Cutover_FilenameDate_SkipsHistorical(t *testing.T) {
 	dir := t.TempDir()
 	srv, _ := newWhisperTestServer(t, "should not appear")
 
-	// Cutover: 2026-05-30 00:00:00 Local
-	cutover := time.Date(2026, 5, 30, 0, 0, 0, 0, time.Local)
+	// Cutover: 2026-05-30 00:00:00 UTC (prod cutover is always normalised to
+	// UTC by collectorCutover; constructing it any other way here would make
+	// this test's outcome depend on the host's local timezone).
+	cutover := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)
 
 	// Historical file: filename encodes 2026-01-20 (before cutover),
 	// but mtime is set to "now+1h" (after cutover) — simulating a staging copy.
@@ -260,7 +262,7 @@ func TestWhisperCollector_Cutover_FilenameDate_TPhone_SkipsHistorical(t *testing
 	dir := t.TempDir()
 	srv, _ := newWhisperTestServer(t, "should not appear")
 
-	cutover := time.Date(2026, 5, 30, 0, 0, 0, 0, time.Local)
+	cutover := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC) // prod cutover is always normalised to UTC (collectorCutover)
 
 	recentMtime := time.Now().Add(time.Hour)
 
@@ -362,7 +364,7 @@ func TestWhisperCollector_Cutover_FilenameDate_SubdirPath(t *testing.T) {
 	}
 	srv, _ := newWhisperTestServer(t, "subdir transcription")
 
-	cutover := time.Date(2026, 5, 30, 0, 0, 0, 0, time.Local)
+	cutover := time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC) // prod cutover is always normalised to UTC (collectorCutover)
 	recentMtime := time.Now().Add(time.Hour)
 
 	// Filename date: 2026-06-01 (after cutover) — should pass.
@@ -386,5 +388,98 @@ func TestWhisperCollector_Cutover_FilenameDate_SubdirPath(t *testing.T) {
 
 	if len(docs) != 1 {
 		t.Fatalf("got %d docs, want 1 (file in date-named subdir should be processed by filename date)", len(docs))
+	}
+}
+
+// TestRecordingTime_ParsesUTCNotHostLocal is a direct regression test for the
+// recordingTime time.Local → time.UTC fix. It does not depend on t.Setenv
+// changing the process's actual host timezone (Go's time.Local is captured
+// once at process start from TZ and is not safely mutable mid-test); instead
+// it asserts the parsed instant directly against the UTC-correct value and
+// against what the old Local-parsing bug would have produced, so the
+// assertion is correct regardless of which TZ this test binary happens to
+// run under.
+func TestRecordingTime_ParsesUTCNotHostLocal(t *testing.T) {
+	t.Parallel()
+
+	sentinel := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	filename := "01025777190_20260826054434.m4a" // 05:44:34 UTC
+
+	got := recordingTime(filename, sentinel)
+
+	wantUTC := time.Date(2026, 8, 26, 5, 44, 34, 0, time.UTC)
+	if !got.Equal(wantUTC) {
+		t.Fatalf("recordingTime() = %v, want %v (parsed as UTC)", got, wantUTC)
+	}
+
+	kst, err := time.LoadLocation("Asia/Seoul")
+	if err != nil {
+		t.Skipf("Asia/Seoul tzdata unavailable in this environment: %v", err)
+	}
+	// What the pre-fix time.Local parse would have produced on a KST host:
+	// the same wall-clock digits interpreted as KST instead of UTC — an
+	// instant 9 hours earlier than the correct one.
+	oldBuggyResult := time.Date(2026, 8, 26, 5, 44, 34, 0, kst)
+	if got.Equal(oldBuggyResult) {
+		t.Fatalf("recordingTime() matched the pre-fix KST-misparse value %v — must parse as UTC", oldBuggyResult.UTC())
+	}
+	if diff := got.Sub(oldBuggyResult); diff != 9*time.Hour {
+		t.Fatalf("sanity check on the test itself failed: expected exactly 9h from the KST-misparse value, got %v", diff)
+	}
+}
+
+// TestWhisperCollector_Cutover_UTCNotLocal_TZIndependent is the key
+// regression test for the recordingTime time.Local → time.UTC fix. It
+// constructs a scenario where the old bug (parsing the filename timestamp as
+// time.Local) and the fix (parsing as time.UTC) produce OPPOSITE cutover
+// verdicts on a non-UTC host — proving the fix, and proving the fix is host
+// timezone independent, since this test must pass identically whether the
+// suite is run under TZ=UTC or TZ=Asia/Seoul (see the go-best-practices skill
+// self-check: "TZ=Asia/Seoul go test ./internal/collector/..." must be green).
+//
+// Setup:
+//   - cutover floor = 2026-08-26 03:00:00 UTC.
+//   - call file's filename encodes 05:44:34 (i.e. 05:44:34 UTC, confirmed by
+//     call-log cross-reference — see the reTPhone var block comment) — that
+//     is AFTER the cutover, so the file must be processed.
+//
+// Under the pre-fix bug, on a host whose time.Local is KST (UTC+9), the same
+// digits would have been parsed as 05:44:34 KST = 2026-08-25 20:44:34 UTC —
+// BEFORE the cutover — incorrectly suppressing the file. The fix parses the
+// digits as UTC regardless of host timezone, so the file is correctly kept
+// on every host.
+func TestWhisperCollector_Cutover_UTCNotLocal_TZIndependent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	srv, _ := newWhisperTestServer(t, "tz independence transcript")
+
+	cutover := time.Date(2026, 8, 26, 3, 0, 0, 0, time.UTC)
+	recentMtime := time.Now().Add(time.Hour)
+
+	// Filename encodes 05:44:34 UTC — after the 03:00 UTC cutover floor.
+	// Under the pre-fix time.Local bug this would misparse to
+	// 2026-08-25 20:44:34 UTC on a KST host — before the cutover — and be
+	// wrongly suppressed.
+	name := "01025777190_20260826054434.m4a"
+	writeDummyAudio(t, dir, name, recentMtime)
+
+	cfg := &config.Config{
+		WhisperAudioDir: dir,
+		WhisperAPIURL:   srv.URL,
+		WhisperModel:    "whisper-1",
+		WhisperLanguage: "ko",
+	}
+	c := makeWhisperCollector(cfg, srv)
+	c.WithCutover(cutover)
+	c.WithIndexedIDs(map[string]struct{}{})
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1 — filename timestamp (05:44:34 UTC) is after cutover (03:00 UTC) and must be processed regardless of host timezone", len(docs))
 	}
 }


### PR DESCRIPTION
## 요약

- 통화 녹음 문서의 `occurred_at`이 파일 mtime(서버 저장 시각)으로 채워지던 버그를 수정. 파일명(`<전화번호>_<YYYYMMDDHHMMSS>.m4a`)의 타임스탬프를 UTC로 파싱해 사용하도록 변경, 파싱 실패/미래 시각/비현실적 과거는 mtime 폴백
- `recordingTime`(cutover 비교용)이 같은 파일명을 `time.Local`로 파싱하던 버그도 함께 수정 (비교 대상 `cutover`는 이미 `.UTC()`로 정규화됨)

## 왜 지금까지 안 보였는가

**버그 1**: 평소엔 통화 직후 폰이 곧바로 업로드해 mtime과 실제 통화 시각의 차이가 0~3분이라 드러나지 않았다. 2026-08-26 서버 bind mount 권한 장애로 전송이 16시간 지연되며 표면화됐다 — 오후 2시 44분 통화가 밤 10시 16분으로 기록됨.

**버그 2**: 프로덕션 컨테이너 TZ가 UTC(`Etc/UTC`, `TZ` unset)라 `time.Local == time.UTC`였던 우연 때문에 안 깨졌다. TZ가 설정되거나 개발 머신에서 돌리면 9시간 어긋난다. 버그 1과 동일하게 "우연한 일치에 기댄" 구조.

## UTC 근거 (되돌리지 마세요)

같은 통화의 `call-log` 문서(폰이 JSON으로 별도 전송)와 대조해 초 단위까지 일치를 확인했다. 파일명 `20260826054434` = call-log의 `05:44:34 UTC` (= KST 14:44:34). **KST로 해석하면 9시간 어긋난다.** 리뷰 시 `time.Local`로 되돌리지 말 것.

## 변경 내용

- `parseTPhoneFilenameUTC` 공통 헬퍼로 파싱 로직 일원화, `time.UTC`로 통일 (기존 두 곳에서 각기 다른 오프셋으로 파싱하던 문제 제거)
- 각 호출부의 폴백 정책(mtime fallback)은 유지

## 알려진 한계

파일명이 UTC라는 건 TPhone 패턴만 call-log 대조로 확정됐다. Voice Recorder 패턴은 같은 기기 클럭이라는 추론이며, 대조할 로그가 없어 독립 검증이 불가능하다. 코드 주석에 이 구분을 남겨둠.

## 테스트

회귀 테스트 10개 추가. `time.UTC`를 임시로 `time.Local`로 되돌려 6개가 실제로 FAIL하는지 확인 후 원복 — 테스트가 공허하지 않음을 검증.

| 실행 | RUN | PASS | FAIL |
|---|---|---|---|
| `TZ=UTC go test ./internal/collector/...` | 531 | 314 | 0 |
| `TZ=Asia/Seoul go test ./internal/collector/...` | 531 | 314 | 0 |

두 환경의 PASS/FAIL 집합이 `diff` 기준 완전 동일.

## Test plan

- [ ] CI 그린 확인
- [ ] TZ=UTC / TZ=Asia/Seoul 양쪽 테스트 재확인
- [ ] 리뷰 시 `time.Local`로 되돌리지 않았는지 확인

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>