### PR TITLE
feat(calendar): MCP 기간 필터 노출 + 취소 일정 soft-delete

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -434,7 +434,7 @@ func run() error {
 		collector.NewNotionCollector(cfg.NotionToken),
 		collector.NewTelegramCollector(cfg.TelegramBotToken, cfg.TelegramChatIDs),
 		collector.NewGmailCollector(cfg),
-		collector.NewCalendarCollector(cfg),
+		collector.NewCalendarCollector(cfg).WithCancellationStore(docStore),
 		collector.NewSMSCollector(cfg.SMSSourceDir, cfg.SMSMaxFileBytes).
 			WithNumberHashingEnabled(cfg.PIINumberHashingEnabled),
 		collector.NewWhisperCollector(cfg),

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/baekenough/second-brain/internal/note"
 	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/store"
+	"github.com/baekenough/second-brain/internal/timeutil"
 )
 
 func main() {
@@ -249,7 +250,9 @@ func registerSearchTool(s *server.MCPServer, svc *search.Service) {
 		"search",
 		mcp.WithDescription(
 			"Hybrid full-text and semantic search over the second-brain knowledge base. "+
-				"Returns matching documents ordered by relevance score.",
+				"Returns matching documents ordered by relevance score. "+
+				"Use occurred_from/occurred_to to restrict results to an event-time window "+
+				"(e.g. \"next week's calendar\", \"messages from yesterday\").",
 		),
 		mcp.WithString("query",
 			mcp.Required(),
@@ -263,6 +266,22 @@ func registerSearchTool(s *server.MCPServer, svc *search.Service) {
 				"Optional source type filter. One of: slack, github, gdrive, notion, "+
 					"filesystem, discord, telegram, secretary, llm-memory (deprecated), "+
 					"gmail, calendar, sms, call-log, call-transcript, upload, agent-note.",
+			),
+		),
+		mcp.WithString("occurred_from",
+			mcp.Description(
+				"Optional start of an event-time window (inclusive) on documents.occurred_at. "+
+					"Together with occurred_to this forms a half-open range [occurred_from, occurred_to) — "+
+					"documents with no occurred_at (e.g. some notes/attachments) are excluded whenever "+
+					"either bound is set. Accepts RFC3339 (\"2026-09-05T00:00:00+09:00\") or a bare "+
+					"date (\"2026-09-05\"); a bare date is interpreted as KST midnight. May be given alone.",
+			),
+		),
+		mcp.WithString("occurred_to",
+			mcp.Description(
+				"Optional end of the event-time window (exclusive) on documents.occurred_at — see "+
+					"occurred_from for the window semantics and accepted formats. Must be strictly "+
+					"after occurred_from when both are given. May be given alone.",
 			),
 		),
 	)
@@ -301,6 +320,26 @@ func registerSearchTool(s *server.MCPServer, svc *search.Service) {
 				)), nil
 			}
 			sq.SourceType = &st
+		}
+
+		if raw := req.GetString("occurred_from", ""); raw != "" {
+			t, err := parseOccurredBound(raw)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("invalid occurred_from %q: %v", raw, err)), nil
+			}
+			sq.OccurredFrom = t
+		}
+		if raw := req.GetString("occurred_to", ""); raw != "" {
+			t, err := parseOccurredBound(raw)
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("invalid occurred_to %q: %v", raw, err)), nil
+			}
+			sq.OccurredTo = t
+		}
+		if sq.OccurredFrom != nil && sq.OccurredTo != nil && !sq.OccurredTo.After(*sq.OccurredFrom) {
+			return mcp.NewToolResultError(
+				"occurred_to must be strictly after occurred_from (half-open window [occurred_from, occurred_to))",
+			), nil
 		}
 
 		results, err := svc.Search(ctx, sq)
@@ -573,6 +612,37 @@ func registerAddNoteTool(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// parseOccurredBound parses one occurred_from/occurred_to argument of the
+// search tool. It accepts either a full RFC3339 timestamp
+// (e.g. "2026-09-05T00:00:00+09:00") or a bare date ("2026-09-05").
+//
+// A bare date is interpreted at midnight in KST (UTC+9). This mirrors the
+// convention internal/intent/plan.go's parseWindow already uses for the same
+// documents.occurred_at half-open window: the query planner resolves LLM- and
+// heuristic-produced "YYYY-MM-DD" bounds against timeutil.KST(), and second-
+// brain's users and data are Korea-based, so a bare date given to this MCP
+// tool must resolve to the same instant a planner-produced date would — an
+// MCP client asking for "2026-09-05" should get the same window as /ask
+// asking for "오늘(9/5)".
+//
+// The caller distinguishes "not provided" (empty string, skip the field
+// entirely) from "provided but malformed" (returns an error) — this function
+// only handles the latter; empty-string short-circuiting happens at the call
+// site so a truly optional bound leaves the corresponding model.SearchQuery
+// field nil.
+func parseOccurredBound(s string) (*time.Time, error) {
+	s = strings.TrimSpace(s)
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return &t, nil
+	}
+	t, err := time.ParseInLocation("2006-01-02", s, timeutil.KST())
+	if err != nil {
+		return nil, fmt.Errorf(
+			"must be RFC3339 (e.g. 2026-09-05T00:00:00+09:00) or a date (e.g. 2026-09-05)")
+	}
+	return &t, nil
+}
 
 // truncateRunes returns the first n runes of s.
 // When s is shorter than n runes it is returned unchanged.

