### PR TITLE
fix(deploy): compose가 요구하는 env 파일 유실을 10분 주기로 탐지

### DIFF
--- a/deploy/ubuntu1-stack/README.md
+++ b/deploy/ubuntu1-stack/README.md
@@ -39,6 +39,8 @@
 쓰기 가능 여부를 컨테이너 안에서 직접 실측(touch/rm)해 10분 주기로 검사하고
 실패 시 `journalctl --user -u sb-permcheck` / `systemctl --user status
 sb-permcheck.service`에 남긴다. 자세한 배경은 아래 "함정 1" 참고.
+2026-08-29에 compose `env_file:` 목록의 존재·비어있지 않음 점검이
+추가됐다(내용은 읽지 않는다). 자세한 배경은 아래 "함정 5" 참고.
 
 `cloudflared/config-second-brain.yml`은 터널 ID와 credentials **경로**만
 담고 있다. credentials json(`ee3b9a8b-....json`) 자체는 시크릿이라 이 리포에
@@ -68,7 +70,7 @@ docker compose --env-file .env.local -f docker-compose.ubuntu1.yml up -d
 깜빡 잊고 이 단계를 건너뛰어도 늦어도 10분 안에 `journalctl --user -u
 sb-permcheck`에 FAIL로 드러난다.
 
-## 이전 과정에서 실제로 부딪힌 함정 4가지
+## 이전 과정에서 실제로 부딪힌 함정 5가지
 
 **재발 방지를 위해 반드시 기록한다.**
 