--- a/cmd/mcp/main_test.go
+++ b/cmd/mcp/main_test.go
@@ -12,7 +12,9 @@ import (
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
 	"github.com/baekenough/second-brain/internal/model"
+	"github.com/baekenough/second-brain/internal/search"
 	"github.com/baekenough/second-brain/internal/store"
+	"github.com/baekenough/second-brain/internal/timeutil"
 )
 
 // ---------------------------------------------------------------------------
@@ -343,6 +345,295 @@ type fakeSearchSvc struct{}
 
 func (f *fakeSearchSvc) Search(_ context.Context, _ model.SearchQuery) ([]model.SearchResult, error) {
 	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// occurred_from / occurred_to wiring tests
+//
+// These exercise registerSearchTool end-to-end through callTool with a real
+// *search.Service (not the inline stub newTestMCPServer registers for the
+// query/source/auth tests above) so that the assertions cover the actual
+// parameter names, the parsing rules, and the exact model.SearchQuery.
+// OccurredFrom/OccurredTo values svc.Search() receives — a stub tool handler
+// could not catch a typo in the argument name or a missing wiring line, since
+// it never touches registerSearchTool's own handler body.
+// ---------------------------------------------------------------------------
+
+// fakeOccurredDocSearcher implements search.DocumentSearcher and records the
+// last model.SearchQuery it was called with, so tests can assert on the
+// OccurredFrom/OccurredTo fields the handler actually built.
+type fakeOccurredDocSearcher struct {
+	called    bool
+	lastQuery model.SearchQuery
+}
+
+func (f *fakeOccurredDocSearcher) Search(_ context.Context, q model.SearchQuery) ([]*model.SearchResult, error) {
+	f.called = true
+	f.lastQuery = q
+	return nil, nil
+}
+
+// disabledEmbeddingEngine implements search.EmbeddingEngine in its
+// permanently-disabled state, so search.Service.Search skips the embedding
+// call entirely and goes straight to the DocumentSearcher.
+type disabledEmbeddingEngine struct{}
+
+func (disabledEmbeddingEngine) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, nil
+}
+func (disabledEmbeddingEngine) EmbedBatch(_ context.Context, texts []string) ([][]float32, error) {
+	return make([][]float32, len(texts)), nil
+}
+func (disabledEmbeddingEngine) Enabled() bool  { return false }
+func (disabledEmbeddingEngine) Dimension() int { return 0 }
+
+// newOccurredTestServer builds an *mcpserver.MCPServer with the real
+// registerSearchTool wired to a real *search.Service backed by the given
+// fake document searcher, so occurred_from/occurred_to tests observe the
+// production handler code path, not a test stub.
+func newOccurredTestServer(docs *fakeOccurredDocSearcher) *mcpserver.MCPServer {
+	svc := search.NewService(docs, disabledEmbeddingEngine{})
+	s := mcpserver.NewMCPServer("test", "0.0.0", mcpserver.WithToolCapabilities(false))
+	registerSearchTool(s, svc)
+	return s
+}
+
+func TestSearchTool_OccurredRange_BothBoundsRFC3339(t *testing.T) {
+	t.Parallel()
+
+	docs := &fakeOccurredDocSearcher{}
+	s := newOccurredTestServer(docs)
+
+	result := callTool(t, s, "search", authorizedCtx(), map[string]any{
+		"query":         "test",
+		"occurred_from": "2026-09-05T00:00:00+09:00",
+		"occurred_to":   "2026-09-06T00:00:00+09:00",
+	})
+
+	if isErrorResult(result) {
+		t.Fatalf("unexpected error result: %s", resultText(result))
+	}
+	if !docs.called {
+		t.Fatal("expected the document searcher to be called")
+	}
+
+	wantFrom, _ := time.Parse(time.RFC3339, "2026-09-05T00:00:00+09:00")
+	wantTo, _ := time.Parse(time.RFC3339, "2026-09-06T00:00:00+09:00")
+
+	if docs.lastQuery.OccurredFrom == nil || !docs.lastQuery.OccurredFrom.Equal(wantFrom) {
+		t.Errorf("OccurredFrom = %v, want %v", docs.lastQuery.OccurredFrom, wantFrom)
+	}
+	if docs.lastQuery.OccurredTo == nil || !docs.lastQuery.OccurredTo.Equal(wantTo) {
+		t.Errorf("OccurredTo = %v, want %v", docs.lastQuery.OccurredTo, wantTo)
+	}
+}
+
+// TestSearchTool_OccurredRange_DateOnly_ParsedAsKSTMidnight pins the
+// timezone-interpretation decision documented on parseOccurredBound: a bare
+// "YYYY-MM-DD" date must resolve to midnight KST, matching the convention
+// internal/intent/plan.go's parseWindow already uses for the same
+// documents.occurred_at window (see parseOccurredBound's doc comment).
+func TestSearchTool_OccurredRange_DateOnly_ParsedAsKSTMidnight(t *testing.T) {
+	t.Parallel()
+
+	docs := &fakeOccurredDocSearcher{}
+	s := newOccurredTestServer(docs)
+
+	result := callTool(t, s, "search", authorizedCtx(), map[string]any{
+		"query":         "test",
+		"occurred_from": "2026-09-05",
+		"occurred_to":   "2026-09-06",
+	})
+
+	if isErrorResult(result) {
+		t.Fatalf("unexpected error result: %s", resultText(result))
+	}
+	if !docs.called {
+		t.Fatal("expected the document searcher to be called")
+	}
+
+	wantFrom := time.Date(2026, 9, 5, 0, 0, 0, 0, timeutil.KST())
+	wantTo := time.Date(2026, 9, 6, 0, 0, 0, 0, timeutil.KST())
+
+	if docs.lastQuery.OccurredFrom == nil || !docs.lastQuery.OccurredFrom.Equal(wantFrom) {
+		t.Errorf("OccurredFrom = %v, want %v (KST midnight)", docs.lastQuery.OccurredFrom, wantFrom)
+	}
+	if docs.lastQuery.OccurredTo == nil || !docs.lastQuery.OccurredTo.Equal(wantTo) {
+		t.Errorf("OccurredTo = %v, want %v (KST midnight)", docs.lastQuery.OccurredTo, wantTo)
+	}
+}
+
+func TestSearchTool_OccurredRange_OnlyFromGiven_ToStaysNil(t *testing.T) {
+	t.Parallel()
+
+	docs := &fakeOccurredDocSearcher{}
+	s := newOccurredTestServer(docs)
+
+	result := callTool(t, s, "search", authorizedCtx(), map[string]any{
+		"query":         "test",
+		"occurred_from": "2026-09-05",
+	})
+
+	if isErrorResult(result) {
+		t.Fatalf("unexpected error result: %s", resultText(result))
+	}
+	if docs.lastQuery.OccurredFrom == nil {
+		t.Error("expected OccurredFrom to be set")
+	}
+	if docs.lastQuery.OccurredTo != nil {
+		t.Errorf("expected OccurredTo to remain nil, got %v", docs.lastQuery.OccurredTo)
+	}
+}
+
+func TestSearchTool_OccurredRange_OnlyToGiven_FromStaysNil(t *testing.T) {
+	t.Parallel()
+
+	docs := &fakeOccurredDocSearcher{}
+	s := newOccurredTestServer(docs)
+
+	result := callTool(t, s, "search", authorizedCtx(), map[string]any{
+		"query":       "test",
+		"occurred_to": "2026-09-06",
+	})
+
+	if isErrorResult(result) {
+		t.Fatalf("unexpected error result: %s", resultText(result))
+	}
+	if docs.lastQuery.OccurredFrom != nil {
+		t.Errorf("expected OccurredFrom to remain nil, got %v", docs.lastQuery.OccurredFrom)
+	}
+	if docs.lastQuery.OccurredTo == nil {
+		t.Error("expected OccurredTo to be set")
+	}
+}
+
+// TestSearchTool_OccurredRange_BothOmitted_NoRegression guards the existing
+// caller path (no occurred_from/occurred_to given at all): both bounds must
+// remain nil so the query behaves exactly as it did before this feature —
+// an unfiltered search — rather than picking up a stray zero-value window.
+func TestSearchTool_OccurredRange_BothOmitted_NoRegression(t *testing.T) {
+	t.Parallel()
+
+	docs := &fakeOccurredDocSearcher{}
+	s := newOccurredTestServer(docs)
+
+	result := callTool(t, s, "search", authorizedCtx(), map[string]any{
+		"query": "test",
+	})
+
+	if isErrorResult(result) {
+		t.Fatalf("unexpected error result: %s", resultText(result))
+	}
+	if docs.lastQuery.OccurredFrom != nil {
+		t.Errorf("expected OccurredFrom to be nil, got %v", docs.lastQuery.OccurredFrom)
+	}
+	if docs.lastQuery.OccurredTo != nil {
+		t.Errorf("expected OccurredTo to be nil, got %v", docs.lastQuery.OccurredTo)
+	}
+}
+
+func TestSearchTool_OccurredRange_InvalidFormat_Rejected(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]map[string]any{
+		"invalid occurred_from": {"query": "test", "occurred_from": "not-a-date"},
+		"invalid occurred_to":   {"query": "test", "occurred_to": "2026/09/06"},
+	}
+
+	for name, args := range cases {
+		args := args
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			docs := &fakeOccurredDocSearcher{}
+			s := newOccurredTestServer(docs)
+
+			result := callTool(t, s, "search", authorizedCtx(), args)
+
+			if !isErrorResult(result) {
+				t.Fatalf("expected an error result for malformed date, got success: %s", resultText(result))
+			}
+			if docs.called {
+				t.Error("the document searcher must not be called when parsing fails")
+			}
+		})
+	}
+}
+
+func TestSearchTool_OccurredRange_ToNotAfterFrom_Rejected(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]map[string]any{
+		"to before from": {
+			"query":         "test",
+			"occurred_from": "2026-09-06",
+			"occurred_to":   "2026-09-05",
+		},
+		"to equal from": {
+			"query":         "test",
+			"occurred_from": "2026-09-05",
+			"occurred_to":   "2026-09-05",
+		},
+	}
+
+	for name, args := range cases {
+		args := args
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			docs := &fakeOccurredDocSearcher{}
+			s := newOccurredTestServer(docs)
+
+			result := callTool(t, s, "search", authorizedCtx(), args)
+
+			if !isErrorResult(result) {
+				t.Fatalf("expected an error result for a non-positive window, got success: %s", resultText(result))
+			}
+			if docs.called {
+				t.Error("the document searcher must not be called when the window is invalid")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseOccurredBound unit tests
+// ---------------------------------------------------------------------------
+
+func TestParseOccurredBound_RFC3339(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseOccurredBound("2026-09-05T12:30:00+09:00")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want, _ := time.Parse(time.RFC3339, "2026-09-05T12:30:00+09:00")
+	if got == nil || !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseOccurredBound_DateOnly_KST(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseOccurredBound("2026-09-05")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := time.Date(2026, 9, 5, 0, 0, 0, 0, timeutil.KST())
+	if got == nil || !got.Equal(want) {
+		t.Errorf("got %v, want %v (KST midnight)", got, want)
+	}
+}
+
+func TestParseOccurredBound_Invalid_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{"not-a-date", "2026/09/05", "", "2026-13-40"} {
+		if _, err := parseOccurredBound(in); err == nil {
+			t.Errorf("parseOccurredBound(%q): expected error, got nil", in)
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/collector/calendar.go
+++ b/internal/collector/calendar.go
@@ -24,7 +24,20 @@ import (
 const (
 	calendarScope   = "https://www.googleapis.com/auth/calendar.readonly"
 	calendarBaseURL = "https://www.googleapis.com"
+
+	// calendarStatusCancelled is the Google Calendar API event status value
+	// for a deleted event or a cancelled instance of a recurring series.
+	// See https://developers.google.com/calendar/api/v3/reference/events —
+	// "status: cancelled" events frequently omit summary/description.
+	calendarStatusCancelled = "cancelled"
 )
+
+// CalendarCancellationStore is the document persistence interface used by
+// CalendarCollector to soft-delete documents for calendar events that have
+// been cancelled upstream. It is a subset of store.DocumentStore.
+type CalendarCancellationStore interface {
+	SoftDeleteBySourceID(ctx context.Context, sourceType model.SourceType, sourceID string) (bool, error)
+}
 
 // CalendarCollector collects events from Google Calendar via the Calendar REST API.
 // It is disabled when credentials or token are not configured.
@@ -39,6 +52,11 @@ type CalendarCollector struct {
 	tokenMu     sync.Mutex
 	tokenSource oauth2.TokenSource
 	cachedToken *oauth2.Token
+
+	// cancellationStore soft-deletes documents for cancelled calendar events.
+	// When nil, cancellations are observed but not acted upon (the
+	// corresponding document, if any, is left active) — see Collect.
+	cancellationStore CalendarCancellationStore
 }
 
 // NewCalendarCollector returns a CalendarCollector configured from cfg.
@@ -50,6 +68,14 @@ func NewCalendarCollector(cfg *config.Config) *CalendarCollector {
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 		baseURL:    calendarBaseURL,
 	}
+}
+
+// WithCancellationStore configures the store used to soft-delete documents
+// for calendar events that are reported as cancelled. Passing nil disables
+// cancellation handling (matches the pre-existing behavior).
+func (c *CalendarCollector) WithCancellationStore(s CalendarCancellationStore) *CalendarCollector {
+	c.cancellationStore = s
+	return c
 }
 
 func (c *CalendarCollector) Name() string             { return "calendar" }
@@ -124,6 +150,8 @@ func (c *CalendarCollector) Collect(ctx context.Context, since time.Time) ([]mod
 	var docs []model.Document
 	var failedCalendars []string
 	totalSkippedEmpty := 0
+	totalCancelled := 0
+	totalCancelledUnhandled := 0
 
 	for i, calID := range calIDs {
 		// The first configured calendar keeps the legacy (non-namespaced)
@@ -140,7 +168,33 @@ func (c *CalendarCollector) Collect(ctx context.Context, since time.Time) ([]mod
 		}
 
 		calSkippedEmpty := 0
+		calCancelled := 0
+		calCancelledUnhandled := 0
 		for _, ev := range events {
+			// A cancelled event (single deletion, or a cancelled instance of
+			// a recurring series) must never become — or remain — an active
+			// document. Google Calendar frequently omits summary/description
+			// on a cancelled event, so this check MUST run before the
+			// empty-summary skip below: otherwise a cancellation for a
+			// previously-collected active event would silently fall through
+			// the skip and leave its old (still-active, now stale) document
+			// behind forever. Soft-deleting by source_id is a no-op when the
+			// event was never collected while active, so this never
+			// manufactures a new document out of a tombstone.
+			if ev.Status == calendarStatusCancelled {
+				calCancelled++
+				sourceID := calendarSourceID(ev.ID, calID, legacy)
+				if c.cancellationStore == nil {
+					calCancelledUnhandled++
+					continue
+				}
+				if _, err := c.cancellationStore.SoftDeleteBySourceID(ctx, model.SourceCalendar, sourceID); err != nil {
+					slog.Warn("calendar: failed to soft-delete cancelled event",
+						"calendar_id", calID, "id", ev.ID, "error", err)
+				}
+				continue
+			}
+
 			// A calendar shared at freeBusyReader (rather than "See all event
 			// details") returns HTTP 200 with events that have no summary or
 			// description — busy/free slots only, no identifiable content.
@@ -166,7 +220,13 @@ func (c *CalendarCollector) Collect(ctx context.Context, since time.Time) ([]mod
 			slog.Warn("calendar: skipped events with no visible content — likely freeBusyReader-only sharing, not an error; will collect automatically once sharing permission is upgraded",
 				"calendar_id", calID, "skipped", calSkippedEmpty, "total", len(events))
 		}
+		if calCancelledUnhandled > 0 {
+			slog.Warn("calendar: cancellation store not configured — cancelled events observed but not soft-deleted",
+				"calendar_id", calID, "cancelled", calCancelledUnhandled)
+		}
 		totalSkippedEmpty += calSkippedEmpty
+		totalCancelled += calCancelled
+		totalCancelledUnhandled += calCancelledUnhandled
 	}
 
 	if len(failedCalendars) > 0 {
@@ -183,7 +243,9 @@ func (c *CalendarCollector) Collect(ctx context.Context, since time.Time) ([]mod
 		"count", len(docs),
 		"calendars", len(calIDs),
 		"failed_calendars", len(failedCalendars),
-		"skipped_empty", totalSkippedEmpty)
+		"skipped_empty", totalSkippedEmpty,
+		"cancelled", totalCancelled,
+		"cancelled_unhandled", totalCancelledUnhandled)
 	return docs, nil
 }
 
@@ -341,21 +403,27 @@ func calendarEventToDocument(ev calendarEvent, calID string, legacy bool, collec
 		meta["end"] = endTime.Format(time.RFC3339)
 	}
 
-	sourceID := "calendar:" + ev.ID
-	if !legacy {
-		sourceID = "calendar:" + calID + ":" + ev.ID
-	}
-
 	return model.Document{
 		ID:          uuid.New(),
 		SourceType:  model.SourceCalendar,
-		SourceID:    sourceID,
+		SourceID:    calendarSourceID(ev.ID, calID, legacy),
 		Title:       ev.Summary,
 		Content:     content,
 		Metadata:    meta,
 		OccurredAt:  occurredAt,
 		CollectedAt: collectAt,
 	}, nil
+}
+
+// calendarSourceID computes the source_id for a calendar event, matching the
+// legacy-vs-namespaced scheme documented on calendarEventToDocument. It is
+// also used by the cancellation path in Collect, which needs the source_id
+// without building a full document.
+func calendarSourceID(eventID, calID string, legacy bool) string {
+	if legacy {
+		return "calendar:" + eventID
+	}
+	return "calendar:" + calID + ":" + eventID
 }
 
 // parseCalendarDateTime parses a CalendarEventDateTime into a *time.Time.

--- a/internal/collector/calendar_test.go
+++ b/internal/collector/calendar_test.go
@@ -832,6 +832,228 @@ func TestCalendarCollector_Collect_NoSourceIDCollisionAcrossCalendars(t *testing
 	}
 }
 
+// --- cancellation handling ---
+
+// fakeCancellationStore is a test double for CalendarCancellationStore.
+// activeSourceIDs simulates the set of source_ids that currently have an
+// active document in the store: SoftDeleteBySourceID returns true and
+// removes the entry (simulating the row's status flipping to 'deleted') the
+// first time it is called for a given id, and false on every subsequent
+// call for the same id — mirroring the real UPDATE ... WHERE status='active'
+// semantics, which is what makes the store method (and therefore the
+// collector's use of it) idempotent.
+type fakeCancellationStore struct {
+	activeSourceIDs map[string]bool
+	err             error
+	calls           []fakeCancellationCall
+}
+
+type fakeCancellationCall struct {
+	sourceType model.SourceType
+	sourceID   string
+}
+
+func (f *fakeCancellationStore) SoftDeleteBySourceID(_ context.Context, sourceType model.SourceType, sourceID string) (bool, error) {
+	f.calls = append(f.calls, fakeCancellationCall{sourceType: sourceType, sourceID: sourceID})
+	if f.err != nil {
+		return false, f.err
+	}
+	if f.activeSourceIDs[sourceID] {
+		delete(f.activeSourceIDs, sourceID)
+		return true, nil
+	}
+	return false, nil
+}
+
+// cancelledEventJSON builds a cancelled-event payload. Matching real Google
+// Calendar API behavior, a cancelled event typically omits summary/
+// description/location entirely — only id, status, and updated survive.
+func cancelledEventJSON(id string) map[string]any {
+	return map[string]any{
+		"id":      id,
+		"status":  "cancelled",
+		"updated": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// TestCalendarCollector_Collect_CancelledEvent_TransitionsExistingDocument
+// covers the exact defect found in production: an event that was previously
+// collected as an active document is later cancelled. The cancellation must
+// soft-delete that existing document, and must NOT produce a new active
+// document for the cancelled event.
+func TestCalendarCollector_Collect_CancelledEvent_TransitionsExistingDocument(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		ev := cancelledEventJSON("evt-was-active")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	fake := &fakeCancellationStore{activeSourceIDs: map[string]bool{"calendar:evt-was-active": true}}
+	c := newCalendarCollectorWithFakeSource(validCalendarConfig(), srv, nil).WithCancellationStore(fake)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("got %d docs, want 0 — a cancelled event must never become an active document", len(docs))
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SoftDeleteBySourceID called %d times, want 1", len(fake.calls))
+	}
+	if fake.calls[0].sourceType != model.SourceCalendar || fake.calls[0].sourceID != "calendar:evt-was-active" {
+		t.Errorf("SoftDeleteBySourceID called with (%q, %q), want (%q, %q)",
+			fake.calls[0].sourceType, fake.calls[0].sourceID, model.SourceCalendar, "calendar:evt-was-active")
+	}
+	if fake.activeSourceIDs["calendar:evt-was-active"] {
+		t.Error("expected the fake store's active entry to be removed (soft-deleted)")
+	}
+}
+
+// TestCalendarCollector_Collect_CancelledEvent_NeverSeenBefore verifies that
+// a cancellation for an event the collector has never fetched while active
+// does not manufacture a new document — SoftDeleteBySourceID is a no-op in
+// the store for a nonexistent source_id, and Collect must not compensate by
+// building one anyway.
+func TestCalendarCollector_Collect_CancelledEvent_NeverSeenBefore(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		ev := cancelledEventJSON("evt-never-active")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	fake := &fakeCancellationStore{activeSourceIDs: map[string]bool{}}
+	c := newCalendarCollectorWithFakeSource(validCalendarConfig(), srv, nil).WithCancellationStore(fake)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("got %d docs, want 0", len(docs))
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SoftDeleteBySourceID called %d times, want 1", len(fake.calls))
+	}
+}
+
+// TestCalendarCollector_Collect_ConfirmedEvent_UnaffectedByCancellationHandling
+// is a regression guard: a normal confirmed event must be collected exactly
+// as before, and must never trigger a SoftDeleteBySourceID call.
+func TestCalendarCollector_Collect_ConfirmedEvent_UnaffectedByCancellationHandling(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().UTC()
+	end := start.Add(time.Hour)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		ev := buildCalendarEventJSON("evt-confirmed", "Still Happening", "", "", "confirmed", start, end, "", nil)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	fake := &fakeCancellationStore{activeSourceIDs: map[string]bool{}}
+	c := newCalendarCollectorWithFakeSource(validCalendarConfig(), srv, nil).WithCancellationStore(fake)
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("got %d docs, want 1", len(docs))
+	}
+	if docs[0].SourceID != "calendar:evt-confirmed" {
+		t.Errorf("SourceID = %q, want %q", docs[0].SourceID, "calendar:evt-confirmed")
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("SoftDeleteBySourceID called %d times, want 0 for a confirmed event", len(fake.calls))
+	}
+}
+
+// TestCalendarCollector_Collect_CancelledEvent_Idempotent verifies that
+// collecting the same cancellation twice (e.g. the same event still falls
+// inside the updatedMin window on a later tick) produces the same
+// observable result both times: no documents, no error. The second call's
+// SoftDeleteBySourceID invocation reports no row affected (already
+// soft-deleted), which Collect must treat as a normal, non-error outcome.
+func TestCalendarCollector_Collect_CancelledEvent_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		ev := cancelledEventJSON("evt-repeat-cancel")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	fake := &fakeCancellationStore{activeSourceIDs: map[string]bool{"calendar:evt-repeat-cancel": true}}
+	c := newCalendarCollectorWithFakeSource(validCalendarConfig(), srv, nil).WithCancellationStore(fake)
+
+	docs1, err1 := c.Collect(context.Background(), time.Time{})
+	if err1 != nil {
+		t.Fatalf("first Collect: %v", err1)
+	}
+	docs2, err2 := c.Collect(context.Background(), time.Time{})
+	if err2 != nil {
+		t.Fatalf("second Collect: %v", err2)
+	}
+
+	if len(docs1) != 0 || len(docs2) != 0 {
+		t.Fatalf("got %d and %d docs, want 0 and 0", len(docs1), len(docs2))
+	}
+	if len(fake.calls) != 2 {
+		t.Fatalf("SoftDeleteBySourceID called %d times, want 2 (once per Collect)", len(fake.calls))
+	}
+	for i, call := range fake.calls {
+		if call.sourceID != "calendar:evt-repeat-cancel" {
+			t.Errorf("call[%d].sourceID = %q, want %q", i, call.sourceID, "calendar:evt-repeat-cancel")
+		}
+	}
+}
+
+// TestCalendarCollector_Collect_CancelledEvent_NoCancellationStoreConfigured
+// verifies backward compatibility: when WithCancellationStore is never
+// called (cancellationStore is nil), a cancelled event is observed and
+// skipped without a nil-pointer dereference, and without producing a
+// document.
+func TestCalendarCollector_Collect_CancelledEvent_NoCancellationStoreConfigured(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/calendar/v3/calendars/primary/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		ev := cancelledEventJSON("evt-no-store")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{ev}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := newCalendarCollectorWithFakeSource(validCalendarConfig(), srv, nil) // no WithCancellationStore call
+
+	docs, err := c.Collect(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("got %d docs, want 0", len(docs))
+	}
+}
+
 // keysOf returns the keys of a source_id-keyed document map, for test failure messages.
 func keysOf(m map[string]model.Document) []string {
 	out := make([]string, 0, len(m))

--- a/internal/store/document.go
+++ b/internal/store/document.go
@@ -1056,6 +1056,30 @@ func (s *DocumentStore) MarkDeleted(ctx context.Context, sourceType model.Source
 	return int(tag.RowsAffected()), nil
 }
 
+// SoftDeleteBySourceID soft-deletes the active document identified by
+// (source_type, source_id), if one exists, and reports whether a row was
+// affected.
+//
+// Unlike Upsert/UpsertTracked, this method NEVER inserts: when no row with
+// the given (source_type, source_id) exists, it is a pure no-op (false, nil).
+// This is deliberate — it lets a collector that only observes a partial
+// event stream (e.g. a calendar collector that receives a cancellation for
+// an event it may never have fetched while active) signal a deletion
+// without ever manufacturing a new document out of a tombstone event. It is
+// idempotent: calling it again for an already-deleted or never-existing
+// document is a harmless no-op (0 rows affected, no error).
+func (s *DocumentStore) SoftDeleteBySourceID(ctx context.Context, sourceType model.SourceType, sourceID string) (bool, error) {
+	const q = `
+		UPDATE documents
+		SET status = 'deleted', deleted_at = now()
+		WHERE source_type = $1 AND source_id = $2 AND status = 'active'`
+	tag, err := s.pg.pool.Exec(ctx, q, sourceType, sourceID)
+	if err != nil {
+		return false, fmt.Errorf("soft delete %s/%s: %w", sourceType, sourceID, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 // CountActiveDocuments returns the total number of active (non-deleted) documents
 // for the given source type. It is used by the scheduler's deletion-ratio sanity
 // check (issue #135) to detect a suspicious bulk-deletion before calling MarkDeleted.

--- a/migrations/030_calendar_cancelled_soft_delete.sql
+++ b/migrations/030_calendar_cancelled_soft_delete.sql
@@ -1,0 +1,62 @@
+-- Migration 030: soft-delete calendar documents for events Google Calendar
+-- reports as cancelled.
+--
+-- Background:
+--   internal/collector/calendar.go recorded metadata.status = ev.Status on
+--   every collected event but never branched on that value. A cancelled
+--   event (single deletion, or a cancelled instance of a recurring series)
+--   therefore stayed status='active' forever, and — because Google Calendar
+--   frequently omits summary/description on a cancelled event — several of
+--   these rows carry an empty title AND empty content, polluting the search
+--   candidate pool with blank documents. The collector-side fix (see
+--   CalendarCollector.Collect, CalendarCollector.cancellationStore) now
+--   soft-deletes these going forward; this migration is the one-off backfill
+--   for rows created before that fix shipped.
+--
+-- Scope:
+--   Only source_type='calendar' rows that are currently status='active' AND
+--   whose metadata->>'status' = 'cancelled'. Every other source_type and
+--   every non-cancelled calendar row is untouched.
+--
+-- Safety guard:
+--   As of 2026-08-29, production has exactly 13 such rows (occurred_at
+--   2026-08-20..2026-08-27). 500 is used as the "something is structurally
+--   wrong" threshold (same value and rationale as migration 019's SMS rekey
+--   guard) — comfortably above any realistic volume of cancelled-but-still-
+--   active calendar rows, while still low enough to catch a runaway match
+--   (e.g. a WHERE clause bug that widens the scope far beyond cancelled
+--   events). On RAISE EXCEPTION the entire transaction rolls back — no rows
+--   are soft-deleted. Re-run after investigation.
+--
+-- Idempotent: the WHERE clause only ever matches status='active' rows, so a
+-- second run always affects 0 rows once the first run has completed.
+--
+-- Hard delete is never used — rows are soft-deleted (status='deleted',
+-- deleted_at=now()) and remain recoverable via
+--   UPDATE documents SET status='active', deleted_at=NULL WHERE id = '<uuid>';
+DO $$
+DECLARE
+    v_would_affect bigint := 0;
+    v_deleted      bigint := 0;
+BEGIN
+    SELECT count(*) INTO v_would_affect
+    FROM documents
+    WHERE source_type = 'calendar'
+      AND status = 'active'
+      AND metadata ->> 'status' = 'cancelled';
+
+    IF v_would_affect > 500 THEN
+        RAISE EXCEPTION 'calendar cancelled soft-delete aborted: % row(s) would be affected, exceeds safety threshold 500 — review data before re-running', v_would_affect;
+    END IF;
+
+    UPDATE documents
+    SET    status     = 'deleted',
+           deleted_at = now()
+    WHERE  source_type = 'calendar'
+      AND  status = 'active'
+      AND  metadata ->> 'status' = 'cancelled';
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+    RAISE NOTICE 'calendar cancelled soft-delete: % row(s) soft-deleted', v_deleted;
+END $$;


### PR DESCRIPTION
## 요약

### 문제 1 — MCP search 도구에서 기간 조회 불가
`model.SearchQuery`에는 `OccurredFrom`/`OccurredTo`가 이미 있고 store·OpenSearch 레인·search 서비스에 완전히 배선돼 있었으나, MCP `search` 도구만 이를 노출하지 않았다. 그 결과 MCP 클라이언트는 "다음 주 일정"처럼 기간으로 질의할 수단이 없었고 검색어로 맞히는 수밖에 없었다. 실제로 2026-08-29 에이전트 질의가 이 때문에 실패했고, 데이터는 정상인데 "동기화가 안 된 것 같다"는 잘못된 결론에 도달했다.

날짜만 주어졌을 때의 타임존 해석은 새 규칙을 만들지 않고 `internal/intent/plan.go`의 기존 `parseWindow`(KST 자정) 선례를 따랐다 — 같은 날짜 문자열이 MCP 경로와 `/ask` 경로에서 다른 창이 되면 안 되기 때문.

### 문제 2 — 취소된 일정이 active로 잔존
`calendarEventToDocument`가 `metadata.status = ev.Status`로 취소 여부를 기록만 하고 아무도 분기하지 않았다. 게다가 freeBusyReader 대응용 empty-summary 스킵 가드가 취소 이벤트를 함께 걸러내, 이미 적재된 문서가 취소되어도 Upsert가 호출되지 않고 낡은 active 문서가 방치됐다. 운영 DB에 title·content가 모두 0바이트인 취소 문서 13건(occurred_at 2026-08-20~08-27)이 검색 후보 풀에 남아 임베딩·tsvector까지 생성된 상태였다.

수정: 취소 분기를 empty-summary 스킵보다 **먼저** 실행하고, `SoftDeleteBySourceID`로 soft-delete한다. 이 메서드는 절대 insert하지 않으므로 tombstone에서 새 문서가 만들어지지 않으며 멱등하다. 기존 13건은 마이그레이션 030으로 백필한다(500건 가드, 하드 삭제 없음, 멱등).

## 검증 결과

- `go build ./...` / `go vet ./...` 통과
- `go test -count=1 ./cmd/... ./internal/collector/... ./internal/store/...` 전부 통과
- 결함 상태로 되돌려 FAIL 확인(3/5건)
- 마이그레이션 운영 DB BEGIN/ROLLBACK 검증: 13건 매칭 → 재실행 시 0건(멱등) → 600건 합성 데이터로 500건 가드 발동 확인

## 배포 시 주의

마이그레이션 030은 아직 운영에 적용되지 않았다. 배포 시 collector·mcp 재빌드와 함께 적용해야 한다(ubuntu1).

## 후속 과제

회사 캘린더(`baeksy@agilesoda.ai`)는 개인 계정에 `freeBusyReader`로만 공유돼 있어 제목·내용 접근이 불가하다. `CALENDAR_ID`에 추가하면 빈 블록만 쌓이므로 이번 PR에는 포함하지 않았다. 계정별 복수 토큰 지원(스키마 변경)이 선행되어야 한다.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./cmd/... ./internal/collector/... ./internal/store/...`
- [ ] ubuntu1 배포 후 마이그레이션 030 적용 확인
- [ ] 배포 후 MCP search 기간 필터 실제 질의 검증

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>