@@ -143,6 +145,44 @@ macmini의 `stage/sms/*.xml`은 `stat` 크기 0인 파일이다(`du`는 285MB로
 경로로 수집되며 이 파일들은 레거시다. collector 로그의 "sms: source file is
 empty — possible OneDrive materialization/bridge failure" 경고는 정상
 동작이다.
+
+### 5. gitignore 대상 env 파일이 소스 동기화로 유실 — 2026-08-29
+
+**사고**: 2026-08-27 재배포 때 ubuntu1의 `~/second-brain-app/web/` 트리를
+git 추적 파일만으로 통째 교체했는데, 그 과정에서 gitignore 대상인
+`web/.env.local`이 함께 사라졌다(증거: `web/` 안 모든 파일의 mtime이
+`2026-08-27 03:26`로 동일하고 내용물이 추적 파일뿐이었다 —
+`node_modules`·`.next`도 없음).
+
+**왜 즉시 안 드러났는가**: 당시 web 컨테이너는 이미 기동 중이었고, 실행
+중인 프로세스는 시작 시점에 물었던 환경변수를 계속 들고 있다 —
+`docker compose up -d`가 컨테이너를 재생성하지 않는 한 파일 유실은 아무
+증상도 내지 않는다. 이틀 뒤인 2026-08-29, 다음 배포에서 `docker compose
+... up -d`가 프로젝트 전체에 대해 `env file
+/home/baekenough/second-brain-app/web/.env.local not found`로 실패하고
+나서야 발견됐다. **재배포 시점까지 잠복하는 결함이라 사고 당시 로그만
+봐서는 절대 못 잡는다.**
+
+**ubuntu1에 존재해야 하지만 git에는 없는 파일**:
+- `~/second-brain-app/.env.local`
+- `~/second-brain-app/web/.env.local`
+
+둘 다 `.gitignore` 대상(시크릿)이라 이 리포에 없는 것이 정상이다 — 문제는
+"리포에 없다"가 아니라 "소스 동기화가 이 파일들까지 지우거나 덮을 수
+있다"는 점이다.
+
+**지침**: 소스 동기화(재배포)는 git 추적 대상만 명시적으로 한정할 것 —
+예를 들어 `cmd/ internal/ migrations/ go.mod go.sum Dockerfile`처럼
+동기화할 경로를 나열하고, `web/` 트리 전체를 통째로 교체하지 말 것.
+rsync를 쓴다면 `--delete` 사용에 특히 주의(대상 디렉토리에만 국한, 상위
+디렉토리 전체에 걸지 말 것). git 기반으로 교체하는 경우에도 "추적
+파일만 남기고 나머지 삭제" 방식은 gitignore 파일을 함께 날린다는 점을
+명심할 것.
+
+**검증 자동화**: `verify-mounts.sh`가 이제 compose 파일의 `env_file:`
+목록을 추출해 각 파일의 존재·비어있지 않음을 10분마다 점검한다(내용은
+읽지 않는다 — 시크릿이다). `sb-permcheck.timer`로 함정 1의 bind mount
+점검과 같은 주기로 함께 돈다.
 
 ## 데이터 동기화
 

--- a/deploy/ubuntu1-stack/verify-mounts.sh
+++ b/deploy/ubuntu1-stack/verify-mounts.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# second-brain — bind mount 쓰기 가능 여부 실측 검증 (ubuntu1)
+# second-brain — bind mount 쓰기 가능 여부 + compose env 파일 존재 실측 검증 (ubuntu1)
 #
 # 권한 숫자(ls -ldn)가 맞아 보여도 실제로 쓸 수 있는지는 별개다
 # (2026-08-26 사고: drwxr-xr-x 여도 uid가 다르면 못 씀). 이 스크립트는
 # 컨테이너 안에서 직접 touch/rm을 실행해 실측한다.
 #
+# 2026-08-29 사고: 재배포 때 web/.env.local(gitignore 대상)이 소스 동기화로
+# 유실됐는데, 당시 web 컨테이너가 이미 환경변수를 물고 떠 있어서 아무 증상이
+# 없었다. 이틀 뒤 다음 `up -d`에서야 "env file ... not found"로 배포 자체가
+# 실패했다. bind mount와 동일하게 "지금 떠 있음"이 "다음 배포도 될 것"을
+# 보장하지 않는 사례라 같은 스크립트에 편입한다.
+#
 # 사용처:
 #   1. 배포 직후 수동 실행 (README "기동 방법" 참고)
 #   2. sb-permcheck.timer 가 주기적으로 실행 (드리프트 조기 발견,
-#      2026-08-26 사고처럼 반나절 뒤 발견되는 일을 막기 위함)
+#      2026-08-26/2026-08-29 사고처럼 한참 뒤에야 발견되는 일을 막기 위함)
 #
 # 종료 코드: 0 = 전부 통과, 1 = 하나 이상 실패 (systemd가 실패로 기록 →
 # `systemctl --user status sb-permcheck.service` / journalctl 로 즉시 확인 가능)
@@ -16,6 +22,8 @@ set -uo pipefail
 
 PROJECT="second-brain-ubuntu1"
 LOG_TAG="sb-permcheck"
+APP_DIR="${HOME}/second-brain-app"
+COMPOSE_FILE="${APP_DIR}/docker-compose.ubuntu1.yml"
 
 log() { logger -t "$LOG_TAG" "$*"; echo "$(date -Is) $*"; }
 
@@ -30,14 +38,75 @@ check() {
   fi
 }
 
+# compose 파일의 `env_file:` 블록에서 파일 경로 목록을 뽑는다. YAML 파서 없이
+# grep/sed로 처리하되, "무매치가 초록으로 보이는" 사고를 반복하지 않기 위해
+# 추출 결과가 0건이면 그 자체를 실패로 취급한다(아래 호출부에서 처리).
+#
+# 매칭 대상: `env_file:` 다음 줄부터 이어지는 `  - path` 리스트 항목.
+# 다른 `key:` 라인(들여쓰기가 같거나 얕은)이 나오면 블록이 끝난 것으로 본다.
+extract_env_files() {
+  local compose_file="$1"
+  awk '
+    /^[[:space:]]*env_file:[[:space:]]*$/ { in_block=1; next }
+    in_block && /^[[:space:]]*-[[:space:]]*.+/ {
+      line=$0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+      sub(/[[:space:]]*#.*$/, "", line)
+      gsub(/^["'\'']|["'\'']$/, "", line)
+      if (line != "") print line
+      next
+    }
+    in_block { in_block=0 }
+  ' "$compose_file"
+}
+
+check_env_file() {
+  local raw="$1" resolved
+  case "$raw" in
+    /*) resolved="$raw" ;;
+    *)  resolved="${APP_DIR}/${raw}" ;;
+  esac
+
+  if [ ! -e "$resolved" ]; then
+    log "FAIL: env_file missing ($raw → $resolved not found) — gitignore 대상 파일이라 소스 동기화(재배포)로 유실될 수 있음, 실행 중 컨테이너의 환경변수에서 복원 필요"
+    return 1
+  fi
+  if [ ! -s "$resolved" ]; then
+    log "FAIL: env_file empty ($raw → $resolved size 0) — gitignore 대상 파일이라 소스 동기화(재배포)로 유실될 수 있음, 실행 중 컨테이너의 환경변수에서 복원 필요"
+    return 1
+  fi
+  log "OK: env_file present and non-empty ($raw)"
+  return 0
+}
+
 rc=0
 check "${PROJECT}-server-1"    "/data/call/ingest"   "server:/data/call/ingest"   || rc=1
 check "${PROJECT}-server-1"    "/data/call/complete" "server:/data/call/complete" || rc=1
 check "${PROJECT}-server-1"    "/data/call/to-text"  "server:/data/call/to-text"  || rc=1
 
-if [ "$rc" -eq 0 ]; then
-  log "all mount write checks passed"
+if [ ! -f "$COMPOSE_FILE" ]; then
+  log "FAIL: compose file not found ($COMPOSE_FILE) — env_file 추출 자체가 불가능하므로 실패로 처리"
+  rc=1
 else
-  log "one or more mount write checks FAILED — see above"
+  env_file_count=0
+  # mapfile 대신 while-read를 쓴다 — bash 버전에 덜 의존적이고, 명령이
+  # 조용히 실패해도(예: 오래된 bash) 카운터가 0으로 남아 아래 "0건 추출"
+  # 분기가 그대로 실패를 잡아낸다.
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    env_file_count=$((env_file_count + 1))
+    check_env_file "$f" || rc=1
+  done < <(extract_env_files "$COMPOSE_FILE" | sort -u)
+
+  if [ "$env_file_count" -eq 0 ]; then
+    log "FAIL: extracted 0 env_file entries from $COMPOSE_FILE — 추출 로직이 깨졌거나 compose 형식이 바뀐 것으로 간주(무매치를 통과로 처리하지 않음)"
+    rc=1
+  fi
+fi
+
+if [ "$rc" -eq 0 ]; then
+  log "all mount write + env file checks passed"
+else
+  log "one or more checks FAILED — see above"
 fi
 exit "$rc"


### PR DESCRIPTION
## 문제

2026-08-27 재배포 때 ubuntu1의 `~/second-brain-app/web/` 트리를 git 추적 파일만으로 통째 교체했고, 그 과정에서 gitignore 대상인 `web/.env.local`이 유실됐다. 증거: `web/` 안 모든 파일의 mtime이 `2026-08-27 03:26`으로 동일하고 내용물이 추적 파일만이다(`node_modules`·`.next` 없음).

이 결함은 **즉시 드러나지 않는다.** 실행 중인 컨테이너는 이미 환경변수를 물고 있어서 2일간 완전히 정상으로 보였고, 2026-08-29 배포에서 `docker compose up -d`가 프로젝트 전체에 대해 실패하면서야 발현됐다:
`env file /home/baekenough/second-brain-app/web/.env.local not found`

## 조치

`verify-mounts.sh`(이미 `sb-permcheck.timer`로 10분마다 실행 중)에 compose가 요구하는 env 파일의 존재·비어있지 않음 점검을 추가했다. 다음 배포 때까지 잠복하던 결함이 이제 10분 안에 `journalctl --user -u sb-permcheck`에 드러난다.

- 점검 대상은 하드코딩하지 않고 compose의 `env_file:` 항목에서 추출한다 — 서비스가 추가돼도 자동 커버.
- 파일 **내용은 읽지 않는다**. `-e`/`-s`만 확인한다(시크릿 파일).
- **추출 결과가 0건이면 실패로 처리**한다. 무매치를 통과로 처리하지 않기 위함이며, 이 리포에는 "검증이 아무것도 검사하지 않고 초록으로 보인" 사고 이력이 있다.
- README에 5번째 함정으로 이번 사고와 "git에 없지만 ubuntu1에 존재해야 하는 파일" 목록을 기록했다.

## 검증

- `bash -n` 통과
- 가짜 compose/HOME으로 5개 케이스 검증: 파일 둘 다 없음 / 하나가 빈 파일 / 둘 다 정상 / `env_file:` 항목 0건 / compose 파일 자체 없음 → 정상 케이스만 rc=0
- 구현 중 최초 버전이 `mapfile`(bash 4+ 전용)을 써서, 명령이 없을 때 조용히 rc=0으로 통과하는 결함이 실측으로 발견되어 `while read` + 프로세스 치환으로 교체했다 — 막으려던 결함이 검증 코드 자체에서 재현된 사례
- ubuntu1 실배포 후 양성 대조(exit=0, `.env.local`·`web/.env.local` 탐지) / 음성 대조(파일 없는 환경 exit=1) 확인

## 참고

유실됐던 `web/.env.local`은 실행 중이던 컨테이너의 환경변수에서 이미 복원했고, ubuntu1의 `~/bin/verify-mounts.sh`에도 이 스크립트를 배포 완료했다.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>